### PR TITLE
test(dashboard): stelle Uhr und Zone still, statt sie vom Rechner zu erben

### DIFF
--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -327,19 +327,102 @@ test('formatDueDate liest due_date/due_time in der Anzeigezone, nicht im Browser
   }
 });
 
-test('formatDueDate: eine Faelligkeit spaeter am Tag ist nicht schon ueberfaellig', async () => {
+/* Die Grenze zwischen „gleich faellig" und „schon vorbei" - an JEDER Minute des
+ * Tages, nicht an der, die gerade zufaellig ist.
+ *
+ * Diese Probe erbte ihre Eingabe von der echten Uhr: sie las `nowFields()`,
+ * rechnete `Date.UTC(...) + 60000` und reichte nur STUNDE UND MINUTE des
+ * Ergebnisses weiter, den Tag aber unveraendert aus dem Vorher. Um 23:59 der
+ * Anzeigezone faellt die eine Minute auf den naechsten Tag: die Uhrzeit sprang
+ * auf 00:00, der Tag blieb stehen, und die angebliche „Minute in der Zukunft"
+ * war in Wahrheit 23 Stunden und 59 Minuten VERGANGENHEIT. `formatDueDate`
+ * antwortete voellig richtig „ueberfaellig", der Test nannte das einen Fehler.
+ *
+ * Ein Tageswechsel ist nicht die Zeitzone des RECHNERS - der spielt hier keine
+ * Rolle, weil `zonedFields()` mit gesetzter Anzeigezone ueber
+ * `Intl.DateTimeFormat` liest und `Date.UTC`/`getUTC*` reine Feldarithmetik
+ * sind. Gemessen: unter TZ=UTC, TZ=Europe/Berlin und TZ=America/Los_Angeles
+ * faellt exakt dieselbe eine Minute (2026-09-09T09:59Z = 23:59 in Honolulu).
+ * Die Suite war deshalb 1439 Minuten am Tag gruen und blind, und der eine rote
+ * Lauf sah aus wie eine Zonenabhaengigkeit, weil er nur dem einen Rechner
+ * begegnete, der gerade lief.
+ *
+ * Deshalb steht hier BEIDES still: die Anzeigezone (wie in den Proben darueber)
+ * und die Uhr. Zwischen dem Stellen und dem Zuruecksetzen liegt kein `await` -
+ * die Tests dieser Datei laufen verschraenkt, und ein `await` mitten drin
+ * uebergaebe einer anderen Probe eine gestellte Uhr und eine fremde Zone.
+ */
+test('formatDueDate: die Faelligkeitsgrenze haelt an jeder Minute des Tages', async () => {
   const tz = await import('/utils/timezone.js');
   const { __test } = await import('../public/pages/dashboard.js');
+
+  // Ab hier synchron.
+  const RealDate = Date;
+  let fixedMs = RealDate.UTC(2026, 8, 9);
+  class FrozenDate extends RealDate {
+    constructor(...args) { super(...(args.length ? args : [fixedMs])); }
+    static now() { return fixedMs; }
+  }
+
+  const p2 = (n) => String(n).padStart(2, '0');
+  const dayOf = (f) => `${f.year}-${p2(f.month)}-${p2(f.day)}`;
+  // Wanduhr-Felder plus/minus Minuten - dieselbe Feldarithmetik, die
+  // `formatDueDate` intern fuehrt, und diesmal MIT dem Tagesuebertrag.
+  const shiftWallMinutes = (f, minutes) => {
+    const d = new RealDate(RealDate.UTC(f.year, f.month - 1, f.day, f.hour, f.minute) + minutes * 60000);
+    return {
+      day: `${d.getUTCFullYear()}-${p2(d.getUTCMonth() + 1)}-${p2(d.getUTCDate())}`,
+      time: `${p2(d.getUTCHours())}:${p2(d.getUTCMinutes())}`,
+    };
+  };
+
   try {
-    tz.setDisplayTimeZone('Pacific/Honolulu');
-    const now = tz.nowFields();
-    const p2 = (n) => String(n).padStart(2, '0');
-    const today = `${now.year}-${p2(now.month)}-${p2(now.day)}`;
-    // Eine Minute in der Zukunft, in der Zone gerechnet, in der die Anzeige liest.
-    const later = new Date(Date.UTC(now.year, now.month - 1, now.day, now.hour, now.minute) + 60000);
-    const res = __test.formatDueDate(today, `${p2(later.getUTCHours())}:${p2(later.getUTCMinutes())}`);
-    nodeAssert.equal(res.overdue, false, `nicht ueberfaellig, erhalten: ${res.text}`);
+    globalThis.Date = FrozenDate;
+    // Eine westlich von UTC (-10), eine knapp oestlich (+2) und eine am
+    // aeussersten Ostrand (+14): der Tageswechsel der Anzeigezone faellt in
+    // jeder auf eine andere UTC-Minute, und in Kiritimati liegt er sogar auf
+    // einem anderen UTC-Datum.
+    for (const zone of ['Pacific/Honolulu', 'Europe/Berlin', 'Pacific/Kiritimati']) {
+      tz.setDisplayTimeZone(zone);
+      let sawLastMinuteOfDay = 0;
+
+      // Ein voller Tag im Minutenraster - damit ist die 23:59 der Zone
+      // zwangslaeufig dabei, in welcher Zone auch immer.
+      for (let i = 0; i < 1440; i++) {
+        fixedMs = RealDate.UTC(2026, 8, 9) + i * 60000;
+        const now = tz.nowFields();
+        const when = `${zone} @ ${dayOf(now)} ${p2(now.hour)}:${p2(now.minute)}`;
+        if (now.hour === 23 && now.minute === 59) sawLastMinuteOfDay += 1;
+
+        // Eine Minute spaeter ist noch nicht vorbei - auch wenn sie ueber
+        // Mitternacht faellt.
+        const future = shiftWallMinutes(now, 1);
+        const ahead = __test.formatDueDate(future.day, future.time);
+        nodeAssert.equal(ahead.overdue, false,
+          `${when}: eine Minute spaeter (${future.day} ${future.time}) ist nicht ueberfaellig, erhalten: ${ahead.text}`);
+
+        // Und eine Minute frueher ist es. Ohne diese Haelfte bestuende die Probe
+        // auch dann, wenn `formatDueDate` gar nichts mehr ueberfaellig nennt.
+        const past = shiftWallMinutes(now, -1);
+        const behind = __test.formatDueDate(past.day, past.time);
+        nodeAssert.equal(behind.overdue, true,
+          `${when}: eine Minute frueher (${past.day} ${past.time}) ist ueberfaellig, erhalten: ${behind.text}`);
+
+        // Die Grenze selbst: genau jetzt faellig ist noch nicht vorbei. Ohne
+        // diesen Fall bliebe ein `<=` statt `<` in `formatDueDate` unbemerkt -
+        // gemessen: die Probe war mit dieser Aenderung gruen.
+        const same = shiftWallMinutes(now, 0);
+        const onTime = __test.formatDueDate(same.day, same.time);
+        nodeAssert.equal(onTime.overdue, false,
+          `${when}: genau jetzt faellig (${same.day} ${same.time}) ist noch nicht ueberfaellig, erhalten: ${onTime.text}`);
+      }
+
+      // Sonst haette das Raster die Stelle, um die es geht, gar nicht getroffen.
+      nodeAssert.equal(sawLastMinuteOfDay, 1,
+        `${zone}: das Raster muss den Tageswechsel genau einmal enthalten, gezaehlt: ${sawLastMinuteOfDay}`);
+    }
   } finally {
+    globalThis.Date = RealDate;
     tz.setDisplayTimeZone(null);
   }
 });


### PR DESCRIPTION
## Summary

`test/test-dashboard.js` hatte eine Probe, die exakt eine Minute pro Tag rot war: `formatDueDate: eine Faelligkeit spaeter am Tag ist nicht schon ueberfaellig`. Sie baute ihre Eingabe aus der echten Uhr und verlor dabei den Tagesuebertrag. `public/pages/dashboard.js` bleibt unveraendert - der Produktivcode war immer richtig.

### Der Fehler

Der Test rechnete `Date.UTC(...) + 60000` und reichte davon nur **Stunde und Minute** weiter, den Tag aber unveraendert aus dem Vorher:

```js
const later = new Date(Date.UTC(now.year, now.month - 1, now.day, now.hour, now.minute) + 60000);
const res = __test.formatDueDate(today, `${p2(later.getUTCHours())}:${p2(later.getUTCMinutes())}`);
```

Um 23:59 der Anzeigezone faellt die eine Minute auf den naechsten Tag: die Uhrzeit springt auf 00:00, der Tag bleibt stehen. Die angebliche "Minute in der Zukunft" war damit 23 h 59 min **Vergangenheit**. `formatDueDate` antwortete voellig richtig "ueberfaellig", der Test nannte das einen Fehler.

### Es war keine Zonenabhaengigkeit

Der Befund kam als "faellt oestlich von UTC um" herein. Nachgemessen mit gestellter Uhr ueber alle 1440 Minuten des Tages:

```
Zone Pacific/Honolulu / TZ=UTC:                 1 von 1440 Minuten rot
Zone Pacific/Honolulu / TZ=Europe/Berlin:       1 von 1440 Minuten rot
Zone Pacific/Honolulu / TZ=America/Los_Angeles: 1 von 1440 Minuten rot
  2026-09-09T09:59:00.000Z -> zone 2026-09-08 23:59 :: dashboard.overdue - 2026-09-08T00:00, 2026-09-08T00:00
```

Exakt dieselbe Minute in jeder Maschinenzone, mit exakt der gemeldeten Meldung. Mit gesetzter Anzeigezone liest `zonedFields()` ueber `Intl.DateTimeFormat`, und `Date.UTC`/`getUTC*` sind reine Feldarithmetik - die Zone des Rechners hat gar keinen Angriffspunkt. Zwei TZ-Laeufe zu verschiedenen Zeiten belegen keine Zonenabhaengigkeit.

## Changes

- Die Probe stellt jetzt **beides** still: die Anzeigezone (wie die Proben darueber) und die Uhr, ueber eine `Date`-Unterklasse mit festem `now`. Zwischen Setzen und Zuruecksetzen liegt kein `await` - die Tests dieser Datei laufen verschraenkt, und ein `await` mittendrin uebergaebe einer anderen Probe eine gestellte Uhr und eine fremde Zone.
- Geprueft wird ueber ein **Minutenraster eines ganzen Tages in drei Zonen** (Honolulu -10, Berlin +2, Kiritimati +14), je mit einer Minute davor, einer danach und der Grenze selbst. Ein Zaehler belegt, dass das Raster den Tageswechsel wirklich trifft.
- Laufzeit der Dashboard-Suite: 0,84 s.

## Gegenproben

Alle per `cp`-Backup, alle rot, danach wieder gruen:

| Manipulation | Ergebnis |
| --- | --- |
| alte Testarithmetik ohne Tagesuebertrag | rot bei 23:59, mit exakt der gemeldeten Meldung |
| `overdue` fest auf `false` | rot ueber den Vergangenheitsfall |
| `overdue` fest auf `true` | rot ueber den Zukunftsfall |
| `<=` statt `<` in `formatDueDate` | rot ueber den Grenzfall |

Der letzte Fall fehlte in der ersten Fassung des neuen Tests und kam gruen durch - deshalb steht die Grenze selbst jetzt mit drin.

## Nicht angefasst

Unter `TZ=Pacific/Kiritimati` (+14) faellt `Geburtstage: Eigener heutiger Geburtstag muss enthalten sein`. Gegen den unveraenderten Stand geprueft: vorbestehend, andere Ursache (der Test seedet einen lokalen Kalendertag, `hydrateBirthday` liest die Haushaltszone). Kein Teil dieses PRs.

## Checklist

- [x] `npm test` passes - vollstaendig gruen (exit 0) unter `TZ=UTC`, `TZ=Europe/Berlin` und `TZ=America/Los_Angeles`
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text) - nicht betroffen, reine Testaenderung
- [x] CHANGELOG.md updated (if user-facing change) - nicht noetig, kein nutzersichtbares Verhalten geaendert
