### PR TITLE
test(server): frag den Listener nach seinem Port, statt 400 ms auf ihn zu wetten

### DIFF
--- a/test/server-ready.js
+++ b/test/server-ready.js
@@ -1,0 +1,71 @@
+/**
+ * Modul: Bereitschaft eines echten Servers in Tests
+ * Zweck: Die eine Regel, wie eine Suite an eine Basis-URL kommt, ueber die sie
+ *        per fetch mit der App spricht - ohne feste Portnummer und ohne Warten.
+ * Abhaengigkeiten: keine
+ *
+ * WAS DAS HIER SOLL, IST EIN GEMESSENER FEHLER UND KEINE VORSICHTSMASSNAHME.
+ *
+ * Drei Suiten banden einen festen Port und warteten danach fest ab:
+ * test-admin-password-reset.js (13098), test-setup.js (13099) und
+ * test-password-normalization.js (13100), jeweils mit
+ * `await new Promise((r) => setTimeout(r, 400))`. Das ist kein
+ * Bereitschaftssignal, sondern eine Wette - und sie ist nach BEIDEN Seiten
+ * falsch:
+ *
+ *   - Sie wartet auf nichts. Gemessen am 2026-09-09: app.listen() bindet den
+ *     Socket SYNCHRON. Direkt nach dem listen()-Aufruf ist `server.listening`
+ *     bereits true, und das geschieht 1 ms VOR dem Ende des Modul-Imports.
+ *     Wenn `await import('../server/index.js')` zurueckkehrt, nimmt der Port
+ *     also laengst Verbindungen an; eine Sonde ohne jedes Warten verband sich
+ *     auf Anhieb. Die 400 ms warteten pro Suite auf nichts.
+ *
+ *   - Sie prueft nichts. Antwortet der Port doch nicht, laeuft der erste
+ *     Top-Level-fetch in `[TypeError: fetch failed]`, und der Prozess endet mit
+ *     Node-Code 7 ("Internal Exception Handler Run-Time Failure") - mit einem
+ *     AggregateError, der nur die abgewiesenen Adressen nennt (`::1:13098`,
+ *     `127.0.0.1:13098`), aber nicht, dass niemand lauschte.
+ *
+ * Beim Lesen solcher Laeufe fuehrt die Zeile "[Yuvomi] Server running on port
+ * ..." zusaetzlich in die Irre. Sie steht im Log VOR dem Fehler, auch wenn der
+ * Server durchgehend oben war - nachgestellt am 2026-09-09 mit einem laufenden
+ * Server auf 13990, abgefragt gegen den toten Port 13991: identisches
+ * Fehlerbild, exit=7, Logzeile davor. Sie sagt sogar noch weniger: belegt ein
+ * fremder Prozess den Port auf `::`, faellt Node beim Bind still auf 0.0.0.0
+ * zurueck und meldet trotzdem "Server running" - der Server lauscht dann nur
+ * auf IPv4, waehrend fetch() `localhost` per Happy Eyeballs aufloest und
+ * zuerst auf ::1 landet, also beim fremden Prozess. Gemessen mit einem Blocker
+ * auf 13998: Logzeile da, Server oben, fetch trotzdem tot.
+ *
+ * Beides faellt weg, wenn eine Suite gar keine feste Portnummer waehlt.
+ * listenOnFreePort() nimmt darum den Weg, den 13 andere Suiten hier bereits
+ * gehen (test-idempotency.js, test-invites.js, test-sso-only.js und weitere):
+ * einen eigenen Listener auf Port 0 - die Nummer vergibt das Betriebssystem,
+ * sie kann also nicht belegt sein - und das `listening`-Ereignis als das, was
+ * es ist: das Bereitschaftssignal. Gebunden wird explizit auf 127.0.0.1, und
+ * die Basis-URL nennt dieselbe Adresse; damit gibt es fuer fetch() nichts
+ * aufzuloesen und keine zweite Adressfamilie, auf die es ausweichen koennte.
+ */
+
+/**
+ * Startet einen eigenen Listener fuer `app` auf einem freien Port und liefert
+ * die Basis-URL zurueck, sobald er wirklich lauscht.
+ *
+ * @param {import('express').Express} app Die App aus `server/index.js`.
+ * @returns {Promise<string>} z.B. 'http://127.0.0.1:52341'
+ */
+export function listenOnFreePort(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1');
+    // Ohne error-Handler wuerde ein fehlgeschlagener Bind als uncaughtException
+    // enden - also genau als der nichtssagende Abbruch, den dieser Helfer
+    // vermeiden soll.
+    server.once('error', reject);
+    server.once('listening', () => {
+      server.removeListener('error', reject);
+      resolve(`http://127.0.0.1:${server.address().port}`);
+    });
+  });
+}
+
+export default listenOnFreePort;

--- a/test/test-admin-password-reset.js
+++ b/test/test-admin-password-reset.js
@@ -9,18 +9,20 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { listenOnFreePort } from './server-ready.js';
 
 const tmpDir = mkdtempSync(join(tmpdir(), 'oikos-admin-pwreset-test-'));
 
 process.env.SESSION_SECRET = 'test-admin-pwreset-secret-minimum-32ch';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
+// Der Test spricht ueber listenOnFreePort() mit einem eigenen Listener. PORT gilt
+// nur noch dem Listener, den server/index.js beim Import selbst startet: ohne
+// die Zuweisung waere das 3000, wo lokal gern schon ein Dev-Server sitzt.
 process.env.PORT = '13098';
 
 const { default: app } = await import('../server/index.js');
-await new Promise((r) => setTimeout(r, 400));
-
-const BASE = 'http://localhost:13098';
+const BASE = await listenOnFreePort(app);
 
 function cookieHeader(setCookie) {
   return String(setCookie || '')

--- a/test/test-admin-password-reset.js
+++ b/test/test-admin-password-reset.js
@@ -16,10 +16,12 @@ const tmpDir = mkdtempSync(join(tmpdir(), 'oikos-admin-pwreset-test-'));
 process.env.SESSION_SECRET = 'test-admin-pwreset-secret-minimum-32ch';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
-// Der Test spricht ueber listenOnFreePort() mit einem eigenen Listener. PORT gilt
-// nur noch dem Listener, den server/index.js beim Import selbst startet: ohne
-// die Zuweisung waere das 3000, wo lokal gern schon ein Dev-Server sitzt.
-process.env.PORT = '13098';
+// Auch der Listener, den server/index.js beim Import selbst startet, darf keinen
+// festen Port belegen: `app.listen(PORT)` dort hat keinen error-Handler, ein
+// EADDRINUSE endet also als uncaughtException und reisst die Suite mit. Port 0
+// laesst das Betriebssystem einen freien waehlen; der Test selbst spricht ohnehin
+// ueber den eigenen Listener aus listenOnFreePort().
+process.env.PORT = '0';
 
 const { default: app } = await import('../server/index.js');
 const BASE = await listenOnFreePort(app);

--- a/test/test-password-normalization.js
+++ b/test/test-password-normalization.js
@@ -71,10 +71,12 @@ const tmpDir = mkdtempSync(join(tmpdir(), 'yuvomi-password-nfc-test-'));
 process.env.SESSION_SECRET = 'test-password-nfc-secret-minimum-32ch';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
-// Der Test spricht ueber listenOnFreePort() mit einem eigenen Listener. PORT gilt
-// nur noch dem Listener, den server/index.js beim Import selbst startet: ohne
-// die Zuweisung waere das 3000, wo lokal gern schon ein Dev-Server sitzt.
-process.env.PORT = '13100';
+// Auch der Listener, den server/index.js beim Import selbst startet, darf keinen
+// festen Port belegen: `app.listen(PORT)` dort hat keinen error-Handler, ein
+// EADDRINUSE endet also als uncaughtException und reisst die Suite mit. Port 0
+// laesst das Betriebssystem einen freien waehlen; der Test selbst spricht ohnehin
+// ueber den eigenen Listener aus listenOnFreePort().
+process.env.PORT = '0';
 // Der Login-Limiter zählt Fehlversuche; die Suite prüft mehrere davon bewusst.
 process.env.RATE_LIMIT_MAX_ATTEMPTS = '100';
 

--- a/test/test-password-normalization.js
+++ b/test/test-password-normalization.js
@@ -13,6 +13,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import bcrypt from 'bcrypt';
+import { listenOnFreePort } from './server-ready.js';
 
 import { hashPassword, normalizePassword, verifyPassword } from '../server/utils/password.js';
 
@@ -70,15 +71,16 @@ const tmpDir = mkdtempSync(join(tmpdir(), 'yuvomi-password-nfc-test-'));
 process.env.SESSION_SECRET = 'test-password-nfc-secret-minimum-32ch';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
+// Der Test spricht ueber listenOnFreePort() mit einem eigenen Listener. PORT gilt
+// nur noch dem Listener, den server/index.js beim Import selbst startet: ohne
+// die Zuweisung waere das 3000, wo lokal gern schon ein Dev-Server sitzt.
 process.env.PORT = '13100';
 // Der Login-Limiter zählt Fehlversuche; die Suite prüft mehrere davon bewusst.
 process.env.RATE_LIMIT_MAX_ATTEMPTS = '100';
 
-await import('../server/index.js');
+const { default: app } = await import('../server/index.js');
 const db = await import('../server/db.js');
-await new Promise((r) => setTimeout(r, 400));
-
-const BASE = 'http://localhost:13100';
+const BASE = await listenOnFreePort(app);
 
 after(() => {
   rmSync(tmpDir, { recursive: true, force: true });

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -10,10 +10,12 @@ const tmpDir = mkdtempSync(join(tmpdir(), 'oikos-setup-test-'));
 process.env.SESSION_SECRET = 'test-setup-secret-minimum-32-chars-x';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
-// Der Test spricht ueber listenOnFreePort() mit einem eigenen Listener. PORT gilt
-// nur noch dem Listener, den server/index.js beim Import selbst startet: ohne
-// die Zuweisung waere das 3000, wo lokal gern schon ein Dev-Server sitzt.
-process.env.PORT = '13099';
+// Auch der Listener, den server/index.js beim Import selbst startet, darf keinen
+// festen Port belegen: `app.listen(PORT)` dort hat keinen error-Handler, ein
+// EADDRINUSE endet also als uncaughtException und reisst die Suite mit. Port 0
+// laesst das Betriebssystem einen freien waehlen; der Test selbst spricht ohnehin
+// ueber den eigenen Listener aus listenOnFreePort().
+process.env.PORT = '0';
 process.env.APP_BUILD_REVISION = 'acceptance-route-test';
 
 // Dynamic import so env vars are set before module initialization

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -3,20 +3,22 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { listenOnFreePort } from './server-ready.js';
 
 const tmpDir = mkdtempSync(join(tmpdir(), 'oikos-setup-test-'));
 
 process.env.SESSION_SECRET = 'test-setup-secret-minimum-32-chars-x';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
+// Der Test spricht ueber listenOnFreePort() mit einem eigenen Listener. PORT gilt
+// nur noch dem Listener, den server/index.js beim Import selbst startet: ohne
+// die Zuweisung waere das 3000, wo lokal gern schon ein Dev-Server sitzt.
 process.env.PORT = '13099';
 process.env.APP_BUILD_REVISION = 'acceptance-route-test';
 
 // Dynamic import so env vars are set before module initialization
 const { default: app } = await import('../server/index.js');
-await new Promise(r => setTimeout(r, 400));
-
-const BASE = 'http://localhost:13099';
+const BASE = await listenOnFreePort(app);
 
 function cookieHeader(setCookie) {
   return String(setCookie || '')


### PR DESCRIPTION
## Worum es geht

`test/test-admin-password-reset.js` wartete nach dem Import von `server/index.js`
mit `await new Promise((r) => setTimeout(r, 400))` auf den Serverstart, bevor sie
gegen `http://localhost:13098` fetchte. Am 09.09.2026 brach die Kette dort im
vollen `npm test`-Lauf mit `exit=7` ab, Fehlerbild `[TypeError: fetch failed]` /
`AggregateError [ECONNREFUSED]` auf `::1:13098` und `127.0.0.1:13098`.

## Die naheliegende Erklaerung traegt nicht

Bevor hier etwas repariert wurde, ist die vermutete Ursache gemessen worden:

- **`app.listen()` bindet den Socket synchron.** Direkt nach dem `listen()`-Aufruf
  ist `server.listening` bereits `true`, und das passiert 1 ms **vor** dem Ende
  von `await import('../server/index.js')`. Eine Sonde ohne jedes Warten verband
  sich auf Anhieb; das `listening`-Ereignis kommt zwar erst rund 20 ms spaeter,
  der Socket nimmt aber vorher schon an. Die 400 ms warteten auf nichts und
  konnten einen ECONNREFUSED weder verursachen noch verhindern.
- **Die Logzeile `Server running on port ...` beweist nichts.** Nachgestellt mit
  einem durchgehend laufenden Server auf 13990, abgefragt gegen den toten Port
  13991: identisches Bild, Logzeile oben, darunter `fetch failed` mit
  `ECONNREFUSED` auf beiden Adressen, `exit=7`. Sie erscheint sogar dann, wenn der
  Bind auf `::` scheiterte und Node still auf `0.0.0.0` zurueckfiel, waehrend
  `fetch()` per Happy Eyeballs zuerst auf `::1` geht.
- **`exit=7` ist kein Testfehler**, sondern Nodes "Internal Exception Handler
  Run-Time Failure". Er kommt von einem `fetch` **vor** dem ersten `test()`, also
  aus dem Setup.

Die Ursache jenes einen Laufs ist damit **nicht rekonstruiert** und wird hier auch
nicht behauptet. Eine Hypothese liess sich ausschliessen: ein belegter Port erzeugt
`UND_ERR_SOCKET`, nicht das `ECONNREFUSED` auf beiden Adressen.

## Was sich aendert

Drei Suiten trugen dasselbe Muster (fester Port plus festes Warten):
`test-admin-password-reset.js` (13098), `test-setup.js` (13099),
`test-password-normalization.js` (13100).

**`64566990` - Bereitschaftssignal statt Zeitwarten.** Die drei folgen jetzt dem
Muster, das **13 Suiten hier bereits fahren** (`test-idempotency.js`,
`test-invites.js`, `test-sso-only.js` und weitere): ein eigener
`app.listen(0, '127.0.0.1')`, das `listening`-Ereignis als Bereitschaftssignal,
die Basis-URL aus `server.address().port`. Damit faellt neben dem Warten auch die
`localhost`-Aufloesung auf zwei Adressfamilien weg. Gebuendelt in
`test/server-ready.js` als `listenOnFreePort()`; ein Einzelfix je Suite waere
dreimal dieselbe Regel gewesen.

**`c289fe6a` - auch der Import-Listener ohne feste Nummer.** Nach dem ersten
Commit war die feste Portnummer nur fuer den Test-Listener verschwunden, nicht
fuer den, den `server/index.js` beim Import selbst startet; `app.listen(PORT)`
dort hat keinen `error`-Handler, ein EADDRINUSE endet also als
uncaughtException. Mit `PORT = '0'` vergibt das Betriebssystem auch dort einen
freien Port. Gemessen: 13098 ist nach dem Import vorher belegt, nachher frei.
Die einzige weitere `PORT`-Nutzung ist `internalBaseUrl()` in
`server/mcp/tools.js`, das keine der drei Suiten beruehrt.

Der beschriebene Abbruch liess sich lokal allerdings **nicht ausloesen**: mit
einem echten Blocker auf 13098 blieb die Suite in allen drei Belegungsvarianten
gruen (`::`, `0.0.0.0`, dual-stack) und ohne EADDRINUSE, weil Node beim Bind auf
die jeweils andere Adressfamilie ausweicht und ein `::`-Blocker seinerseits
verhindert, dass ein zweiter Prozess IPv4 belegt. Der zweite Commit ist damit
Haertung fuer Plattformen, die den Bind-Fallback anders handhaben, kein
reproduzierter Fehler.

`server/index.js` bleibt unangetastet.

## Gegenprobe

Per `cp`-Backup, nicht `git checkout`. Bind kuenstlich verzoegert, also der
Zustand "beim fetch lauscht niemand":

| Bind-Verzoegerung | alt (400 ms fest) | neu (`listenOnFreePort`) |
|---|---|---|
| 800 ms | `exit=7`, 0 Tests | `exit=0`, 3 gruen |
| 1500 ms | `exit=7`, 0 Tests | `exit=0`, 3 gruen |
| 3000 ms | `exit=7`, 0 Tests | `exit=0`, 3 gruen |

Die alte Fassung meldet dabei woertlich `ECONNREFUSED ::1:13098` **und**
`ECONNREFUSED 127.0.0.1:13098`. Das Fehlerbild reproduziert sich also mit dem
alten Warten und verschwindet mit dem neuen.

## Laeufe

Volle `npm test`-Kette auf dem Stand von `c289fe6a`, echte `exit=$?`-Zeile
gelesen (nicht der Exit des letzten Kommandos):

- `TZ=UTC` -> **0**
- `TZ=Europe/Berlin` -> **0**

Beide bis `test:readme-consistency`. Die drei Suiten melden in beiden Zonen
unveraendert 3, 14 und 11 Tests, `test:suite-chain` ist gruen.

## Nicht in diesem PR

`process.exit(0)` im `after()`-Hook maskiert den Exit-Code: ein absichtlich rot
gestellter Test meldete `exit=0` bei zwei sichtbaren `✖`-Zeilen. `process.exitCode`
ist im Hook noch `undefined`, auch nach `setImmediate` und nach
`setTimeout(..., 50)`. Diese Suiten koennen in der Kette also nur ueber einen
Top-Level-Fehler rot werden. Ein sauberer Fix braucht Eingriffe in die Scheduler
(ohne `process.exit` haengt der Prozess, 30 s gemessen) und betrifft alle
Route-Suiten, deshalb laeuft das als eigener Vorgang.
