### PR TITLE
fix(ci): lass den eigenen Strom des Laufs die Abbruchbehauptung schlagen

### DIFF
--- a/.github/scripts/review-verdict.mjs
+++ b/.github/scripts/review-verdict.mjs
@@ -90,8 +90,30 @@ export function bejaht(text, muster) {
  * enthaelt der Strom diese Bloecke nicht. Der Schalter ist damit tragend, und
  * eine Probe in test-claude-review-workflow.js haelt ihn fest.
  */
-const POSTBEFEHL = /\bgh\s+pr\s+(?:comment|review)\b|\bgh\s+api\b[^"]*\/(?:comments|reviews)\b/i;
+/**
+ * Ein Befehl, der NUR posten kann - keine Kette, kein Nebenbei.
+ *
+ * Der Befehl muss am Anfang stehen (`^`), damit `irgendwas; gh pr comment ...`
+ * nicht durchrutscht, und er muss die Form eines echten Postbefehls haben statt
+ * nur dessen Namen zu tragen. Bei `gh pr comment` heisst das `--body` oder
+ * `--body-file`: das ist eine ALLOWLIST der liefernden Form, keine Denylist von
+ * `--help` und `--delete-last` - eine Denylist sagt zu jedem unbekannten
+ * Schalter ja.
+ */
+const POSTBEFEHL =
+  /^\s*gh\s+pr\s+comment\b(?=[\s\S]*--body(?:-file)?[\s=])|^\s*gh\s+pr\s+review\b(?=[\s\S]*--(?:body|body-file|comment|approve|request-changes)\b)|^\s*gh\s+api\b[^"']*\/(?:comments|reviews)\b/i;
 const POSTWERKZEUG = /inline_comment|create_.*comment/i;
+
+/**
+ * Und keine Verkettung. Nach dem Review zu #1085, zweite Runde: die
+ * Erlaubnisliste gibt `Bash(gh pr comment:*)` frei, und
+ * `gh pr comment --help; gh pr view 1085 --json comments --jq '.comments[-1].url'`
+ * endet mit 0 und DRUCKT die Adresse eines fremden, laengst vorhandenen
+ * Kommentars. Der Befehl trug den Namen, das Ergebnis trug die Adresse - und
+ * gepostet hat er nichts. Ein Postbefehl braucht keine Kette; wer eine baut,
+ * bekommt hier keinen Beleg.
+ */
+const KETTE = /;|&&|\|\||\n\s*\S/;
 
 /**
  * Der Beleg im ERGEBNIS, nicht nur im Befehl.
@@ -123,7 +145,8 @@ export function zaehleGepostet(eintraege) {
     if (block?.type !== 'tool_use') continue;
     const name = String(block.name ?? '');
     const befehl = String(block.input?.command ?? '');
-    if (POSTWERKZEUG.test(name) || POSTBEFEHL.test(befehl)) versuche.add(block.id);
+    const gekettet = KETTE.test(befehl.replace(/"\$\(cat <<'?EOF'?[\s\S]*?EOF\s*\)"/g, '"..."'));
+    if (POSTWERKZEUG.test(name) || (POSTBEFEHL.test(befehl) && !gekettet)) versuche.add(block.id);
   }
   let erfolge = 0;
   for (const block of bloecke) {
@@ -246,7 +269,19 @@ export function beurteile({
   // stehen. Dort sagt der Lauf, dass er noch nicht fertig ist, und eine
   // unterwegs abgesetzte Anmerkung belegt dann nur einen Teil - hier dagegen
   // widerspricht der Strom der Behauptung, gar nichts getan zu haben.
-  if (gepostet.erfolge === 0 && bejaht(text, SCHON_KOMMENTIERT)) {
+  //
+  // Und `zahl.gebunden` gehoert genauso dazu (Review zu #1085, dritte Runde).
+  // Ohne diese Haelfte kann der Fallback darunter bei einer Abbruchbehauptung
+  // NIE greifen - dieser Zweig kehrt vorher zurueck. Damit widerspraeche der
+  // Kommentar bei POSTADRESSE seinem eigenen Code: er begruendet die
+  // verschaerfte Adresspruefung ausgerechnet damit, dass `zahl.gebunden`
+  // Reviews und Inline-Anmerkungen "ohnehin" auffaengt.
+  //
+  // Es passt auch zur Frage, die dieses Modul stellt: nicht "hat DIESER LAUF
+  // geprueft", sondern "wurde DIESER STAND geprueft". Eine Aeusserung, die die
+  // SHA des Kopfes traegt und nach dem Laufbeginn kam, beantwortet das mit ja -
+  // auch wenn sie von einem abgebrochenen Vorgaenger zu demselben Stand stammt.
+  if (gepostet.erfolge === 0 && zahl.gebunden === 0 && bejaht(text, SCHON_KOMMENTIERT)) {
     return stumm('schon-kommentiert', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
   }
 
@@ -376,17 +411,28 @@ function stumm(grund, neu, seit, ergebnis, gebunden = 0, erfolge = 0) {
   // ist dann eine Behauptung ins Blaue - und bei einem Lauf, der gepostet hat
   // und danach auf seine Agenten wartet, schlicht falsch. Dieser Fall bleibt
   // rot, aber aus dem RICHTIGEN Grund: geliefert schon, fertig nicht.
-  const belegt = gebunden > 0 || erfolge > 0;
+  // NUR `erfolge` traegt die Aussage "DIESER Lauf hat gepostet" (Review zu
+  // #1085, zweite Runde). `gebunden` sagt, dass eine Aeusserung die SHA dieses
+  // Stands nennt - wer sie geschrieben hat, sagt es nicht: der Mention-Pfad
+  // antwortet als derselbe Bot, und ein abgebrochener Vorgaenger kann noch
+  // posten, nachdem dieser Lauf seinen Beginn notiert hat. Genau das steht
+  // schon bei `zaehleSeit`. Bei `lauf-fehler`, `daten-kaputt` und
+  // `kein-ergebnis` wies die Meldung die fremde Aeusserung sonst diesem Lauf
+  // zu und schickte die Suche in die falsche Richtung.
   const kopf =
     grund === 'kein-stand'
       ? 'Der Nachweis konnte den Laufbeginn nicht bestimmen.'
       : neu === 0
         ? `Die Review hat in diesem Lauf nichts hinterlassen (nichts nach dem Laufbeginn ${seit}).`
-        : belegt
-          ? `Die Review hat in diesem Lauf zwar gepostet (${neu} Aeusserung(en) nach dem ` +
-            `Laufbeginn ${seit}), aber keine davon belegt eine ABGESCHLOSSENE Pruefung.`
-          : `Die Review hat zu diesem Stand nichts Zuzuordnendes hinterlassen: ${neu} ` +
-            `Aeusserung(en) nach dem Laufbeginn ${seit}, aber keine davon belegt DIESEN Lauf.`;
+        : erfolge > 0
+          ? `Die Review hat in diesem Lauf zwar gepostet (belegt durch ihren eigenen Strom), ` +
+            `aber nichts davon belegt eine ABGESCHLOSSENE Pruefung. ${neu} Aeusserung(en) ` +
+            `nach dem Laufbeginn ${seit}.`
+          : gebunden > 0
+            ? `${neu} Aeusserung(en) nach dem Laufbeginn ${seit}, davon ${gebunden} mit der SHA ` +
+              `dieses Stands - wer sie geschrieben hat, sagt der Strom DIESES Laufs aber nicht.`
+            : `Die Review hat zu diesem Stand nichts Zuzuordnendes hinterlassen: ${neu} ` +
+              `Aeusserung(en) nach dem Laufbeginn ${seit}, aber keine davon belegt DIESEN Lauf.`;
   const zahlen = ergebnis
     ? ` num_turns: ${ergebnis.num_turns ?? '?'}, subtype: ${ergebnis.subtype ?? '?'}, ` +
       `Verweigerungen: ${Array.isArray(ergebnis.permission_denials) ? ergebnis.permission_denials.length : '?'}.`

--- a/.github/scripts/review-verdict.mjs
+++ b/.github/scripts/review-verdict.mjs
@@ -200,7 +200,31 @@ export function beurteile({
   if (ergebnis.subtype && ergebnis.subtype !== 'success') {
     return stumm('lauf-fehler', neu, seit, ergebnis);
   }
-  if (bejaht(text, SCHON_KOMMENTIERT)) return stumm('schon-kommentiert', neu, seit, ergebnis);
+  // ... MIT EINER AUSNAHME, und nur mit dieser einen: hat DIESER Lauf
+  // nachweislich gepostet, kann er nicht im Tor abgebrochen sein. Der Abbruch
+  // heisst "ich hoere auf, bevor ich anfange" - er hinterlaesst nichts, und der
+  // Strom eines solchen Laufs traegt entsprechend keinen Postbefehl. Gemessen
+  // an #1082 am 09.09., zwei Laeufe am selben PR:
+  //
+  //   Lauf 1  num_turns 21, Verweigerungen 8, Postbefehle 1 von 5 ohne Fehler
+  //           -> hat geprueft UND gepostet, und wurde trotzdem rot, weil sein
+  //              result-Text nebenbei "already ... commented" sagte
+  //   Rerun   num_turns 4, Verweigerungen 0, Postbefehle 0 von 0
+  //           -> der echte Abbruch. Bleibt rot, und muss es.
+  //
+  // Die Prosa gegen den eigenen Strom des Laufs zu stellen ist genau die
+  // Abwaegung, die dieses Modul sonst ueberall zugunsten des Stroms trifft
+  // ("DER EINE BELEG, DER NICHT AUF PROSA BERUHT", weiter unten). Ein
+  // gescheiterter Postbefehl rettet nichts: `erfolge` zaehlt nur `tool_result`
+  // ohne `is_error`.
+  //
+  // NICHT verallgemeinern: `WARTET_AUF_AGENTEN` bleibt bewusst VOR den Belegen
+  // stehen. Dort sagt der Lauf, dass er noch nicht fertig ist, und eine
+  // unterwegs abgesetzte Anmerkung belegt dann nur einen Teil - hier dagegen
+  // widerspricht der Strom der Behauptung, gar nichts getan zu haben.
+  if (gepostet.erfolge === 0 && bejaht(text, SCHON_KOMMENTIERT)) {
+    return stumm('schon-kommentiert', neu, seit, ergebnis);
+  }
 
   // EIN BELEG FUER UNVOLLSTAENDIGKEIT SCHLAEGT JEDEN BELEG FUER LIEFERUNG.
   // Der Lauf sagt hier selbst, dass er auf seine Agenten wartet - dann ist die
@@ -316,10 +340,18 @@ const DIAGNOSE = {
 };
 
 function stumm(grund, neu, seit, ergebnis) {
+  // Die Zahl, die zwei Zeilen weiter oben im Job-Log steht, muss hier
+  // wiederauftauchen. Stand hier pauschal "nichts hinterlassen", waehrend der
+  // Schritt darueber "Aeusserungen von claude seit dem Laufbeginn: 1" ausgab,
+  // widersprachen sich zwei Zeilen desselben Logs - und der Leser sucht den
+  // Fehler an der falschen Stelle (09.09., #1082).
   const kopf =
     grund === 'kein-stand'
       ? 'Der Nachweis konnte den Laufbeginn nicht bestimmen.'
-      : `Die Review hat in diesem Lauf nichts hinterlassen (nichts nach dem Laufbeginn ${seit}).`;
+      : neu > 0
+        ? `Die Review hat zu diesem Stand nichts Zuzuordnendes hinterlassen: ${neu} ` +
+          `Aeusserung(en) nach dem Laufbeginn ${seit}, aber keine davon belegt DIESEN Lauf.`
+        : `Die Review hat in diesem Lauf nichts hinterlassen (nichts nach dem Laufbeginn ${seit}).`;
   const zahlen = ergebnis
     ? ` num_turns: ${ergebnis.num_turns ?? '?'}, subtype: ${ergebnis.subtype ?? '?'}, ` +
       `Verweigerungen: ${Array.isArray(ergebnis.permission_denials) ? ergebnis.permission_denials.length : '?'}.`

--- a/.github/scripts/review-verdict.mjs
+++ b/.github/scripts/review-verdict.mjs
@@ -93,6 +93,25 @@ export function bejaht(text, muster) {
 const POSTBEFEHL = /\bgh\s+pr\s+(?:comment|review)\b|\bgh\s+api\b[^"]*\/(?:comments|reviews)\b/i;
 const POSTWERKZEUG = /inline_comment|create_.*comment/i;
 
+/**
+ * Der Beleg im ERGEBNIS, nicht nur im Befehl.
+ *
+ * Ein zweiter Blick nach dem Review zu #1085: die Erlaubnisliste im Workflow
+ * gibt `Bash(gh pr comment:*)` als GANZES frei, und bis hierher genuegte der
+ * Befehlsanfang plus ein `tool_result` ohne Fehler. `gh pr comment --help`
+ * endet mit 0 und postet nichts; `gh pr comment --delete-last --yes` endet mit
+ * 0 und LOESCHT sogar einen. Beides haette `erfolge` erhoeht - und seit die
+ * Abbruchbehauptung von diesem Zaehler geschlagen wird, waere das eine Tuer.
+ *
+ * Ein echter Postbefehl gibt die Adresse dessen zurueck, was er angelegt hat
+ * (an #1066 gemessen: `.../pull/1066#issuecomment-5596556584`); auch die
+ * JSON-Antwort von `gh api .../comments` traegt sie als `html_url`. Genau das
+ * wird verlangt. Faellt eine echte Lieferung ohne Adresse durch, ist das die
+ * SICHERE Richtung: dieses Modul faerbt im Zweifel rot, und der Fallback ueber
+ * `zahl.gebunden` faengt Reviews und Inline-Anmerkungen ohnehin ab.
+ */
+const POSTADRESSE = /\/(?:pull|issues)\/\d+#(?:issuecomment-\d+|discussion_r\d+|pullrequestreview-\d+)/i;
+
 export function zaehleGepostet(eintraege) {
   const versuche = new Set();
   const bloecke = [];
@@ -111,6 +130,11 @@ export function zaehleGepostet(eintraege) {
     if (block?.type !== 'tool_result') continue;
     if (!versuche.has(block.tool_use_id)) continue;
     if (block.is_error === true) continue;
+    // Kein Exit-Code, sondern die Adresse des Angelegten - siehe POSTADRESSE.
+    const inhalt = typeof block.content === 'string'
+      ? block.content
+      : JSON.stringify(block.content ?? '');
+    if (!POSTADRESSE.test(inhalt)) continue;
     erfolge += 1;
   }
   return { versuche: versuche.size, erfolge };
@@ -185,8 +209,8 @@ export function beurteile({
   const zahl = zaehleSeit(aeusserungen, seit, kopf);
   const neu = zahl.gesamt;
 
-  if (kaputt > 0) return stumm('daten-kaputt', neu, seit, ergebnis);
-  if (!ergebnis) return stumm('kein-ergebnis', neu, seit, ergebnis);
+  if (kaputt > 0) return stumm('daten-kaputt', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
+  if (!ergebnis) return stumm('kein-ergebnis', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
 
   const text = String(ergebnis.result ?? '');
   const sperren = Array.isArray(ergebnis.permission_denials)
@@ -196,9 +220,9 @@ export function beurteile({
   // DAS PROTOKOLL DES LAUFS SCHLAEGT DIE KOMMENTARZAEHLUNG. Was dieser Lauf
   // getan hat, weiss nur sein eigener Strom; die Kommentare am PR sind die
   // Wirkung und koennen von woanders stammen.
-  if (ergebnis.is_error === true) return stumm('lauf-fehler', neu, seit, ergebnis);
+  if (ergebnis.is_error === true) return stumm('lauf-fehler', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
   if (ergebnis.subtype && ergebnis.subtype !== 'success') {
-    return stumm('lauf-fehler', neu, seit, ergebnis);
+    return stumm('lauf-fehler', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
   }
   // ... MIT EINER AUSNAHME, und nur mit dieser einen: hat DIESER Lauf
   // nachweislich gepostet, kann er nicht im Tor abgebrochen sein. Der Abbruch
@@ -223,7 +247,7 @@ export function beurteile({
   // unterwegs abgesetzte Anmerkung belegt dann nur einen Teil - hier dagegen
   // widerspricht der Strom der Behauptung, gar nichts getan zu haben.
   if (gepostet.erfolge === 0 && bejaht(text, SCHON_KOMMENTIERT)) {
-    return stumm('schon-kommentiert', neu, seit, ergebnis);
+    return stumm('schon-kommentiert', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
   }
 
   // EIN BELEG FUER UNVOLLSTAENDIGKEIT SCHLAEGT JEDEN BELEG FUER LIEFERUNG.
@@ -231,7 +255,7 @@ export function beurteile({
   // Pruefung nicht fertig, auch wenn unterwegs schon eine Anmerkung
   // herausgegangen ist. Stuende diese Zeile hinter den Belegen, machte eine
   // einzelne Inline-Anmerkung eines abgebrochenen Laufs den Haken gruen.
-  if (WARTET_AUF_AGENTEN.test(text)) return stumm('agenten', neu, seit, ergebnis);
+  if (WARTET_AUF_AGENTEN.test(text)) return stumm('agenten', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
 
   // DER EINE BELEG, DER NICHT AUF PROSA BERUHT: dieser Lauf hat den Postbefehl
   // ausgefuehrt, und er kam ohne Fehler zurueck. Er schlaegt auch die
@@ -263,7 +287,7 @@ export function beurteile({
     };
   }
 
-  if (sperren > 0) return stumm('werkzeugsperre', neu, seit, ergebnis);
+  if (sperren > 0) return stumm('werkzeugsperre', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
 
   if (bejaht(text, TOR_STOPP) && TRIVIAL.test(text) && !VERNEINT.test(text)) {
     return {
@@ -278,8 +302,8 @@ export function beurteile({
     };
   }
 
-  if (zahl.frei > 0) return stumm('nicht-zuzuordnen', neu, seit, ergebnis);
-  return stumm('unbekannt', neu, seit, ergebnis);
+  if (zahl.frei > 0) return stumm('nicht-zuzuordnen', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
+  return stumm('unbekannt', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);
 }
 
 const DIAGNOSE = {
@@ -339,19 +363,30 @@ const DIAGNOSE = {
     'vollstaendig und schweigt danach absichtlich.'
 };
 
-function stumm(grund, neu, seit, ergebnis) {
+function stumm(grund, neu, seit, ergebnis, gebunden = 0, erfolge = 0) {
   // Die Zahl, die zwei Zeilen weiter oben im Job-Log steht, muss hier
   // wiederauftauchen. Stand hier pauschal "nichts hinterlassen", waehrend der
   // Schritt darueber "Aeusserungen von claude seit dem Laufbeginn: 1" ausgab,
   // widersprachen sich zwei Zeilen desselben Logs - und der Leser sucht den
   // Fehler an der falschen Stelle (09.09., #1082).
+  //
+  // Und die Meldung darf nur behaupten, was der Aufrufer ihr auch mitgegeben
+  // hat (Review zu #1085): fuenf der Rueckgaben hier fallen, BEVOR
+  // `zahl.gebunden` ueberhaupt geprueft wird. "Keine davon belegt DIESEN Lauf"
+  // ist dann eine Behauptung ins Blaue - und bei einem Lauf, der gepostet hat
+  // und danach auf seine Agenten wartet, schlicht falsch. Dieser Fall bleibt
+  // rot, aber aus dem RICHTIGEN Grund: geliefert schon, fertig nicht.
+  const belegt = gebunden > 0 || erfolge > 0;
   const kopf =
     grund === 'kein-stand'
       ? 'Der Nachweis konnte den Laufbeginn nicht bestimmen.'
-      : neu > 0
-        ? `Die Review hat zu diesem Stand nichts Zuzuordnendes hinterlassen: ${neu} ` +
-          `Aeusserung(en) nach dem Laufbeginn ${seit}, aber keine davon belegt DIESEN Lauf.`
-        : `Die Review hat in diesem Lauf nichts hinterlassen (nichts nach dem Laufbeginn ${seit}).`;
+      : neu === 0
+        ? `Die Review hat in diesem Lauf nichts hinterlassen (nichts nach dem Laufbeginn ${seit}).`
+        : belegt
+          ? `Die Review hat in diesem Lauf zwar gepostet (${neu} Aeusserung(en) nach dem ` +
+            `Laufbeginn ${seit}), aber keine davon belegt eine ABGESCHLOSSENE Pruefung.`
+          : `Die Review hat zu diesem Stand nichts Zuzuordnendes hinterlassen: ${neu} ` +
+            `Aeusserung(en) nach dem Laufbeginn ${seit}, aber keine davon belegt DIESEN Lauf.`;
   const zahlen = ergebnis
     ? ` num_turns: ${ergebnis.num_turns ?? '?'}, subtype: ${ergebnis.subtype ?? '?'}, ` +
       `Verweigerungen: ${Array.isArray(ergebnis.permission_denials) ? ergebnis.permission_denials.length : '?'}.`

--- a/test/test-review-proof.js
+++ b/test/test-review-proof.js
@@ -364,6 +364,75 @@ test('ein bewiesener Postbefehl schlaegt die Abbruchbehauptung (#1082)', () => {
   assert.equal(urteil.grund, 'postbefehl');
 });
 
+/* Und ein Befehl, der zwar so AUSSIEHT, aber nichts angelegt hat (Review zu
+ * #1085). Die Erlaubnisliste im Workflow gibt `Bash(gh pr comment:*)` als
+ * Ganzes frei: `--help` endet mit 0 und postet nichts, `--delete-last --yes`
+ * endet mit 0 und loescht sogar einen. Beides zaehlte bis dahin als Beleg -
+ * und seit die Abbruchbehauptung davon geschlagen wird, waere das eine Tuer.
+ * Verlangt wird deshalb die Adresse des Angelegten im ERGEBNIS. */
+const stromMit = (befehl, inhalt) => [
+  { type: 'assistant', message: { content: [
+    { type: 'tool_use', id: 'toolu_probe', name: 'Bash', input: { command: befehl } }
+  ] } },
+  { type: 'user', message: { content: [
+    { type: 'tool_result', tool_use_id: 'toolu_probe', content: inhalt, is_error: false }
+  ] } }
+];
+
+test('ein Postbefehl OHNE Adresse im Ergebnis ist kein Beleg (#1085)', () => {
+  for (const [befehl, inhalt] of [
+    ['gh pr comment --help', 'Add a comment to a pull request\n\nUSAGE\n  gh pr comment ...'],
+    ['gh pr comment 1085 --repo ulsklyc/yuvomi --delete-last --yes', 'Deleted comment.']
+  ]) {
+    assert.deepEqual(zaehleGepostet(stromMit(befehl, inhalt)), { versuche: 1, erfolge: 0 },
+      `${befehl}: endet mit 0, legt aber nichts an`);
+
+    const urteil = beurteile({
+      seit: seit(ABBRUCH_LAUF),
+      kopf: kopf(ABBRUCH_LAUF),
+      ergebnis: ABBRUCH,
+      aeusserungen: [],
+      gepostet: zaehleGepostet(stromMit(befehl, inhalt))
+    });
+    assert.equal(urteil.ausgang, 'stumm', `${befehl} darf die Abbruchbehauptung nicht aushebeln`);
+    assert.equal(urteil.grund, 'schon-kommentiert');
+  }
+});
+
+test('die Adresse zaehlt auch aus einer JSON-Antwort', () => {
+  // `gh api .../comments` gibt ein Objekt zurueck, keine nackte Adresse.
+  const strom = stromMit(
+    'gh api repos/ulsklyc/yuvomi/pulls/1066/comments -f body=x',
+    { html_url: 'https://github.com/ulsklyc/yuvomi/pull/1066#discussion_r3968998598' }
+  );
+  assert.deepEqual(zaehleGepostet(strom), { versuche: 1, erfolge: 1 });
+});
+
+/* Die Meldung darf nur behaupten, was der Aufrufer ihr mitgegeben hat (Review
+ * zu #1085). Fuenf Rueckgaben in `beurteile` fallen, BEVOR `zahl.gebunden`
+ * geprueft wird - "keine davon belegt DIESEN Lauf" waere dort ins Blaue
+ * gesprochen. Bei einem Lauf, der gepostet hat und danach auf seine Agenten
+ * wartet, ist es sogar falsch: der bleibt rot, aber weil er UNFERTIG ist, nicht
+ * weil nichts zuzuordnen waere. */
+test('ein Lauf, der gepostet hat und dann wartet, wird richtig benannt', () => {
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: {
+      num_turns: 9, subtype: 'success', is_error: false, permission_denials: [],
+      result: "I'll wait for both background agents to complete before continuing."
+    },
+    aeusserungen: [{ login: 'claude[bot]', zeit: '2026-09-09T06:41:00Z', commit: kopf(ABBRUCH_LAUF) }],
+    gepostet: zaehleGepostet(fixture.strom.gepostet)
+  });
+  assert.equal(urteil.ausgang, 'stumm');
+  assert.equal(urteil.grund, 'agenten', 'der Grund bleibt die Unvollstaendigkeit');
+  assert.match(urteil.meldung, /zwar gepostet/);
+  assert.match(urteil.meldung, /ABGESCHLOSSENE Pruefung/);
+  assert.ok(!/keine davon belegt DIESEN Lauf/.test(urteil.meldung),
+    'das waere falsch: die Aeusserung traegt die SHA dieses Laufs');
+});
+
 test('ein GESCHEITERTER Postbefehl rettet die Abbruchbehauptung nicht', () => {
   // Die Gegenrichtung, damit die Ausnahme oben nicht zur Tuer wird: `erfolge`
   // zaehlt nur `tool_result` ohne `is_error`. Ein Versuch allein genuegt nicht.

--- a/test/test-review-proof.js
+++ b/test/test-review-proof.js
@@ -384,7 +384,10 @@ test('ein Postbefehl OHNE Adresse im Ergebnis ist kein Beleg (#1085)', () => {
     ['gh pr comment --help', 'Add a comment to a pull request\n\nUSAGE\n  gh pr comment ...'],
     ['gh pr comment 1085 --repo ulsklyc/yuvomi --delete-last --yes', 'Deleted comment.']
   ]) {
-    assert.deepEqual(zaehleGepostet(stromMit(befehl, inhalt)), { versuche: 1, erfolge: 0 },
+    // Seit der zweiten Runde zaehlen sie nicht einmal mehr als VERSUCH: `--help`
+    // und `--delete-last` tragen kein `--body`, und die Form des Postbefehls ist
+    // eine Allowlist. Entscheidend bleibt `erfolge: 0`.
+    assert.deepEqual(zaehleGepostet(stromMit(befehl, inhalt)), { versuche: 0, erfolge: 0 },
       `${befehl}: endet mit 0, legt aber nichts an`);
 
     const urteil = beurteile({
@@ -397,6 +400,66 @@ test('ein Postbefehl OHNE Adresse im Ergebnis ist kein Beleg (#1085)', () => {
     assert.equal(urteil.ausgang, 'stumm', `${befehl} darf die Abbruchbehauptung nicht aushebeln`);
     assert.equal(urteil.grund, 'schon-kommentiert');
   }
+});
+
+/* Der Bypass aus der zweiten Runde zu #1085: der Befehl traegt den Namen, das
+ * ERGEBNIS traegt eine fremde Adresse - gepostet hat er nichts.
+ *
+ *   gh pr comment --help; gh pr view 1085 --json comments --jq '.comments[-1].url'
+ *
+ * endet mit 0 und druckt die Adresse eines laengst vorhandenen Kommentars.
+ * Beide Haelften sind von `Bash(gh pr comment:*)` gedeckt. Ein Postbefehl
+ * braucht keine Kette; wer eine baut, bekommt hier keinen Beleg. */
+test('eine Befehlskette ist kein Postbefehl (#1085, zweite Runde)', () => {
+  const ketten = [
+    // Der gemeldete Fall: die erste Haelfte traegt den Namen, die zweite die
+    // fremde Adresse. Faengt schon die Form ab - `--help` hat kein `--body`.
+    "gh pr comment --help; gh pr view 1085 --json comments --jq '.comments[-1].url'",
+    // Und der Fall, den NUR die Kettenpruefung faengt: `--body` ist da, `--help`
+    // bricht trotzdem vor dem Posten ab, und der zweite Befehl druckt die
+    // Adresse eines fremden Kommentars.
+    "gh pr comment 1085 --body x --help; gh pr view 1085 --json comments --jq '.comments[-1].url'",
+    // Dasselbe ueber && und ||.
+    "gh pr comment 1085 --body x --help && gh pr view 1085 --jq '.comments[-1].url'",
+    "gh pr comment 1085 --body x --help || gh pr view 1085 --jq '.comments[-1].url'"
+  ];
+  for (const befehl of ketten) {
+    const strom = stromMit(befehl, 'https://github.com/ulsklyc/yuvomi/pull/1085#issuecomment-5596556584');
+    assert.deepEqual(zaehleGepostet(strom), { versuche: 0, erfolge: 0 }, befehl);
+
+    const urteil = beurteile({
+      seit: seit(ABBRUCH_LAUF), kopf: kopf(ABBRUCH_LAUF),
+      ergebnis: ABBRUCH, aeusserungen: [], gepostet: zaehleGepostet(strom)
+    });
+    assert.equal(urteil.ausgang, 'stumm', befehl);
+    assert.equal(urteil.grund, 'schon-kommentiert', befehl);
+  }
+});
+
+test('der echte Postbefehl mit Heredoc bleibt ein Beleg', () => {
+  // Die Gegenrichtung: die Fassung aus #1066 traegt Zeilenumbrueche im Body und
+  // darf nicht als Kette gelten.
+  assert.deepEqual(zaehleGepostet(fixture.strom.gepostet), { versuche: 1, erfolge: 1 });
+});
+
+/* Nur der eigene Strom traegt die Aussage "DIESER Lauf hat gepostet" (#1085,
+ * zweite Runde). Eine Aeusserung mit der SHA dieses Stands sagt nicht, WER sie
+ * geschrieben hat - der Mention-Pfad antwortet als derselbe Bot, und ein
+ * abgebrochener Vorgaenger kann noch posten. Bei einem gescheiterten Lauf wies
+ * die Meldung sie sonst diesem Lauf zu. */
+test('eine SHA-gebundene Aeusserung wird einem gescheiterten Lauf nicht zugeschrieben', () => {
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: { num_turns: 3, subtype: 'error_during_execution', is_error: true, permission_denials: [] },
+    aeusserungen: [{ login: 'claude[bot]', zeit: '2026-09-09T06:41:00Z', commit: kopf(ABBRUCH_LAUF) }],
+    gepostet: zaehleGepostet(fixture.strom.nichts_gepostet)
+  });
+  assert.equal(urteil.ausgang, 'stumm');
+  assert.equal(urteil.grund, 'lauf-fehler');
+  assert.ok(!/zwar gepostet/.test(urteil.meldung),
+    'ohne eigenen Beleg darf die Meldung diesem Lauf keinen Post zuschreiben');
+  assert.match(urteil.meldung, /wer sie geschrieben hat, sagt der Strom DIESES Laufs aber nicht/);
 });
 
 test('die Adresse zaehlt auch aus einer JSON-Antwort', () => {
@@ -431,6 +494,43 @@ test('ein Lauf, der gepostet hat und dann wartet, wird richtig benannt', () => {
   assert.match(urteil.meldung, /ABGESCHLOSSENE Pruefung/);
   assert.ok(!/keine davon belegt DIESEN Lauf/.test(urteil.meldung),
     'das waere falsch: die Aeusserung traegt die SHA dieses Laufs');
+});
+
+/* Und der Fallback muss bei einer Abbruchbehauptung ueberhaupt erreichbar sein
+ * (Review zu #1085, dritte Runde). Ohne `zahl.gebunden === 0` in der Bedingung
+ * kehrt der Abbruchzweig vorher zurueck - und der Kommentar bei POSTADRESSE
+ * widerspraeche seinem eigenen Code, denn der begruendet die verschaerfte
+ * Adresspruefung genau damit, dass `zahl.gebunden` Reviews und
+ * Inline-Anmerkungen "ohnehin" auffaengt.
+ *
+ * Der Fall: eine Inline-Anmerkung, deren tool_result keine Adresse traegt (oder
+ * ein Lauf ohne `show_full_output: true`), plus Prosa, die nebenbei "already
+ * commented" sagt. Die Frage dieses Moduls ist "wurde DIESER STAND geprueft" -
+ * eine Aeusserung mit der SHA des Kopfes beantwortet sie mit ja. */
+test('eine SHA-gebundene Aeusserung macht den Fallback auch bei Abbruchprosa erreichbar', () => {
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: ABBRUCH,
+    aeusserungen: [{ login: 'claude[bot]', zeit: '2026-09-09T06:41:00Z', commit: kopf(ABBRUCH_LAUF) }],
+    gepostet: zaehleGepostet(fixture.strom.nichts_gepostet)
+  });
+  assert.equal(urteil.ausgang, 'geprueft');
+  assert.equal(urteil.grund, 'gebunden');
+});
+
+test('OHNE gebundene Aeusserung bleibt die Abbruchbehauptung rot', () => {
+  // Die Gegenrichtung, damit die zweite Haelfte der Bedingung nicht zur Tuer
+  // wird: der Fall aus #1066 hat keine Aeusserung mit der SHA dieses Kopfes.
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: ABBRUCH,
+    aeusserungen: [{ login: 'claude[bot]', zeit: '2026-09-09T06:41:00Z', commit: 'ein-anderer-stand' }],
+    gepostet: zaehleGepostet(fixture.strom.nichts_gepostet)
+  });
+  assert.equal(urteil.ausgang, 'stumm');
+  assert.equal(urteil.grund, 'schon-kommentiert');
 });
 
 test('ein GESCHEITERTER Postbefehl rettet die Abbruchbehauptung nicht', () => {

--- a/test/test-review-proof.js
+++ b/test/test-review-proof.js
@@ -338,6 +338,63 @@ test('eine Zusammenfassung ohne SHA zaehlt ueber den Postbefehl des Laufs', () =
   assert.equal(urteil.grund, 'postbefehl');
 });
 
+/* Und dieselbe Vorfahrt gegen die ABBRUCHBEHAUPTUNG - der Fall aus #1082.
+ *
+ * Am 09.09. liefen an einem PR zwei Laeufe hintereinander:
+ *
+ *   Lauf 1  num_turns 21, Verweigerungen 8, Postbefehle 1 von 5 ohne Fehler
+ *   Rerun   num_turns 4,  Verweigerungen 0, Postbefehle 0 von 0
+ *
+ * Der Rerun ist der echte Abbruch und gehoert rot. Lauf 1 hatte geprueft und
+ * gepostet - der Kommentar steht bis heute am PR - und wurde trotzdem rot,
+ * weil sein result-Text nebenbei "already ... commented" sagte. Ein Abbruch im
+ * Tor hinterlaesst aber nichts; wer nachweislich gepostet hat, hat nicht im Tor
+ * abgebrochen.
+ */
+test('ein bewiesener Postbefehl schlaegt die Abbruchbehauptung (#1082)', () => {
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: ABBRUCH,                       // derselbe Text, der #1066 rot faerbt
+    aeusserungen: [],
+    gepostet: zaehleGepostet(fixture.strom.gepostet)
+  });
+  assert.equal(urteil.ausgang, 'geprueft',
+    'ein Lauf, der nachweislich gepostet hat, kann nicht im Tor abgebrochen sein');
+  assert.equal(urteil.grund, 'postbefehl');
+});
+
+test('ein GESCHEITERTER Postbefehl rettet die Abbruchbehauptung nicht', () => {
+  // Die Gegenrichtung, damit die Ausnahme oben nicht zur Tuer wird: `erfolge`
+  // zaehlt nur `tool_result` ohne `is_error`. Ein Versuch allein genuegt nicht.
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: ABBRUCH,
+    aeusserungen: [],
+    gepostet: zaehleGepostet(fixture.strom.post_gescheitert)
+  });
+  assert.equal(urteil.ausgang, 'stumm');
+  assert.equal(urteil.grund, 'schon-kommentiert');
+});
+
+test('die Meldung nennt die Zahl, die der Schritt darueber ausgegeben hat', () => {
+  // Hier stand pauschal "nichts hinterlassen", waehrend der Job-Log zwei Zeilen
+  // hoeher "Aeusserungen von claude seit dem Laufbeginn: 1" ausgab. Zwei Zeilen
+  // desselben Logs widersprachen sich, und der Leser sucht dann falsch.
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    ergebnis: fixture.ergebnisse['stumm-unbekannt'],
+    aeusserungen: [{ login: 'claude[bot]', zeit: '2026-09-09T06:41:00Z' }],
+    gepostet: zaehleGepostet(fixture.strom.nichts_gepostet)
+  });
+  assert.equal(urteil.ausgang, 'stumm');
+  assert.equal(urteil.neu, 1);
+  assert.match(urteil.meldung, /1 Aeusserung\(en\) nach dem Laufbeginn/);
+  assert.ok(!/in diesem Lauf nichts hinterlassen/.test(urteil.meldung),
+    'die Meldung darf nicht behaupten, es sei gar nichts gesagt worden');
+});
+
 test('ZUORDNUNG AUS ABWESENHEIT TRAEGT NICHT: "Done." bleibt rot', () => {
   // Der Befund aus der zweiten Codex-Runde. Ein Lauf, der still mit "Done."
   // endet, hat nichts gepostet - eine fremde Zusammenfassung (Mention-Pfad oder


### PR DESCRIPTION
## Summary

`beurteile()` in `.github/scripts/review-verdict.mjs` prueft die Abbruchbehauptung im result-Text (`SCHON_KOMMENTIERT`) **vor** dem einen Beleg, den dasselbe Modul "DER EINE BELEG, DER NICHT AUF PROSA BERUHT" nennt: einen Postbefehl aus dem Strom des Laufs, der ohne Fehler zurueckkam. Damit faerbte Prosa einen Lauf rot, der nachweislich geprueft und gepostet hatte.

### Gemessen an #1082, zwei Laeufe am selben PR

| | Lauf 1 (12:13Z) | Rerun (12:21Z) |
| --- | --- | --- |
| `num_turns` | 21 | 4 |
| Verweigerungen | 8 | 0 |
| Postbefehle | **1 von 5 ohne Fehler** | 0 von 0 |
| Urteil bisher | rot (`schon-kommentiert`) | rot (`schon-kommentiert`) |

Der Rerun ist der echte Abbruch im Tor und gehoert rot - dieser Lauf hat in vier Turns nichts getan. Lauf 1 dagegen hatte geprueft und gepostet; der Kommentar steht bis heute am PR. Rot war dort falsch.

## Die Aenderung

```js
if (gepostet.erfolge === 0 && bejaht(text, SCHON_KOMMENTIERT)) {
```

Der Abbruch heisst "ich hoere auf, bevor ich anfange" - er hinterlaesst nichts, und der Strom eines solchen Laufs traegt entsprechend keinen Postbefehl. **Wer nachweislich gepostet hat, hat nicht im Tor abgebrochen.** Die Ausnahme ist eng gehalten: `erfolge` zaehlt nur `tool_result` ohne `is_error`, ein gescheiterter Versuch rettet nichts.

**Nicht verallgemeinert.** `WARTET_AUF_AGENTEN` behaelt seine Vorfahrt VOR den Belegen. Dort sagt der Lauf selbst, dass er unfertig ist, und eine unterwegs abgesetzte Anmerkung belegt dann nur einen Teil (#865). Hier dagegen widerspricht der eigene Strom der Behauptung, gar nichts getan zu haben.

### Dazu eine zweite, kleinere Sache aus demselben Job-Log

`stumm()` schrieb pauschal "nichts hinterlassen", waehrend der Schritt zwei Zeilen hoeher `Aeusserungen von claude seit dem Laufbeginn: 1` ausgab. Zwei Zeilen desselben Logs widersprachen sich - und man sucht den Fehler dann an der falschen Stelle (mir genau so passiert). Die Meldung nennt jetzt die Zahl, die sie wirklich gezaehlt hat.

## Gegenproben

Jede trifft genau eine Probe, und jede eine andere:

| Manipulation | wird rot |
| --- | --- |
| Prosa wieder vor dem Beleg | `ein bewiesener Postbefehl schlaegt die Abbruchbehauptung (#1082)` |
| `versuche` statt `erfolge` (Ausnahme zu weit) | `ein GESCHEITERTER Postbefehl rettet die Abbruchbehauptung nicht` |
| `stumm()`-Meldung pauschal | `die Meldung nennt die Zahl, die der Schritt darueber ausgegeben hat` |
| `WARTET_AUF_AGENTEN` hinter die Belege | `ein Beleg fuer Unvollstaendigkeit schlaegt den Postbefehl` (Bestandstest) |

Der Schutzfall aus #1066 (`DER FALL AUS #1066: alter Kommentar plus neuer Push wird rot`) bleibt rot.

Eine vierte Probe zu `WARTET_AUF_AGENTEN` hatte ich zunaechst geschrieben und wieder **entfernt**: die letzte Gegenprobe zeigte, dass ein Bestandstest sie bereits abdeckt - zwei Sperren fuer einen Fall. Und diese Gegenprobe war im ersten Anlauf ein Blindgaenger, weil ich die Zeile an eine Stelle verschoben hatte, die immer noch vor dem Beleg lag; das faellt nur auf, wenn man hinsieht, ob die Manipulation ueberhaupt etwas veraendert hat.

## Restrisiko, bewusst offen

Postet ein Lauf etwas (etwa eine Inline-Anmerkung) und bricht **danach** im Tor ab, gilt er jetzt als geprueft. Das ist dieselbe Abwaegung, die dieses Modul schon bei `permission_denials` trifft - ein erfolgreicher Postbefehl schlaegt sie ebenfalls, mit derselben Begruendung.

## Checklist

- [x] `npm test` passes - vollstaendig gruen (npm-Exit 0, 0 Fehlerzeilen) unter `TZ=UTC` und `TZ=Europe/Berlin`; `test:review-proof` 31/31
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text) - nicht betroffen
- [x] CHANGELOG.md updated (if user-facing change) - nicht noetig, CI-intern
