### PR TITLE
fix(calendar): widen mobile Week's loaded range to match its 3-day window (#1006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mobile Week no longer silently drops timed events on its boundary day** (#1006). Mobile Week
+  renders a 3-day window centered on the cursor, but the calendar only loaded and indexed the fixed
+  7-day desktop week; whenever that 3-day window crossed the week boundary, the neighboring day's
+  timed events were fetched but then clamped out of the day index, while calendar tasks (loaded
+  separately) and Agenda (which reloads a 31-day range) kept showing normally - the mismatch read as
+  an inconsistent Sunday. The loaded range now covers the union of the desktop week and the mobile
+  window whenever they diverge; Month, Day and Agenda are unaffected.
+
 - **A same-version deployment now invalidates the installed PWA shell.** The served service worker
   receives a build-specific revision, so acceptance builds and rebuilt images no longer reuse an
   older cache merely because the application version has not changed.

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -650,7 +650,10 @@ function setSavedCalendarView(view) {
 
 function getRangeForView(view, cursor) {
   if (view === 'month') return getMonthRange(cursor);
-  if (view === 'week') return getWeekRange(cursor);
+  if (view === 'week') {
+    const mobile = window.matchMedia?.(MOBILE_MEDIA_QUERY).matches ?? false;
+    return getWeekRange(cursor, { mobile });
+  }
   if (view === 'day') return { from: cursor, to: cursor };
   if (view === 'agenda') return getAgendaRange(cursor);
   return getMonthRange(cursor);
@@ -871,9 +874,28 @@ function getMonthRange(dateStr) {
   return { from, to };
 }
 
-function getWeekRange(dateStr) {
-  const weekStart = startOfWeekOf(dateStr);
-  return { from: weekStart, to: addDays(weekStart, 6) };
+/**
+ * Ladefenster der Wochenansicht: das haushaltsweite 7-Tage-Raster, auf Mobile
+ * erweitert um das 3-Tage-Fenster (cursor -1..+1), das renderWeekView() dort
+ * tatsächlich zeichnet. Ohne diese Erweiterung klammerte buildDayIndex() auf
+ * das reine 7-Tage-Raster, und ein Cursor am Wochenrand liess auf Mobile den
+ * hereinragenden Nachbartag ohne seine Termine stehen (#1006) - obwohl
+ * fetchWindow() ihn ohnehin mitlädt. Ein Randtag, der ausserhalb BEIDER
+ * Fenster liegt, bleibt weiterhin draussen; das ist kein Sonderfall des
+ * Ladefensters, sondern dieselbe Klammerung, die buildDayIndex() für jedes
+ * mehrtägige Event ohnehin anwendet.
+ */
+function getWeekRange(dateStr, { weekStart = state.weekStart, mobile = false } = {}) {
+  const start = startOfWeekOf(dateStr, weekStart);
+  const desktopFrom = start;
+  const desktopTo   = addDays(start, 6);
+  if (!mobile) return { from: desktopFrom, to: desktopTo };
+  const mobileFrom = addDays(dateStr, -1);
+  const mobileTo   = addDays(dateStr, 1);
+  return {
+    from: mobileFrom < desktopFrom ? mobileFrom : desktopFrom,
+    to:   mobileTo   > desktopTo   ? mobileTo   : desktopTo,
+  };
 }
 
 function getAgendaRange(dateStr) {
@@ -3034,6 +3056,7 @@ async function openFoundEvent(ev) {
 
 export const __test = {
   fetchWindow,
+  getWeekRange,
   resolveEventColor,
   isVisibleLayer,
   normalizeCalendarView,

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -3057,6 +3057,7 @@ async function openFoundEvent(ev) {
 export const __test = {
   fetchWindow,
   getWeekRange,
+  getRangeForView,
   resolveEventColor,
   isVisibleLayer,
   normalizeCalendarView,

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1341,6 +1341,29 @@ test('getWeekRange: Montag-Woche + Montags-Cursor schliesst den vorherigen Sonnt
     `Der vorherige Sonntag muss mitgeladen werden: ${from}..${to}`);
 });
 
+test('getRangeForView: Der echte Week-Aufrufer liest matchMedia und reicht mobile weiter (#1030)', () => {
+  // Die fünf getWeekRange()-Tests oben beweisen nur die Arithmetik, nachdem
+  // `mobile` schon feststeht. Wenn der echte Aufrufer aufhört, das Flag zu
+  // liefern (z.B. `return getWeekRange(cursor)` ohne Optionen), blieben sie
+  // trotzdem grün - dieser Test prüft die fehlende Verbindung.
+  const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, 'window');
+  const previousWindow = globalThis.window;
+  try {
+    globalThis.window = { matchMedia: () => ({ matches: true }) };
+    const mobile = calendarHelpers.getRangeForView('week', '2026-03-15');
+    assert(mobile.from === '2026-03-09' && mobile.to === '2026-03-16',
+      `Mobile-Aufrufer muss das erweiterte Fenster laden: ${mobile.from}..${mobile.to}`);
+
+    globalThis.window = { matchMedia: () => ({ matches: false }) };
+    const desktop = calendarHelpers.getRangeForView('week', '2026-03-15');
+    assert(desktop.from === '2026-03-09' && desktop.to === '2026-03-15',
+      `Desktop-Aufrufer darf sich nicht erweitern: ${desktop.from}..${desktop.to}`);
+  } finally {
+    if (hadWindow) globalThis.window = previousWindow;
+    else delete globalThis.window;
+  }
+});
+
 // --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1302,6 +1302,45 @@ test('matchesRRuleByday filtert nicht, wo UTC- und Ortsdatum auseinanderfallen',
     'mit Zonenhinweis nicht - lieber ein Vorkommen zu viel als eines lautlos verloren');
 });
 
+test('getWeekRange: Desktop bleibt beim reinen 7-Tage-Raster (#1006)', () => {
+  const { from, to } = calendarHelpers.getWeekRange('2026-03-11', { weekStart: 1, mobile: false });
+  assert(from === '2026-03-09' && to === '2026-03-15',
+    `Desktop-Woche darf sich nicht erweitern: ${from}..${to}`);
+});
+
+test('getWeekRange: Mobile mitten in der Woche erweitert das Ladefenster nicht unnötig (#1006)', () => {
+  // Mittwoch: das 3-Tage-Fenster (Di-Do) liegt vollständig innerhalb der
+  // Montag-Woche - die Vereinigung darf hier gleich dem Desktop-Raster bleiben.
+  const { from, to } = calendarHelpers.getWeekRange('2026-03-11', { weekStart: 1, mobile: true });
+  assert(from === '2026-03-09' && to === '2026-03-15',
+    `Ein Mittwochs-Cursor braucht keine Erweiterung: ${from}..${to}`);
+});
+
+test('getWeekRange: Montag-Woche + Sonntags-Cursor schliesst den folgenden Montag ein (#1006)', () => {
+  // Sonntag ist der letzte Tag der Montag-Woche; das Mobile-Fenster (Sa-Mo)
+  // ragt einen Tag darüber hinaus - genau der Tag, den buildDayIndex() vorher
+  // stillschweigend wegklammerte.
+  const { from, to } = calendarHelpers.getWeekRange('2026-03-15', { weekStart: 1, mobile: true });
+  assert(from === '2026-03-09' && to === '2026-03-16',
+    `Der folgende Montag muss mitgeladen werden: ${from}..${to}`);
+});
+
+test('getWeekRange: Sonntag-Woche + Samstags-Cursor schliesst den folgenden Sonntag ein (#1006)', () => {
+  // Dieselbe Randsituation am anderen Wochenstart: Samstag ist hier der
+  // letzte Tag, das Mobile-Fenster ragt in den folgenden Sonntag hinein.
+  const { from, to } = calendarHelpers.getWeekRange('2026-03-14', { weekStart: 0, mobile: true });
+  assert(from === '2026-03-08' && to === '2026-03-15',
+    `Der folgende Sonntag muss mitgeladen werden: ${from}..${to}`);
+});
+
+test('getWeekRange: Montag-Woche + Montags-Cursor schliesst den vorherigen Sonntag ein (#1006)', () => {
+  // Symmetrischer Fall am linken Rand: Montag ist der erste Tag der Woche,
+  // das Mobile-Fenster ragt einen Tag in die vorherige Woche hinein.
+  const { from, to } = calendarHelpers.getWeekRange('2026-03-09', { weekStart: 1, mobile: true });
+  assert(from === '2026-03-08' && to === '2026-03-15',
+    `Der vorherige Sonntag muss mitgeladen werden: ${from}..${to}`);
+});
+
 // --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1006. Mobile Week renders a 3-day window centered on the cursor
(`cursor-1..cursor+1`), but the calendar only loaded and indexed the fixed
7-day desktop week. Whenever the mobile window crossed that week's boundary,
the neighboring day was fetched (thanks to the existing 1-day timezone
margin in `fetchWindow()`) but then clamped back out by `buildDayIndex()`,
which only trusts `state.rangeFrom`/`state.rangeTo`. Calendar tasks (loaded
separately) and Agenda (which reloads a 31-day range) kept showing normally,
which is why the report read as an inconsistent Sunday rather than an
obviously broken day.

- `getWeekRange()` now accepts an optional `{ weekStart, mobile }` and, on
  mobile, returns the union of the configured desktop week and the 3-day
  cursor window whenever they diverge - otherwise it's unchanged.
- `getRangeForView()` passes the mobile viewport check through, so the
  loaded/indexed range and the rendered range can no longer drift apart.
- No second event-membership rule was added; Month, Day and Agenda paths are
  untouched.

## Test plan

- [x] New unit tests for `getWeekRange()` covering both boundary directions
  (Monday-start week + Sunday cursor -> includes the following Monday;
  Sunday-start week + Saturday cursor -> includes the following Sunday) plus
  a desktop and a mid-week mobile case that must NOT expand the range.
  `npm run test:calendar` - 111/111 pass.
- [x] `npm run test:frontend-audit` - 359/359 pass.
- [x] Full `npm test` - green.
- [x] Manual verification in a real browser against a throwaway instance of
  this branch: seeded a timed event on each boundary day, confirmed it was
  missing at 584px/390px before the fix and visible after, at both week-start
  boundary directions, with desktop unaffected either way.