### PR TITLE
fix(calendar): give overlapping Schedule blocks their own lane (#1043)

### DIFF
--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -3350,6 +3350,8 @@ export const __test = {
   layoutScheduleBlocks,
   scheduleBlockTimeRange,
   renderScheduleTimeBlock,
+  renderWeekView,
+  renderDayView,
 };
 
 function renderAgendaEvent(ev, dayStr) {

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -2235,12 +2235,44 @@ function renderScheduleChip(entry, className = 'allday-holiday') {
   const start = type.start_time ? '<small class="schedule-entry__start">' + esc(type.start_time) + '</small>' : '';
   return `<div class="${className} schedule-entry" style="--holi-color:${esc(type.color)}" title="${esc(scheduleEntryTitle(entry))}"><span>${esc(label)}</span>${scheduleEntryExtraBadge(entry)}${start}</div>`;
 }
-function renderScheduleTimeBlock(entry, className) {
+/**
+ * Zeit-Fenster eines Schichtplan-Blocks in Minuten seit Mitternacht - dieselbe
+ * Dauer-Arithmetik wie zuvor inline in renderScheduleTimeBlock() (Mindestlaenge
+ * 30 Min., Ende-vor-Start heisst "geht ueber Mitternacht"), jetzt eigenstaendig,
+ * damit layoutScheduleBlocks() dieselbe Zeitspanne fuer die Ueberlappungs-Logik
+ * kennt wie die Darstellung selbst.
+ */
+function scheduleBlockTimeRange(entry) {
   const type = entry.shift_type;
   const start = timeToMinutes(type.start_time);
   const end = timeToMinutes(type.end_time);
   const duration = Math.max((end > start ? end : 24 * 60) - start, 30);
-  const bounds = className === 'week-event' ? 'left:2px;width:calc(100% - 4px);' : 'left:calc(4px);width:calc(100% - 14px);';
+  return { start, end: start + duration };
+}
+
+/**
+ * Spalten-Position eines gelegten Blocks in CSS umrechnen - dieselbe Formel wie
+ * renderWeekEvent()/renderDayEvent() fuer gewoehnliche Termine, aber mit den
+ * Schichtplan-eigenen Aussenraendern (Woche: 2px beidseitig; Tag: 4px links /
+ * 10px rechts, damit die Stunden-/Jetzt-Linie hinter dem Balken sichtbar bleibt).
+ * Ohne Layout (Fallback) ergibt sich exakt der alte volle Balken (1 von 1 Spalte).
+ */
+function scheduleLaneStyle(layout, gutter) {
+  const cols = layout?.totalCols ?? 1;
+  const idx = layout?.colIndex ?? 0;
+  return {
+    left: `calc(${(idx / cols) * 100}% + ${gutter.left}px)`,
+    width: `calc(${100 / cols}% - ${gutter.total}px)`,
+  };
+}
+
+function renderScheduleTimeBlock(entry, className, layout = null) {
+  const type = entry.shift_type;
+  const start = timeToMinutes(type.start_time);
+  const end = timeToMinutes(type.end_time);
+  const duration = Math.max((end > start ? end : 24 * 60) - start, 30);
+  const gutter = className === 'week-event' ? { left: 2, total: 4 } : { left: 4, total: 14 };
+  const { left, width } = scheduleLaneStyle(layout, gutter);
   // Sichtbar statt nur im title: .schedule-time-block traegt pointer-events:none
   // (es ist eine Hintergrundflaeche, echte Termine malen darueber, siehe die
   // Begruendung an der Klasse in calendar.css) - ein Hover erreicht dieses
@@ -2255,7 +2287,7 @@ function renderScheduleTimeBlock(entry, className) {
   const overlay = scheduleOverlayMeta(entry);
   const time = esc(scheduleTimeLabel(type));
   const timeLine = overlay ? `${time} · ${esc(overlay)}` : time;
-  return `<div class="${className} schedule-time-block" style="top:${hourOffset(start)};height:calc(${hourOffset(duration)} - 4px);${bounds}--ev-color:${esc(type.color)}" title="${esc(scheduleEntryTitle(entry))}"><span class="schedule-time-block__title">${esc(scheduleEntryLabel(entry))}${scheduleEntryExtraBadge(entry)}</span><small class="schedule-time-block__time">${timeLine}</small></div>`;
+  return `<div class="${className} schedule-time-block" style="top:${hourOffset(start)};height:calc(${hourOffset(duration)} - 4px);left:${left};width:${width};--ev-color:${esc(type.color)}" title="${esc(scheduleEntryTitle(entry))}"><span class="schedule-time-block__title">${esc(scheduleEntryLabel(entry))}${scheduleEntryExtraBadge(entry)}</span><small class="schedule-time-block__time">${timeLine}</small></div>`;
 }
 
 // aria-label der Tageszelle: lokalisiertes Datum + (falls vorhanden) Zahl der
@@ -2300,6 +2332,7 @@ function renderWeekView(container) {
   const schedule = days.map((d) => scheduleEntriesOnDay(d));
   const scheduleChips = schedule.map((items) => state.scheduleDisplay === 'compact' ? items : items.filter((entry) => !scheduleHasTimes(entry) || scheduleIsFullDayShift(entry)));
   const scheduleBlocks = schedule.map((items) => state.scheduleDisplay === 'blocks' ? items.filter((entry) => scheduleHasTimes(entry) && !scheduleIsFullDayShift(entry)) : []);
+  const scheduleLayouts = scheduleBlocks.map((items) => layoutScheduleBlocks(items));
 
   container.replaceChildren();
   container.insertAdjacentHTML('beforeend', `
@@ -2351,7 +2384,7 @@ function renderWeekView(container) {
                 ${Array.from({ length: 24 }, (_, h) => `
                   <div class="week-view__hour-line" style="top:${hourOffset(h * 60)};"></div>
                 `).join('')}
-                ${scheduleBlocks[i].map((entry) => renderScheduleTimeBlock(entry, 'week-event')).join('')}
+                ${scheduleBlocks[i].map((entry) => renderScheduleTimeBlock(entry, 'week-event', scheduleLayouts[i].get(entry))).join('')}
                 ${timedEvs[i].map((ev) => renderWeekEvent(ev, layouts[i].get(ev.id))).join('')}
                 ${d === state.today ? `<div class="week-view__now-line" id="now-line" style="top:${hourOffset(nowMinutes())};"></div>` : ''}
               </div>
@@ -2484,35 +2517,49 @@ function timeRangeForEvent(ev) {
   };
 }
 
-function layoutOverlaps(events) {
+// Gruppiert sich ueberlappende Eintraege (per `rangeFn` bestimmt) in Cluster,
+// innerhalb derer sie sich Spalten teilen muessen - unabhaengig von der Frage,
+// WAS ein Eintrag ist (Termin oder Schichtplan-Block). Haelfte-offen: ein
+// Eintrag, der genau dort endet, wo der naechste beginnt, ueberlappt nicht.
+function overlapGroups(items, rangeFn) {
   const groups = [];
-  const sorted = [...events].sort((a, b) => {
-    const aRange = timeRangeForEvent(a);
-    const bRange = timeRangeForEvent(b);
+  const sorted = [...items].sort((a, b) => {
+    const aRange = rangeFn(a);
+    const bRange = rangeFn(b);
     return aRange.start - bRange.start || aRange.end - bRange.end;
   });
 
   let current = [];
   let currentEnd = -1;
-  for (const ev of sorted) {
-    const range = timeRangeForEvent(ev);
+  for (const item of sorted) {
+    const range = rangeFn(item);
     if (!current.length || range.start < currentEnd) {
-      current.push(ev);
+      current.push(item);
       currentEnd = current.length === 1 ? range.end : Math.max(currentEnd, range.end);
     } else {
       groups.push(current);
-      current = [ev];
+      current = [item];
       currentEnd = range.end;
     }
   }
   if (current.length) groups.push(current);
+  return groups;
+}
 
+// Weist jedem Eintrag innerhalb seiner Ueberlappungs-Gruppe eine Spalte zu.
+// `keyFn` bestimmt den Map-Schluessel: Termine haben eine stabile `id`, aber
+// Schichtplan-Eintraege nicht zwingend (Muster-Eintraege tragen nur
+// pattern_id+position) - und zwei Eintraege koennen legitim denselben Schichttyp
+// und dieselbe Zeit an einem Tag teilen (Muster + Extra-Schicht). Deshalb liefert
+// layoutScheduleBlocks() unten das Eintrags-Objekt selbst als Schluessel: jede
+// sichtbare Instanz bekommt ihren eigenen Platz, auch bei inhaltsgleichen Werten.
+function assignLanes(items, rangeFn, keyFn) {
   const layout = new Map();
-  for (const group of groups) {
+  for (const group of overlapGroups(items, rangeFn)) {
     const columns = [];
     const placements = [];
-    for (const ev of group) {
-      const range = timeRangeForEvent(ev);
+    for (const item of group) {
+      const range = rangeFn(item);
       let colIndex = columns.findIndex((end) => end <= range.start);
       if (colIndex === -1) {
         colIndex = columns.length;
@@ -2520,17 +2567,28 @@ function layoutOverlaps(events) {
       } else {
         columns[colIndex] = range.end;
       }
-      placements.push({ ev, colIndex });
+      placements.push({ item, colIndex });
     }
     const totalCols = Math.max(columns.length, 1);
     for (const placement of placements) {
-      layout.set(placement.ev.id, {
+      layout.set(keyFn(placement.item), {
         colIndex: placement.colIndex,
         totalCols,
       });
     }
   }
   return layout;
+}
+
+function layoutOverlaps(events) {
+  return assignLanes(events, timeRangeForEvent, (ev) => ev.id);
+}
+
+// Schichtplan-Gegenstueck zu layoutOverlaps(): gleiche Spalten-Arithmetik, aber
+// ueber scheduleBlockTimeRange() (Zeiten aus shift_type statt aus start/end_datetime)
+// und mit dem Eintrags-Objekt selbst als Schluessel statt einer ID (siehe assignLanes).
+function layoutScheduleBlocks(entries) {
+  return assignLanes(entries, scheduleBlockTimeRange, (entry) => entry);
 }
 
 // --------------------------------------------------------
@@ -2546,6 +2604,7 @@ function renderDayView(container) {
   const schedule = scheduleEntriesOnDay(state.cursor);
   const scheduleChips = state.scheduleDisplay === 'compact' ? schedule : schedule.filter((entry) => !scheduleHasTimes(entry) || scheduleIsFullDayShift(entry));
   const scheduleBlocks = state.scheduleDisplay === 'blocks' ? schedule.filter((entry) => scheduleHasTimes(entry) && !scheduleIsFullDayShift(entry)) : [];
+  const scheduleLayout = layoutScheduleBlocks(scheduleBlocks);
 
   container.replaceChildren();
   // Kein eigener Datums-Header mehr: die Toolbar zeigt exakt dasselbe Datum
@@ -2582,7 +2641,7 @@ function renderDayView(container) {
             ${Array.from({ length: 24 }, (_, h) => `
               <div class="week-view__hour-line" style="top:${hourOffset(h * 60)};"></div>
             `).join('')}
-            ${scheduleBlocks.map((entry) => renderScheduleTimeBlock(entry, 'day-event')).join('')}
+            ${scheduleBlocks.map((entry) => renderScheduleTimeBlock(entry, 'day-event', scheduleLayout.get(entry))).join('')}
             ${timed.map((ev) => renderDayEvent(ev, layout.get(ev.id))).join('')}
             ${dayEvs.length === 0 && schedule.length === 0 ? `<div class="day-view__empty-hint" style="top:calc(${hourOffset(state.cursor === state.today ? nowMinutes() : 9 * 60)} + 16px)">${t('calendar.dayEmptyHint')}</div>` : ''}
           </div>
@@ -3287,6 +3346,10 @@ export const __test = {
   scheduleEntryTitle,
   scheduleEntriesOnDay,
   state,
+  layoutOverlaps,
+  layoutScheduleBlocks,
+  scheduleBlockTimeRange,
+  renderScheduleTimeBlock,
 };
 
 function renderAgendaEvent(ev, dayStr) {

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1553,6 +1553,128 @@ test('Der Klipp-Guard steht ueber jeder Fassungsregel, die display setzt', () =>
   }
 });
 
+// Schichtplan-Bloecke im Zeitraster: Ueberlappungs-Layout (#1043)
+//
+// Vorher bekam JEDER Schichtplan-Block dieselben festen Aussenraender
+// (renderScheduleTimeBlock() kannte gar kein Layout) - zwei Schichten mit
+// gleichem oder ueberlappendem Zeitfenster lagen deckungsgleich uebereinander,
+// und nur die spaeter gerenderte war ueberhaupt zu sehen/anzuklicken. Diese
+// Tests pruefen dieselbe Ueberlappungs-Arithmetik, die gewoehnliche Termine
+// laengst ueber layoutOverlaps() bekommen, jetzt auch fuer Schichtplan-Bloecke
+// (layoutScheduleBlocks()) - inklusive des Falls, dass zwei Eintraege
+// inhaltlich identisch sind (derselbe Schichttyp, dieselbe Zeit), aber zwei
+// verschiedene sichtbare Instanzen bleiben (Muster + Extra-Schicht, #1043).
+// --------------------------------------------------------
+
+function scheduleEntry({ start, end, name = 'Schicht', color = '#3B82F6' } = {}) {
+  return {
+    user_id: null,
+    date_key: '2026-09-06',
+    source: 'pattern',
+    shift_type_id: 1,
+    shift_type: { id: 1, name, short_code: null, start_time: start, end_time: end, color },
+  };
+}
+
+test('scheduleBlockTimeRange: eine Nachtschicht laeuft bis Tagesende', () => {
+  const overnight = scheduleEntry({ start: '22:00', end: '06:00' });
+  const range = calendarHelpers.scheduleBlockTimeRange(overnight);
+  assert(range.start === 22 * 60 && range.end === 24 * 60,
+    `Nachtschicht muss am Tagesende enden, nicht rueckwaerts laufen: ${JSON.stringify(range)}`);
+});
+
+test('layoutScheduleBlocks: gleicher Start, unterschiedliches Ende bekommt zwei Spalten (#1043)', () => {
+  const basti = scheduleEntry({ start: '08:00', end: '12:00', name: 'Schultag Basti' });
+  const emma = scheduleEntry({ start: '08:00', end: '12:45', name: 'Schultag Emma' });
+  const layout = calendarHelpers.layoutScheduleBlocks([basti, emma]);
+  const a = layout.get(basti);
+  const b = layout.get(emma);
+  assert(a && b, 'beide Eintraege muessen ein Layout bekommen');
+  assert(a.totalCols === 2 && b.totalCols === 2,
+    `der gemeldete Fall (08:00-12:00 / 08:00-12:45) muss zwei Spalten teilen: ${a.totalCols}/${b.totalCols}`);
+  assert(a.colIndex !== b.colIndex, 'gleich startende, ueberlappende Bloecke duerfen keine gemeinsame Spalte bekommen');
+});
+
+test('layoutScheduleBlocks: ein Block, der endet, wo der naechste beginnt, teilt sich eine Spalte (halboffenes Intervall)', () => {
+  const first = scheduleEntry({ start: '08:00', end: '10:00' });
+  const second = scheduleEntry({ start: '10:00', end: '12:00' });
+  const layout = calendarHelpers.layoutScheduleBlocks([first, second]);
+  assert(layout.get(first).totalCols === 1 && layout.get(second).totalCols === 1,
+    'sich beruehrende, aber nicht ueberlappende Bloecke muessen die volle Breite behalten koennen');
+});
+
+test('layoutScheduleBlocks: teilweise ueberlappende Bloecke teilen sich eine Gruppe', () => {
+  const first = scheduleEntry({ start: '08:00', end: '10:00' });
+  const second = scheduleEntry({ start: '09:00', end: '11:00' });
+  const layout = calendarHelpers.layoutScheduleBlocks([first, second]);
+  assert(layout.get(first).totalCols === 2 && layout.get(second).totalCols === 2,
+    'schon eine Stunde Ueberschneidung reicht fuer eine gemeinsame Gruppe');
+  assert(layout.get(first).colIndex !== layout.get(second).colIndex);
+});
+
+test('layoutScheduleBlocks: drei gleichzeitige Schichten bekommen stabile, kollisionsfreie Plaetze', () => {
+  const a = scheduleEntry({ start: '08:00', end: '12:00' });
+  const b = scheduleEntry({ start: '08:00', end: '11:00' });
+  const c = scheduleEntry({ start: '09:00', end: '13:00' });
+  const layout = calendarHelpers.layoutScheduleBlocks([a, b, c]);
+  const cols = [layout.get(a).colIndex, layout.get(b).colIndex, layout.get(c).colIndex];
+  assert(layout.get(a).totalCols === 3 && layout.get(b).totalCols === 3 && layout.get(c).totalCols === 3,
+    `drei sich ueberlappende Eintraege muessen sich drei Spalten teilen: ${layout.get(a).totalCols}`);
+  assert(new Set(cols).size === 3, `alle drei Spaltenindizes muessen verschieden sein: ${cols}`);
+});
+
+test('layoutScheduleBlocks: gleicher Schichttyp und gleiche Zeit bleiben zwei eigene Instanzen (Muster + Extra-Schicht, #1043)', () => {
+  const pattern = scheduleEntry({ start: '08:00', end: '12:00' });
+  const extra = scheduleEntry({ start: '08:00', end: '12:00' });
+  extra.source = 'extra';
+  const layout = calendarHelpers.layoutScheduleBlocks([pattern, extra]);
+  assert(layout.get(pattern) && layout.get(extra), 'beide Objekte muessen unabhaengig voneinander auffindbar sein');
+  assert(layout.get(pattern).colIndex !== layout.get(extra).colIndex,
+    'inhaltsgleiche Eintraege (gleicher Typ, gleiche Zeit, verschiedene Quelle) duerfen sich trotzdem nicht ueberdecken');
+});
+
+test('renderScheduleTimeBlock: ohne Layout bleibt der bisherige volle Balken erhalten (Wochenansicht)', () => {
+  const html = calendarHelpers.renderScheduleTimeBlock(scheduleEntry({ start: '08:00', end: '12:00' }), 'week-event');
+  assert(html.includes('left:calc(0% + 2px)') && html.includes('width:calc(100% - 4px)'),
+    `ein einzelner Block muss die alten Aussenraender behalten: ${html}`);
+});
+
+test('renderScheduleTimeBlock: ohne Layout bleibt der bisherige volle Balken erhalten (Tagesansicht)', () => {
+  const html = calendarHelpers.renderScheduleTimeBlock(scheduleEntry({ start: '08:00', end: '12:00' }), 'day-event');
+  assert(html.includes('left:calc(0% + 4px)') && html.includes('width:calc(100% - 14px)'),
+    `ein einzelner Block muss die alten Aussenraender behalten: ${html}`);
+});
+
+test('renderScheduleTimeBlock: mit berechnetem Layout bekommt jeder Block seine eigene Spalte (Wochenansicht, #1043)', () => {
+  const basti = scheduleEntry({ start: '08:00', end: '12:00' });
+  const emma = scheduleEntry({ start: '08:00', end: '12:45' });
+  const layout = calendarHelpers.layoutScheduleBlocks([basti, emma]);
+  const htmlA = calendarHelpers.renderScheduleTimeBlock(basti, 'week-event', layout.get(basti));
+  const htmlB = calendarHelpers.renderScheduleTimeBlock(emma, 'week-event', layout.get(emma));
+  assert(!htmlA.includes('width:calc(100% - 4px)') && !htmlB.includes('width:calc(100% - 4px)'),
+    'ueberlappende Bloecke duerfen nicht mehr die volle Spaltenbreite bekommen (das war der Bug)');
+  assert(htmlA.includes('width:calc(50% - 4px)') && htmlB.includes('width:calc(50% - 4px)'),
+    `zwei ueberlappende Bloecke teilen sich je die Haelfte: ${htmlA} / ${htmlB}`);
+  const leftA = htmlA.match(/left:calc\(([\d.]+)% \+ 2px\)/)?.[1];
+  const leftB = htmlB.match(/left:calc\(([\d.]+)% \+ 2px\)/)?.[1];
+  assert(leftA !== undefined && leftB !== undefined && leftA !== leftB,
+    `beide Bloecke muessen an unterschiedlicher Stelle beginnen, damit keiner den anderen verdeckt: ${leftA} vs ${leftB}`);
+});
+
+test('renderScheduleTimeBlock: mit berechnetem Layout bekommt jeder Block seine eigene Spalte (Tagesansicht, #1043)', () => {
+  const basti = scheduleEntry({ start: '08:00', end: '12:00' });
+  const emma = scheduleEntry({ start: '08:00', end: '12:45' });
+  const layout = calendarHelpers.layoutScheduleBlocks([basti, emma]);
+  const htmlA = calendarHelpers.renderScheduleTimeBlock(basti, 'day-event', layout.get(basti));
+  const htmlB = calendarHelpers.renderScheduleTimeBlock(emma, 'day-event', layout.get(emma));
+  assert(!htmlA.includes('width:calc(100% - 14px)') && !htmlB.includes('width:calc(100% - 14px)'),
+    'ueberlappende Bloecke duerfen nicht mehr die volle Spaltenbreite bekommen (das war der Bug)');
+  const leftA = htmlA.match(/left:calc\(([\d.]+)% \+ 4px\)/)?.[1];
+  const leftB = htmlB.match(/left:calc\(([\d.]+)% \+ 4px\)/)?.[1];
+  assert(leftA !== undefined && leftB !== undefined && leftA !== leftB,
+    `beide Bloecke muessen an unterschiedlicher Stelle beginnen, damit keiner den anderen verdeckt: ${leftA} vs ${leftB}`);
+});
+
 // --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1676,6 +1676,98 @@ test('renderScheduleTimeBlock: mit berechnetem Layout bekommt jeder Block seine 
 });
 
 // --------------------------------------------------------
+// Schichtplan-Bloecke ueber die echten Ansichts-Aufrufer (#1045 Review-Runde 1)
+//
+// Die layoutScheduleBlocks()/renderScheduleTimeBlock()-Tests oben beweisen nur,
+// dass der Renderer ein mitgegebenes Layout korrekt umsetzt - jeder von ihnen
+// holt sich das Layout selbst und reicht es direkt weiter. Keiner prueft, dass
+// renderWeekView()/renderDayView() dieses Layout ueberhaupt BERECHNEN und an
+// den Renderer WEITERREICHEN. Faellt genau diese Verbindung weg (z.B.
+// scheduleLayouts[i].get(entry) durch null ersetzt), bleiben alle bisherigen
+// Tests gruen - der urspruengliche Bug (#1043) waere zurueck, obwohl die Suite
+// nichts davon meldet. Diese zwei Tests rufen deshalb die echten Aufrufer auf
+// und lesen die erzeugten left-Werte aus dem gerenderten HTML.
+// --------------------------------------------------------
+
+function fakeDomElement() {
+  return {
+    addEventListener: () => {},
+    getBoundingClientRect: () => ({ height: 1440 }),
+    scrollTop: 0,
+  };
+}
+
+function fakeContainer() {
+  let html = '';
+  return {
+    replaceChildren: () => { html = ''; },
+    insertAdjacentHTML: (_position, chunk) => { html += chunk; },
+    querySelector: () => fakeDomElement(),
+    get html() { return html; },
+  };
+}
+
+function scheduleBlockLefts(html) {
+  return [...html.matchAll(/left:calc\((\d+(?:\.\d+)?)%/g)].map((m) => m[1]);
+}
+
+function withOverlappingScheduleState(extra, fn) {
+  const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, 'window');
+  const previousWindow = globalThis.window;
+  const previousState = { ...calendarHelpers.state };
+  try {
+    globalThis.window = { matchMedia: () => ({ matches: false }) };
+    Object.assign(calendarHelpers.state, {
+      cursor: '2026-09-07',
+      today: '2026-09-07',
+      weekStart: 1,
+      scheduleDisplay: 'blocks',
+      layerSchedule: true,
+      assignedToMe: false,
+      people: new Set(),
+      events: [],
+      tasks: [],
+      holidays: [],
+      users: [],
+      scheduleEntries: [
+        scheduleEntry({ start: '08:00', end: '12:00', name: 'Schultag Basti' }),
+        scheduleEntry({ start: '08:00', end: '12:45', name: 'Schultag Emma' }),
+      ].map((entry) => ({ ...entry, date_key: '2026-09-07' })),
+      ...extra,
+    });
+    fn();
+  } finally {
+    Object.assign(calendarHelpers.state, previousState);
+    if (hadWindow) globalThis.window = previousWindow;
+    else delete globalThis.window;
+  }
+}
+
+test('renderWeekView: zwei ueberlappende Schichten am selben Tag bekommen unterschiedliche left-Werte (#1045)', () => {
+  withOverlappingScheduleState({}, () => {
+    const container = fakeContainer();
+    calendarHelpers.renderWeekView(container);
+    const lefts = scheduleBlockLefts(container.html);
+    assert(lefts.length === 2, `die Wochenansicht muss beide ueberlappenden Bloecke rendern: ${lefts.length}`);
+    assert(lefts[0] !== lefts[1],
+      `renderWeekView() muss das berechnete Layout an renderScheduleTimeBlock() weiterreichen, sonst liegen `
+      + `beide Bloecke deckungsgleich uebereinander (#1043): ${lefts}`);
+  });
+});
+
+test('renderDayView: zwei ueberlappende Schichten am selben Tag bekommen unterschiedliche left-Werte (#1045)', () => {
+  withOverlappingScheduleState({}, () => {
+    const container = fakeContainer();
+    calendarHelpers.renderDayView(container);
+    const lefts = scheduleBlockLefts(container.html);
+    assert(lefts.length === 2, `die Tagesansicht muss beide ueberlappenden Bloecke rendern: ${lefts.length}`);
+    assert(lefts[0] !== lefts[1],
+      `renderDayView() muss das berechnete Layout an renderScheduleTimeBlock() weiterreichen, sonst liegen `
+      + `beide Bloecke deckungsgleich uebereinander (#1043): ${lefts}`);
+  });
+});
+
+// --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------
 console.log(`\n[Calendar-Test] Ergebnis: ${passed} bestanden, ${failed} fehlgeschlagen\n`);


### PR DESCRIPTION
Closes #1043.

## Root cause

Ordinary calendar events avoid overlapping via `layoutOverlaps()`, a lane-assignment pass that gives each overlapping event its own column. Timed Schedule entries in the calendar's "blocks" display mode never went through it: `renderScheduleTimeBlock()` gave every block the same fixed full-width bounds, so two shifts with the same or overlapping time range painted directly on top of each other - only the last one drawn was readable, with just its color hinting a second entry existed underneath. Reproducible on `main` today with two household members each holding a shift on the same day (no Schedule v3 features needed).

## Fix

`public/pages/calendar.js`:
- Factored `layoutOverlaps()`'s grouping/lane math into shared `overlapGroups()`/`assignLanes()` helpers.
- Added `layoutScheduleBlocks()`, the Schedule-side equivalent - same algorithm, but keyed by the entry *object* rather than an id. Schedule entries don't reliably carry one (pattern-sourced entries only have `pattern_id`+`position`), and two entries can legitimately share a shift type and time on the same day, so object identity is the only key that can't collide.
- `renderScheduleTimeBlock()` now accepts a computed lane and derives `left`/`width` from it, reusing each view's existing outer gutters (Week: 2px both sides; Day: 4px/10px) - a block with no overlap keeps exactly its old full-width bounds.
- Both Week and Day view now compute and pass a schedule layout alongside the existing `layoutOverlaps()` call for ordinary events.

## Tests

10 new tests in `test/test-calendar.js`: the reported `08:00-12:00`/`08:00-12:45` pair, touching vs. partially-overlapping ranges, a three-way overlap, duplicate-content entries (same shift type + time, different source), and the rendered Week/Day HTML itself no longer using the old fixed full-width bounds. Counter-proved by temporarily reverting the fix: all 10 new tests failed and nothing else did.

`npm run test:calendar` 122/122, `test:frontend-audit` and `test:schedule` green, full `npm test` exit 0.

## Manual verification

Reproduced and confirmed fixed on a throwaway instance built from this branch (screenshots below) - two overlapping shifts ("Schultag Basti" 08:00-12:00, "Schultag Emma" 08:00-12:45) now render as separate, fully readable lanes in both Day and Week view, matching the issue's exact reported case.