### PR TITLE
test(ui): let the focus ratchet see callbacks declared before the modal opens

### DIFF
--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -16086,6 +16086,30 @@ test('jede Seite, die nach einem await neu rendert, zieht den Fokus nach', () =>
     + `Nach dem Rendern refocusAfterRender() rufen:\n  ${fehlend.join('\n  ')}`);
 });
 
+/**
+ * Steht `zeile` in einem Funktionsausdruck INNERHALB der Funktion ab `start`?
+ *
+ * Gesucht wird rueckwaerts nach einer Zeile, die einen Rueckruf oeffnet
+ * (`=> {`, `async () => {`, ein `function` mitten im Rumpf) und flacher liegt
+ * als die fragliche Zeile - dann liegt diese in seinem Koerper. Ein `try {` auf
+ * Funktionsebene zaehlt dabei nicht als Rueckruf, sonst waere jeder
+ * `try`-Block eine Verschachtelung.
+ */
+function inVerschachtelterFunktion(lines, start, zeile) {
+  const tiefe = lines[zeile].match(/^\s*/)[0].length;
+  for (let j = zeile - 1; j > start; j--) {
+    const l = lines[j];
+    if (l.trim() === '') continue;
+    const t = l.match(/^\s*/)[0].length;
+    if (t >= tiefe) continue;
+    // Eine flachere Zeile: oeffnet sie einen Rueckruf?
+    if (/=>\s*\{\s*$|\bfunction\s*\w*\s*\([^)]*\)\s*\{\s*$/.test(l)) return true;
+    // Eine flachere Zeile, die keinen Rueckruf oeffnet (`try {`, `if (…) {`):
+    // weitersuchen, aber ab jetzt auf ihrer Ebene.
+  }
+  return false;
+}
+
 /* DIE ZWEITE BAUART: ASYNCHRON RENDERN, WAEHREND DER DIALOG NOCH OFFEN IST.
  *
  * Der Guard darueber deckt den Handler ab, der nach `closeModal()` rendert.
@@ -16125,10 +16149,26 @@ test('ein Handler, der bei offenem Dialog asynchron rendert, zieht den Fokus nac
         if (!lines.slice(s, e).some((l) => /open(Shared)?Modal\s*\(\s*\{/.test(l))) return;
         for (let j = s; j < e; j++) {
           if (!/\bawait\s+(load|refresh)[A-Z]\w*\s*\(/.test(lines[j])) continue;
-          // NUR NACH DEM OEFFNEN. Ein `await load…()` DAVOR bereitet den Dialog
-          // vor - es baut nichts neu auf, was ein Schliessen betreffen koennte.
-          // (Fehlalarm an `openEditMemberModal` in admin-family.js gemessen.)
-          if (!lines.slice(s, j).some((x) => /open(Shared)?Modal\s*\(\s*\{/.test(x))) continue;
+          // VERSCHACHTELUNG ENTSCHEIDET, NICHT DIE REIHENFOLGE.
+          //
+          // Eine fruehere Fassung verlangte, dass das `openModal({` TEXTLICH vor
+          // dem `await` steht. Das stellte zwar den Fehlalarm an
+          // `openEditMemberModal` in admin-family.js ab - dort bereitet das
+          // `await` den Dialog wirklich nur vor -, schloss aber die haeufigste
+          // Bauart mit aus: den Rueckruf zuerst deklarieren, dann uebergeben.
+          //
+          //   const onChanged = async () => { await loadX(); renderY(); };
+          //   openSharedModal({ … onChanged … });
+          //
+          // Fuenf Stellen haben diese Form (budget, inventory 2x, pantry,
+          // shopping), und der Guard sah keine davon: das Loeschen ihres
+          // `refocusAfterRender()` liess beide Suiten gruen. Ein Guard, der
+          // Schutz behauptet und keinen gibt, ist schlimmer als keiner.
+          //
+          // Der Unterschied liegt in der Verschachtelung: ein `await` INNERHALB
+          // eines verschachtelten Funktionsausdrucks ist eine Auffrischung, eines
+          // auf der Ebene der oeffnenden Funktion ist Vorbereitung.
+          if (!inVerschachtelterFunktion(lines, s, j)) continue;
           const fenster = blockAb(lines, j);
           if (!fenster.some((x) => istNeuaufbau(x, wrapper))) continue;
           // closeModal dazwischen: der synchrone Fall, den der Frame abdeckt.
@@ -16384,4 +16424,46 @@ test('wer refocusAfterRender importiert, ruft es auch', () => {
   }
   assert.deepEqual(tot, [],
     `Diese Dateien importieren refocusAfterRender, ohne es zu rufen:\n  ${tot.join('\n  ')}`);
+});
+
+
+/* VERSCHACHTELUNG, NICHT REIHENFOLGE - direkt geprueft.
+ *
+ * Die Unterscheidung traegt den Ratchet fuer die haeufigste Bauart, und sie ist
+ * an echten Dateien nur zu sehen, solange dort jemand die Form benutzt. Deshalb
+ * hier an einer kuenstlichen Quelle: ein `await` im Rueckruf zaehlt, eines auf
+ * der Ebene der oeffnenden Funktion nicht.
+ */
+test('inVerschachtelterFunktion trennt Rueckruf von Dialogvorbereitung', () => {
+  const imRueckruf = [
+    'function openManager() {',
+    '  const onChanged = async () => {',
+    '    await loadMeta();',
+    '  };',
+    '  openSharedModal({ onChanged });',
+    '}',
+  ];
+  assert.equal(inVerschachtelterFunktion(imRueckruf, 0, 2), true,
+    'ein `await` im Rueckruf ist eine Auffrischung - genau die Bauart, die der Ratchet halten muss');
+
+  const vorbereitung = [
+    'async function openEditor(member) {',
+    '  const ids = await loadIds(member.id);',
+    '  openModal({ content: ids });',
+    '}',
+  ];
+  assert.equal(inVerschachtelterFunktion(vorbereitung, 0, 1), false,
+    'ein `await` auf der Ebene der oeffnenden Funktion bestueckt den Dialog und baut nichts neu auf');
+
+  // Ein `try {` ist kein Rueckruf - sonst waere jeder try-Block eine Verschachtelung.
+  const imTry = [
+    'async function speichern() {',
+    '  try {',
+    '    await loadMeta();',
+    '  } catch (err) {}',
+    '  openModal({});',
+    '}',
+  ];
+  assert.equal(inVerschachtelterFunktion(imTry, 0, 2), false,
+    'ein try-Block oeffnet keinen Rueckruf');
 });


### PR DESCRIPTION
## Summary

The focus ratchet added in #1070 checks handlers that re-render asynchronously while their dialog is
open. A filter inside it required the `openModal({` line to appear **textually before** the
`await load…()` in the same function. That filter silenced a real false positive, but it also
excluded the most common shape in this codebase: declare the callback first, hand it to the modal
afterwards.

```js
const onChanged = async () => { await loadBudgetMeta(); renderBody(); refocusAfterRender(); };
openSharedModal({ /* ...onChanged... */ });
```

Five sites have that shape and **none of them was being checked**: `budget.js`
(`openCategoryManager`), `inventory.js` (`openLocationManager`, `openCategoryManager`),
`pantry.js` (`openLocationManager`), `shopping.js` (`openCategoryManager`).

Measured: deleting `refocusAfterRender()` from `budget.js` left both suites green
(`test:frontend-audit` 377 passing, `test:modal-utils` 45 passing). The calls are correct today, but
nothing held them there. A guard that claims protection and gives none is worse than no guard, so
this is a defect rather than missing coverage.

Found in review of #1070 after it had already merged, which is why it comes as its own PR. Item 4 of
#1083.

## The distinction

Nesting, not order. An `await` inside a nested function expression is a refresh; one at the level of
the opening function is dialog preparation, which is what `openEditMemberModal` in `admin-family.js`
does and why the filter existed in the first place. `inVerschachtelterFunktion()` separates the two
and deliberately does not treat `try {` as nesting, or every try block would count.

**Only the test changes.** The production code is untouched: the five calls are already there, they
are simply held now.

## Counterproofs

| what was done | result |
|---|---|
| delete the call in `budget.js`, keep the old order filter | 0 hits, guard blind |
| delete the call in `budget.js`, with the new nesting filter | fails, names `budget.js:2045` |
| `admin-family.js`, the original false positive | no hit, stays quiet |
| delete all five calls | guard sees them |

Plus a probe on `inVerschachtelterFunktion()` itself against a synthetic source, so the three cases
stay pinned even when no real file exhibits the shape: callback counts, preparation does not, `try`
block does not.

## Notes

- Full `npm test` green (48,688 lines, no failures).
- Branches from `4d9c3792`, the merge of #1070.
