### PR TITLE
test(preferences): pruefe den geltenden Zeitzonenwert positiv statt per Verneinung

### DIFF
--- a/test/test-preferences-routes.js
+++ b/test/test-preferences-routes.js
@@ -14,6 +14,14 @@
 
 process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret';
 process.env.DB_PATH = ':memory:';
+// Die Zone gehoert festgenagelt wie DB_PATH darueber. Ohne Vorgabe faellt
+// `serverTimeZone()` auf die Zone des Rechners zurueck, und dann prueft jede
+// Maschine etwas anderes: die Probe zu `timezone_effective` weiter unten stand
+// fest auf 'Pacific/Auckland' und war auf einer Maschine in Auckland
+// unerfuellbar ("Expected actual to be strictly unequal to: 'Pacific/Auckland'").
+// Genauso halten es test-household-timezone.js, test-display-timezone.js,
+// test-countdown.js und test-tasks-recurrence.js.
+process.env.TZ = 'UTC';
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -190,56 +198,42 @@ test('PUT timezone: Mitglied -> 403, ungültig -> 400, gültig -> persist, null 
   assert.ok(cleared.timezone_effective, 'timezone_effective ist nie leer');
 });
 
-/* Die Beispielzone darf nicht die Rueckfallzone sein.
+/* Der geltende Wert wird POSITIV geprueft, nicht per Verneinung.
  *
- * Hier stand fest `'Pacific/Auckland'` auf beiden Seiten: erst als gewaehlte
- * Zone, dann als das, was `timezone_effective` nach dem Loeschen NICHT sein
- * darf. Auf einer Maschine in Auckland ist der Rueckfall aber genau dieser
- * Wert - die Behauptung war dort unerfuellbar, und die Suite fiel mit
- * `Expected "actual" to be strictly unequal to: 'Pacific/Auckland'`. Gemessen
- * auf main: `TZ=UTC` und `TZ=Europe/Berlin` gruen, `TZ=Pacific/Auckland` rot.
+ * Hier stand `assert.notEqual(fallback.timezone_effective, 'Pacific/Auckland')`
+ * - dieselbe Zone, die zwei Zeilen darueber gesetzt wurde. Zwei Schwaechen in
+ * einer Zeile: auf einer Maschine in Auckland ist der Rueckfall genau dieser
+ * Wert, die Behauptung dort also unerfuellbar (das `process.env.TZ` am
+ * Dateikopf raeumt das aus); und eine Verneinung liesse eine beliebige DRITTE
+ * Zone durch.
  *
- * Die Beispielzone wird deshalb zur Laufzeit gewaehlt, und zwar so, dass sie
- * garantiert eine ANDERE ist als der Rueckfall. Erst dann trennt die Probe die
- * beiden Faelle, um die es geht: "richtig auf den Rueckfall zurueckgefallen"
- * und "die geloeschte Wahl klebt noch".
+ * Was `timezone_effective` ohne Einstellung sein soll, steht in
+ * `householdTimeZone()`: der Rueckfall auf `serverTimeZone()`, und der ist hier
+ * auf 'UTC' genagelt.
  *
- * Und die Verneinung allein war ohnehin zu schwach: "nicht die zuletzt
- * gewaehlte Zone" liesse eine beliebige DRITTE Zone durch. Was
- * `timezone_effective` ohne Einstellung sein soll, steht in
- * `householdTimeZone()` - es faellt auf `serverTimeZone()` zurueck. Das ist
- * jetzt die Aussage; die Verneinung darunter folgt daraus und bleibt nur
- * stehen, um den Fehlerfall zu benennen.
+ * DER SOLLWERT IST DESHALB EIN LITERAL UND NICHT `serverTimeZone()`. Stuende
+ * dort der Aufruf, bildete dieselbe Funktion beide Seiten der Zusicherung, und
+ * ein falscher Rueckfallwert verschoebe beide gleichzeitig. Nachgemessen mit
+ * `serverTimeZone()` auf einen festen Fremdwert sabotiert:
  *
- * Gemessen, dass das nicht bloss anders aussieht: gibt `householdTimeZone()`
- * im RUECKFALL eine dritte Zone zurueck (die gesetzte bleibt korrekt), ist die
- * neue Fassung unter UTC, Europe/Berlin und Pacific/Auckland rot - die alte
- * gruen.
+ *   Sollwert = serverTimeZone()  -> gruen unter UTC, Europe/Berlin, Auckland
+ *   Sollwert = 'UTC' (so wie es jetzt dasteht) -> rot unter allen dreien
+ *
+ * (Eine Sabotage, die nur das Lesen von `TZ` ausbaut, taugt hier NICHT als
+ * Gegenprobe: mit gepinntem `TZ` liefern beide Zweige von `serverTimeZone()`
+ * denselben Wert, sie ist also wirkungslos. Auch gemessen.)
  */
 test('GET timezone: gewählter Wert und geltender Wert sind zwei Felder', async () => {
-  const { serverTimeZone } = await import('../server/utils/timezone.js');
-  const rueckfall = serverTimeZone();
-  const gewaehlt = ['Pacific/Auckland', 'America/Los_Angeles'].find((zone) => zone !== rueckfall);
-
-  await put({ timezone: gewaehlt });
+  await put({ timezone: 'Pacific/Auckland' });
   const body = (await get()).body.data;
-  assert.equal(body.timezone, gewaehlt);
-  assert.equal(body.timezone_effective, gewaehlt);
+  assert.equal(body.timezone, 'Pacific/Auckland');
+  assert.equal(body.timezone_effective, 'Pacific/Auckland');
 
   await put({ timezone: null });
   const fallback = (await get()).body.data;
   assert.equal(fallback.timezone, null);
-  // Die eigentliche Pruefung: ohne Einstellung nennt `timezone_effective` den
-  // Rueckfall - nicht null, nicht die zuletzt gewaehlte Zone, und auch keine
-  // dritte.
-  assert.equal(fallback.timezone_effective, rueckfall,
-    `timezone_effective muss ohne Einstellung den Serverrueckfall nennen (${rueckfall})`);
-  // Aus der Zeile darueber und `gewaehlt !== rueckfall` folgt das hier schon.
-  // Es steht trotzdem da, weil es den Fehlerfall BENENNT, um den es historisch
-  // ging - eine klebende Wahl liest sich sonst nur als "falsche Zone".
-  assert.notEqual(fallback.timezone_effective, gewaehlt,
-    `die geloeschte Wahl (${gewaehlt}) darf nicht als geltender Wert stehenbleiben`);
-  assert.ok(fallback.timezone_effective);
+  assert.equal(fallback.timezone_effective, 'UTC',
+    'ohne Einstellung nennt timezone_effective den Serverrueckfall (process.env.TZ am Dateikopf)');
 });
 
 // --------------------------------------------------------

--- a/test/test-preferences-routes.js
+++ b/test/test-preferences-routes.js
@@ -189,17 +189,56 @@ test('PUT timezone: Mitglied -> 403, ungültig -> 400, gültig -> persist, null 
   assert.equal(cleared.timezone, null);
   assert.ok(cleared.timezone_effective, 'timezone_effective ist nie leer');
 });
+
+/* Die Beispielzone darf nicht die Rueckfallzone sein.
+ *
+ * Hier stand fest `'Pacific/Auckland'` auf beiden Seiten: erst als gewaehlte
+ * Zone, dann als das, was `timezone_effective` nach dem Loeschen NICHT sein
+ * darf. Auf einer Maschine in Auckland ist der Rueckfall aber genau dieser
+ * Wert - die Behauptung war dort unerfuellbar, und die Suite fiel mit
+ * `Expected "actual" to be strictly unequal to: 'Pacific/Auckland'`. Gemessen
+ * auf main: `TZ=UTC` und `TZ=Europe/Berlin` gruen, `TZ=Pacific/Auckland` rot.
+ *
+ * Die Beispielzone wird deshalb zur Laufzeit gewaehlt, und zwar so, dass sie
+ * garantiert eine ANDERE ist als der Rueckfall. Erst dann trennt die Probe die
+ * beiden Faelle, um die es geht: "richtig auf den Rueckfall zurueckgefallen"
+ * und "die geloeschte Wahl klebt noch".
+ *
+ * Und die Verneinung allein war ohnehin zu schwach: "nicht die zuletzt
+ * gewaehlte Zone" liesse eine beliebige DRITTE Zone durch. Was
+ * `timezone_effective` ohne Einstellung sein soll, steht in
+ * `householdTimeZone()` - es faellt auf `serverTimeZone()` zurueck. Das ist
+ * jetzt die Aussage; die Verneinung darunter folgt daraus und bleibt nur
+ * stehen, um den Fehlerfall zu benennen.
+ *
+ * Gemessen, dass das nicht bloss anders aussieht: gibt `householdTimeZone()`
+ * im RUECKFALL eine dritte Zone zurueck (die gesetzte bleibt korrekt), ist die
+ * neue Fassung unter UTC, Europe/Berlin und Pacific/Auckland rot - die alte
+ * gruen.
+ */
 test('GET timezone: gewählter Wert und geltender Wert sind zwei Felder', async () => {
-  await put({ timezone: 'Pacific/Auckland' });
+  const { serverTimeZone } = await import('../server/utils/timezone.js');
+  const rueckfall = serverTimeZone();
+  const gewaehlt = ['Pacific/Auckland', 'America/Los_Angeles'].find((zone) => zone !== rueckfall);
+
+  await put({ timezone: gewaehlt });
   const body = (await get()).body.data;
-  assert.equal(body.timezone, 'Pacific/Auckland');
-  assert.equal(body.timezone_effective, 'Pacific/Auckland');
+  assert.equal(body.timezone, gewaehlt);
+  assert.equal(body.timezone_effective, gewaehlt);
+
   await put({ timezone: null });
   const fallback = (await get()).body.data;
   assert.equal(fallback.timezone, null);
-  // Ohne Einstellung nennt `timezone_effective` den Rueckfall - nicht null, und
-  // nicht die zuletzt gewaehlte Zone.
-  assert.notEqual(fallback.timezone_effective, 'Pacific/Auckland');
+  // Die eigentliche Pruefung: ohne Einstellung nennt `timezone_effective` den
+  // Rueckfall - nicht null, nicht die zuletzt gewaehlte Zone, und auch keine
+  // dritte.
+  assert.equal(fallback.timezone_effective, rueckfall,
+    `timezone_effective muss ohne Einstellung den Serverrueckfall nennen (${rueckfall})`);
+  // Aus der Zeile darueber und `gewaehlt !== rueckfall` folgt das hier schon.
+  // Es steht trotzdem da, weil es den Fehlerfall BENENNT, um den es historisch
+  // ging - eine klebende Wahl liest sich sonst nur als "falsche Zone".
+  assert.notEqual(fallback.timezone_effective, gewaehlt,
+    `die geloeschte Wahl (${gewaehlt}) darf nicht als geltender Wert stehenbleiben`);
   assert.ok(fallback.timezone_effective);
 });
 


### PR DESCRIPTION
## Summary

`GET timezone: gewaehlter Wert und geltender Wert sind zwei Felder` in `test/test-preferences-routes.js` fiel unter `TZ=Pacific/Auckland` um - vorbestehend, die Zeile ist auf `origin/main` byte-identisch. Reine Testaenderung; `server/routes/preferences.js` und `server/utils/timezone.js` bleiben unveraendert.

### Der Fehler

Die Probe nahm `'Pacific/Auckland'` als Beispielzone und prueft danach, dass `timezone_effective` nach dem Loeschen **nicht** dieser Wert ist:

```js
await put({ timezone: 'Pacific/Auckland' });
...
await put({ timezone: null });
assert.notEqual(fallback.timezone_effective, 'Pacific/Auckland');
```

Auf einer Maschine in Auckland ist der Rueckfall genau dieser Wert - die Behauptung war dort unerfuellbar:

```
AssertionError: Expected "actual" to be strictly unequal to: 'Pacific/Auckland'
```

Gemessen auf `main`: `TZ=UTC` und `TZ=Europe/Berlin` gruen, `TZ=Pacific/Auckland` rot. Die CI setzt kein `TZ`, deshalb war der Fehler dort nie sichtbar.

## Changes

Zwei Zeilen Substanz, der Rest faellt weg:

- **`process.env.TZ = 'UTC'` am Dateikopf**, neben `SESSION_SECRET` und `DB_PATH`. Ohne Vorgabe faellt `serverTimeZone()` auf die Zone des Rechners zurueck, und dann fahren zwei Maschinen unter einem Testnamen zwei verschiedene Faelle - `.claude/rules/tests.md` verlangt "Tests must be deterministic". Sechs Schwestersuiten halten es genauso (`test-household-timezone.js:27`, `test-display-timezone.js:32`, `test-countdown.js:21`, `test-tasks-recurrence.js:22`, `test-reminder-offset.js:12`, `test-calendar-timezone-window.js:23`).
- **Aus der Verneinung wird eine Aussage** gegen ein LITERAL: `assert.equal(fallback.timezone_effective, 'UTC')`. "Nicht die zuletzt gewaehlte Zone" liess eine beliebige dritte Zone durch.

Der Sollwert ist bewusst ein Literal und **nicht** `serverTimeZone()`: stuende dort der Aufruf, bildete dieselbe Funktion beide Seiten der Zusicherung. Eine erste Fassung dieses PRs machte genau das und war unter der entsprechenden Sabotage blind - siehe die Gegenproben. Der Test ist damit netto kuerzer als vor dem PR und trotzdem schaerfer.

## Gegenproben

Per `cp`-Backup, danach jeweils wieder gruen:

| Manipulation | jetzige Fassung | 1. Fassung dieses PRs | main |
| --- | --- | --- | --- |
| Rueckfall in `householdTimeZone()` liefert eine dritte Zone (`Africa/Cairo`) | **rot** (UTC, Berlin, Auckland) | rot | gruen |
| `serverTimeZone()` liefert einen festen Fremdwert | **rot** (UTC, Berlin, Auckland) | **gruen** | gruen |
| keine | gruen | gruen | **rot unter Auckland** |

Die zweite Zeile ist der Grund fuer das Literal. Und eine Sabotage, die nur das Lesen von `TZ` ausbaut, taugt hier NICHT als Gegenprobe: mit gepinntem `TZ` liefern beide Zweige von `serverTimeZone()` denselben Wert, sie ist wirkungslos. Auch gemessen und im Kommentar vermerkt.

## Aehnlich aussehend, aber in Ordnung

`test/test-outlook-calendar.js:168` (`assert.notEqual(..., 'Europe/Berlin')`) sieht nach derselben Falle aus, ist es aber nicht: dort schreibt der Test seine Haushaltszone selbst nach `sync_config` (`'America/Toronto'`), der Wert haengt also nicht an der Maschine. Nachgemessen: gruen unter UTC, Europe/Berlin und Pacific/Auckland. Nicht angefasst.

## Nicht angefasst, gemeldet

Das `afterEach` dieser Datei setzt `sync_config.household_timezone` nicht zurueck. Wirft eine Zusicherung zwischen Setzen und Loeschen, bleibt die Zone fuer die restlichen rund 45 Tests der Datei stehen. Vorbestehend, heute folgenlos - kein anderer Test der Datei ist zonenempfindlich - und `cfgDelete` steht bereits in Zeile 71.

## Checklist

- [x] `npm test` passes - vollstaendig gruen (npm-Exit 0, 0 Fehlerzeilen, je 48665 Zeilen) unter `TZ=UTC`, `TZ=Europe/Berlin` und `TZ=Pacific/Auckland`. Suite selbst zusaetzlich gruen unter America/Los_Angeles, Pacific/Kiritimati und NZ.
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text) - nicht betroffen, reine Testaenderung
- [x] CHANGELOG.md updated (if user-facing change) - nicht noetig, kein nutzersichtbares Verhalten geaendert
