### PR TITLE
test(push): schliesse den Listener im after()-Hook statt am Testende

### DIFF
--- a/test/test-push.js
+++ b/test/test-push.js
@@ -3,7 +3,7 @@
  * Zweck: VAPID-Auflösung, Subscribe/Unsubscribe-Routen, Versand, Scheduler.
  * Ausführen: node --experimental-sqlite test/test-push.js
  */
-import test from 'node:test';
+import test, { after } from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
 import express from 'express';
@@ -241,6 +241,19 @@ test('sendPushToUser keeps sub on transient (500) error', async () => {
   assert.equal(db.prepare('SELECT COUNT(*) c FROM push_subscriptions').get().c, 1);
 });
 
+/**
+ * Startet die Push-Routen hinter einem echten Listener und meldet die Basis-URL.
+ *
+ * Der Abbau haengt NICHT am Testende (gemessen am 09.09.2026): frueher schloss
+ * jeder Test den Server in seiner letzten Zeile. Warf eine Assertion davor, war
+ * diese Zeile unerreichbar, der Socket blieb offen - und der Prozess endete
+ * nicht mehr. Im Log stand der `✖`, das Suiten-Ende fehlte, und `npm test` hing
+ * unbegrenzt statt rot zu werden. Betroffen war jeder Test dieser Datei.
+ *
+ * Deshalb raeumt `after()` auf, wie in `test/server-ready.js` (PR #1088).
+ * Innerhalb eines `test()`-Callbacks bindet der Hook an genau diesen Test und
+ * laeuft direkt danach - auch nach einer geworfenen Assertion.
+ */
 async function startApp(db, webpush, userId = 1) {
   const app = express();
   app.use(express.json());
@@ -249,7 +262,15 @@ async function startApp(db, webpush, userId = 1) {
   const pushService = createPushService({ db, webpush });
   app.use('/', buildRouter({ pushService, database: db }));
   const server = await new Promise((r) => { const s = app.listen(0, () => r(s)); });
-  return { baseUrl: `http://127.0.0.1:${server.address().port}`, close: () => new Promise((r) => server.close(r)) };
+
+  after(async () => {
+    // Erst die Keep-Alive-Verbindungen von `fetch`: `close()` wartet sonst auf
+    // einen Socket, den niemand mehr schliesst.
+    server.closeAllConnections?.();
+    await new Promise((r) => server.close(r));
+  });
+
+  return { baseUrl: `http://127.0.0.1:${server.address().port}` };
 }
 
 test('GET /vapid-public-key returns the key', async () => {
@@ -259,7 +280,6 @@ test('GET /vapid-public-key returns the key', async () => {
   const json = await res.json();
   assert.equal(res.status, 200);
   assert.equal(json.data.key, 'PUB_GEN');
-  await app.close();
 });
 
 test('POST /subscribe inserts then upserts the subscription', async () => {
@@ -273,7 +293,6 @@ test('POST /subscribe inserts then upserts the subscription', async () => {
   const rows = db.prepare('SELECT p256dh FROM push_subscriptions WHERE endpoint = ?').all('https://push/x');
   assert.equal(rows.length, 1);
   assert.equal(rows[0].p256dh, 'PP2');
-  await app.close();
 });
 
 test('POST /subscribe rejects missing keys', async () => {
@@ -281,7 +300,6 @@ test('POST /subscribe rejects missing keys', async () => {
   const app = await startApp(db, makeWebpushMock());
   const res = await fetch(`${app.baseUrl}/subscribe`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ endpoint: 'https://push/x' }) });
   assert.equal(res.status, 400);
-  await app.close();
 });
 
 test('POST /unsubscribe removes the subscription', async () => {
@@ -291,7 +309,6 @@ test('POST /unsubscribe removes the subscription', async () => {
   const res = await fetch(`${app.baseUrl}/unsubscribe`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ endpoint: 'https://push/x' }) });
   assert.equal(res.status, 204);
   assert.equal(db.prepare('SELECT COUNT(*) c FROM push_subscriptions').get().c, 0);
-  await app.close();
 });
 
 test('POST /test forwards client-provided localized text', async () => {
@@ -305,7 +322,6 @@ test('POST /test forwards client-provided localized text', async () => {
   assert.equal(json.data.sent, 1);
   assert.equal(json.data.devices, 1);
   assert.match(webpush.calls[0].payload, /Titel/);
-  await app.close();
 });
 
 test('POST /test reports sent 0 / devices 0 when nothing is registered', async () => {
@@ -316,7 +332,6 @@ test('POST /test reports sent 0 / devices 0 when nothing is registered', async (
   assert.equal(res.status, 200);
   assert.equal(json.data.sent, 0);
   assert.equal(json.data.devices, 0);
-  await app.close();
 });
 
 test('POST /test reports sent 0 but devices 1 when the subscription is gone', async () => {
@@ -330,7 +345,6 @@ test('POST /test reports sent 0 but devices 1 when the subscription is gone', as
   // Vor dem Senden gezaehlt: der Client kann "abgelaufen" von "nie registriert" trennen.
   assert.equal(json.data.devices, 1);
   assert.equal(db.prepare('SELECT COUNT(*) c FROM push_subscriptions').get().c, 0);
-  await app.close();
 });
 
 test('POST /test only counts the current user devices', async () => {
@@ -340,7 +354,6 @@ test('POST /test only counts the current user devices', async () => {
   const res = await fetch(`${app.baseUrl}/test`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({}) });
   const json = await res.json();
   assert.equal(json.data.devices, 0);
-  await app.close();
 });
 
 function pastIso() { return new Date(Date.now() - 60_000).toISOString(); }


### PR DESCRIPTION
## Worum es geht

`test/test-push.js` startet pro Test einen echten Listener (`app.listen(0)` im Helfer
`startApp()`) und schloss ihn in der **letzten Zeile** des jeweiligen Tests
(`await app.close()`). Warf eine Assertion davor, war diese Zeile unerreichbar, der Socket
blieb offen - und der Node-Prozess endete nicht mehr. In der `npm test`-Kette hing damit der
ganze Lauf, statt rot zu werden. Betroffen war jeder Test dieser Datei, der `startApp()`
nutzt (acht Stellen), nicht nur der auffaellige.

Gemessen am 09.09.2026 mit einer absichtlich falschen Assertion im Test
`POST /test forwards client-provided localized text`, alles per `npm run test:push`:

| Stand | Ergebnis |
| --- | --- |
| alt, Assertion rot | `signal=SIGTERM` nach 45 s, `✖` im Log, **kein** Suiten-Ende |
| neu, dieselbe Assertion | `exit=1`, `pass 21 / fail 1`, nach 1,5 s von selbst beendet |
| neu, gruen | `exit=0`, `pass 22`, 2,2 s |

Die dritte Zeile allein wuerde nichts beweisen: erst der Lauf gegen den Stand **vor** dem
Umbau zeigt, dass die Gegenprobe den Fehler ueberhaupt faengt.

## Der Umbau

`startApp()` meldet den Server bei `after()` aus `node:test` an, statt sich auf einen Aufruf
am Testende zu verlassen. Vorlage ist `test/server-ready.js` aus #1088, das dasselbe Problem
fuer die drei Suiten geschlossen hat, die `server/index.js` als Programm importieren.

Innerhalb eines `test()`-Callbacks aufgerufen, bindet der Hook an genau **diesen** Test und
laeuft direkt danach - auch nach einer geworfenen Assertion (nachgemessen). Es stehen also
nie acht Listener gleichzeitig offen, es wird pro Test aufgeraeumt.

`server.closeAllConnections?.()` kommt vor `close()`, weil `fetch` Keep-Alive-Verbindungen
haelt und `close()` sonst auf einen Socket wartet, den niemand mehr schliesst - dieselbe
Reihenfolge wie in `server-ready.js`.

Die `close`-Eigenschaft faellt aus dem Rueckgabeobjekt weg. Bliebe sie stehen, waere der
Fallstrick weiter benutzbar, und ein zweiter `close()`-Aufruf traefe einen bereits
geschlossenen Server.

## Was NICHT drin ist

Der betroffene Test ist unter Parallellast sporadisch rot (isoliert acht Mal gruen, auch
unter CPU-Last). Diese Flakiness war der Ausloeser, nicht die Ursache des Haengers, und
bleibt offen - hier geht es nur um den Handle-Leak.

Die uebrigen Suiten mit `app.listen(0)` habe ich durchgesehen: sie schliessen im
`try { ... } finally { ... }` (z.B. `test-budget-routes-scope.js`) oder auf Top-Level, also
ohne Leck bei geworfener Assertion. `test-push.js` war die einzige Stelle mit "close in der
letzten Testzeile".

## Verifikation

- `npm run test:push`: gruen `exit=0`, rot (manipuliert) `exit=1`, beide Male endet der
  Prozess von selbst.
- Volle Kette `npm test` gruen: 267 Suiten-Enden, keine `fail`-Zeile ungleich 0, keine
  `✖`-Zeile.
