### PR TITLE
fix(health): let caregivers correct medicine logs (#999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Authorized caregivers can now correct a cared-for person's medication log entries** (#999).
+  The log row now follows the same explicit care grant as recording, taking and skipping a dose;
+  other family members still see it read-only, and scheduled entries keep their existing
+  pending-instead-of-delete rule.
+
 - **A same-version deployment now invalidates the installed PWA shell.** The served service worker
   receives a build-specific revision, so acceptance builds and rebuilt images no longer reuse an
   older cache merely because the application version has not changed.

--- a/public/pages/health.js
+++ b/public/pages/health.js
@@ -1872,16 +1872,11 @@ function medLogHistoryMarkup() {
   if (!entries.length) return '';
   entries.sort((a, b) => String(b.at).localeCompare(String(a.at)));
 
-  // Korrigieren darf nur, wer IN SEINEM EIGENEN Protokoll ist (#701).
-  //
-  // Nicht `canEditFor`: der Server laesst eine Korrektur ausdruecklich nur den
-  // Eigentuemer machen (`ownLogRow` in server/routes/health/medications.js -
-  // ein Dosis-Eintrag ist eine Aufzeichnung ueber den eigenen Koerper, mitlesen
-  // und nachtraeglich aendern sind zwei verschiedene Rechte). Wer fuer eine
-  // betreute Person eintraegt, darf also buchen, aber nicht nachbessern - und
-  // bekam die Stifte trotzdem angeboten, mit einem 404 dahinter. Ein Knopf, der
-  // nichts tut, ist genau der Fehler, wegen dem #700 ueberhaupt aufkam.
-  const own = meds.personId === meds.meId;
+  // Dasselbe ausdrueckliche Betreuungsrecht wie beim Buchen und Abhaken gilt
+  // auch fuer die Korrektur (#999). Der Server zieht diese Grenze zentral ueber
+  // `ownLogRow` -> `writableChild`; die Oberflaeche muss deshalb denselben
+  // bereits geladenen Grant verwenden statt einer engeren Eigentuemerpruefung.
+  const own = canEditFor(meds.personId, meds.meId);
 
   const rows = entries.slice(0, 10).map((e) => {
     // Uebersprungen und ausstehend sind beide "nicht genommen" und treten

--- a/public/pages/health.js
+++ b/public/pages/health.js
@@ -5539,3 +5539,14 @@ function openCycleSettingsModal() {
     },
   });
 }
+
+export const __test = {
+  canEditFor,
+  // Testseam fuer #1031: setzt `careFor` fuer die drei Berechtigungsfaelle
+  // (eigene Daten, betreute Person, unbeteiligtes Mitglied), ohne das Array
+  // selbst nach aussen zu geben - Tests koennen die Betreuungsliste nur ganz
+  // ersetzen, nicht das Modul-interne Array direkt mutieren.
+  setCareForForTest(list) {
+    careFor = Array.isArray(list) ? [...list] : [];
+  },
+};

--- a/test/test-health-meds.js
+++ b/test/test-health-meds.js
@@ -5,6 +5,7 @@
  * Ausführen: node --loader ./test/test-browser-loader.mjs --test test/test-health-meds.js
  */
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const {
@@ -325,4 +326,21 @@ test('scheduledLogs: eine Bedarfsdosis zaehlt nicht als eingehaltener Plan', () 
   assert.equal(computeAdherence(scheduledLogs(viele), 7).rate, 3 / 7);
 
   assert.deepEqual(scheduledLogs(null), []);
+});
+
+// --------------------------------------------------------
+// Betreuungsrechte im Einnahmeprotokoll (#999)
+// --------------------------------------------------------
+
+test('Einnahmeprotokoll: Korrektur folgt dem gemeinsamen Betreuungsrecht', () => {
+  const source = readFileSync(new URL('../public/pages/health.js', import.meta.url), 'utf8');
+  const start = source.indexOf('function medLogHistoryMarkup()');
+  const end = source.indexOf('/** Ein Log-Eintrag', start);
+  assert.ok(start >= 0 && end > start, 'medLogHistoryMarkup muss auffindbar sein');
+
+  const historyMarkup = source.slice(start, end);
+  assert.match(historyMarkup, /const own = canEditFor\(meds\.personId, meds\.meId\)/,
+    'auch eine ausdruecklich betreute Person braucht den Korrekturknopf');
+  assert.doesNotMatch(historyMarkup, /meds\.personId === meds\.meId/,
+    'eine reine Eigentuemerpruefung schneidet Betreuende vom erlaubten API-Weg ab');
 });

--- a/test/test-health-meds.js
+++ b/test/test-health-meds.js
@@ -24,6 +24,8 @@ const {
   scheduledLogs,
 } = await import('../public/utils/health-meds.js');
 
+const { __test: healthHelpers } = await import('../public/pages/health.js');
+
 // --------------------------------------------------------
 // Wochentags-Masken
 // --------------------------------------------------------
@@ -343,4 +345,24 @@ test('Einnahmeprotokoll: Korrektur folgt dem gemeinsamen Betreuungsrecht', () =>
     'auch eine ausdruecklich betreute Person braucht den Korrekturknopf');
   assert.doesNotMatch(historyMarkup, /meds\.personId === meds\.meId/,
     'eine reine Eigentuemerpruefung schneidet Betreuende vom erlaubten API-Weg ab');
+});
+
+test('canEditFor: eigene Daten, betreute Person und unbeteiligtes Mitglied (#1031, Option 2)', () => {
+  // Der Test oben beweist nur, dass die Aufrufstelle canEditFor() benutzt statt
+  // einer reinen Eigentuemerpruefung - er beweist nicht, dass canEditFor() selbst
+  // die drei Berechtigungsfaelle richtig unterscheidet. Das prueft dieser Test.
+  const selfId = 1;
+  const caredForId = 2;
+  const unrelatedId = 3;
+  try {
+    healthHelpers.setCareForForTest([caredForId]);
+    assert.equal(healthHelpers.canEditFor(selfId, selfId), true,
+      'eigene Daten muessen bearbeitbar bleiben');
+    assert.equal(healthHelpers.canEditFor(caredForId, selfId), true,
+      'eine betreute Person muss bearbeitbar sein');
+    assert.equal(healthHelpers.canEditFor(unrelatedId, selfId), false,
+      'ein unbeteiligtes Mitglied darf nicht bearbeitbar sein');
+  } finally {
+    healthHelpers.setCareForForTest([]);
+  }
 });


### PR DESCRIPTION
## Summary

Closes #999.

Authorized caregivers can now open and correct medication log entries for a cared-for person. The frontend now follows the same explicit care grant already enforced by the backend for recording, taking, skipping, updating, and deleting doses.

## Changes

- Gate intake-log edit controls through the shared caregiver predicate instead of owner-only equality.
- Preserve read-only behavior for unrelated family members.
- Preserve the existing scheduled-entry rule: return to Pending instead of Delete; ad-hoc entries remain deletable.
- Add a focused frontend regression test and an Unreleased changelog entry.

## Verification

- Test-first regression: failed before the fix because child log rows used owner-only equality; passes after the fix.
- npm run test:health-meds: 29/29 passed.
- npm run test:health-api: 104/104 passed.
- npm run test:frontend-audit: 359/359 passed.
- npm test: passed.
- Mobile Chromium at 390 x 844: both scheduled and ad-hoc child log rows opened the correction dialog; saving a scheduled entry as Pending retained its schedule and removed the taken timestamp; scheduled entries exposed no Delete action while ad-hoc entries did.

## Checklist

- [x] npm test passes
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies
- [x] No new UI strings
- [x] CHANGELOG.md updated