### PR TITLE
fix(tasks): die Personenauswahl im Verlauf behaelt auf dem Telefon ihren Namen (#1068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The person filter in the task history is no longer a row of blank buttons on a phone** (#1068).
+  Below 640px the label-loss rule removes every `.group-toggle__label`; it is built on the
+  assumption that an icon stays behind, which is true for the view switcher next to it. These chips
+  had none, so nothing remained but the tinted surface of the active one. The loss was not only
+  visual: `display: none` takes the text out of the accessibility tree as well, so the buttons were
+  just as nameless to a screen reader. Each chip now carries what the rest of the module already
+  uses to identify a person - their avatar, the same disc the history rows below it show - and
+  "All" gets an icon from the same family as the switchers. The name itself moved onto the button
+  as `aria-label`, where no media query can take it away.
+
 - **A recurring event synced from Google no longer shows an end time hours after its start**
   (#1089). Every occurrence of a series is generated from the master, and its end was derived by
   adding the duration to the new start. Which format that end was written in depended on a test

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -2207,11 +2207,26 @@ function renderHistoryPeople() {
       <span class="group-toggle__label">${esc(label)}</span>
     </button>`;
   };
-  // Die Marke ist Schmuck fuer die Vorlesehilfe: den Namen traegt der Knopf.
-  // Ohne `aria-hidden` kaeme er zweimal - einmal als `aria-label`, einmal aus
-  // dem `alt` des Avatarbildes.
+  /* Die Marke ist Schmuck fuer die Vorlesehilfe: den Namen traegt der Knopf.
+   * Ohne `aria-hidden` kaeme er zweimal - einmal als `aria-label`, einmal aus
+   * dem `alt` des Avatarbildes.
+   *
+   * ZWEI RENDERER, ZWEI FELDNAMEN FUER DIESELBE FARBE. `state.users` kommt aus
+   * `/tasks/meta/options` und heisst dort `avatar_color`, so wie es in der
+   * Tabelle steht; `renderAvatarStack` liest `color`, weil es sonst aus
+   * `ASSIGNED_USERS_SQL` gefuettert wird, das genau dafuer umbenennt
+   * (`'color', u.avatar_color`). Beide Seiten sind fuer sich richtig - wer sie
+   * ungefiltert zusammensteckt, bekommt lautlos die Fallback-Farbe fuer JEDEN,
+   * und damit sind zwei Mitglieder mit gleichen Initialen auf dem Telefon nicht
+   * mehr zu unterscheiden. Deshalb hier die Uebersetzung.
+   *
+   * Ein Foto traegt `/meta/options` nicht, also bleiben es Initialen auf der
+   * Nutzerfarbe. Das ist kein Verlust gegenueber dem Nachbarn: `renderUserMulti
+   * Select` wird aus derselben Liste bedient und zeigt aus demselben Grund
+   * ebenfalls keins. Die Farbe ist ohnehin das Identitaetssignal (User-Farben-
+   * Regel), das Bild die Zugabe. */
   const personMark = (u) => `<span class="history-people__mark" aria-hidden="true">${
-    renderAvatarStack([u], { size: 22, maxVisible: 1 })}</span>`;
+    renderAvatarStack([{ ...u, color: u.avatar_color }], { size: 22, maxVisible: 1 })}</span>`;
   // Nur wer wirklich etwas beisteuern kann: die Housekeeping-Konten sind aus
   // /meta/options schon heraus, und ein Haushalt aus einer Person braucht die
   // Auswahl gar nicht.

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -2175,23 +2175,52 @@ function renderHistoryEntry(entry) {
     </button>`;
 }
 
-/** Die Personenauswahl - „Alle" plus je ein Mitglied. */
+/** Die Personenauswahl - „Alle" plus je ein Mitglied.
+ *
+ * JEDER CHIP BRAUCHT ETWAS, DAS BLEIBT, WENN SEIN LABEL FAELLT (#1068).
+ *
+ * Unter 640px entfernt die Label-Verlust-Regel (tasks.css) jedes
+ * `.group-toggle__label`. Sie ist dafuer gebaut, dass ein Icon zurueckbleibt -
+ * beim Ansichts-Umschalter daneben steht es schon immer neben dem Text. Diese
+ * Chips hatten keins, also blieb der Knopf LEER: eine Reihe namenloser Flaechen,
+ * bei der nur die getoente Flaeche verriet, welche gerade gewaehlt ist.
+ *
+ * Und der Verlust war nicht nur ein sichtbarer. `display: none` nimmt den Text
+ * auch aus dem Accessibility-Tree; ohne eigenen Namen am Knopf war der Filter
+ * auf dem Telefon fuer eine Vorlesehilfe ebenso namenlos wie fuers Auge. Der
+ * Name gehoert deshalb an den KNOPF (`aria-label`), nicht in ein Kind, das eine
+ * Media-Query wegnehmen darf.
+ *
+ * Was bleibt: fuer die Mitglieder ihr Avatar - dieselbe Scheibe, die die
+ * Verlaufszeilen darunter schon tragen, also kein neues Zeichen, sondern ein
+ * bekanntes. `renderAvatarStack` bringt Bild oder Initialen samt
+ * Kontrastrechnung mit; sie hier ein zweites Mal zu bauen war schon einmal
+ * falsch (siehe renderHistoryEntry). Fuer „Alle" ein Icon aus derselben
+ * Familie wie die Umschalter daneben. */
 function renderHistoryPeople() {
-  const chip = (id, label) => {
+  const chip = (id, label, mark) => {
     const on = state.history.userId === id;
     return `<button type="button" class="group-toggle__btn${on ? ' group-toggle__btn--active' : ''}"
-            data-history-user="${id === null ? '' : id}" aria-pressed="${on}">
+            data-history-user="${id === null ? '' : id}" aria-pressed="${on}"
+            title="${esc(label)}" aria-label="${esc(label)}">
+      ${mark}
       <span class="group-toggle__label">${esc(label)}</span>
     </button>`;
   };
+  // Die Marke ist Schmuck fuer die Vorlesehilfe: den Namen traegt der Knopf.
+  // Ohne `aria-hidden` kaeme er zweimal - einmal als `aria-label`, einmal aus
+  // dem `alt` des Avatarbildes.
+  const personMark = (u) => `<span class="history-people__mark" aria-hidden="true">${
+    renderAvatarStack([u], { size: 22, maxVisible: 1 })}</span>`;
   // Nur wer wirklich etwas beisteuern kann: die Housekeeping-Konten sind aus
   // /meta/options schon heraus, und ein Haushalt aus einer Person braucht die
   // Auswahl gar nicht.
   if (isSoloHousehold()) return '';
   return `
     <div class="group-toggle history-people" role="group" aria-label="${t('tasks.historyPersonFilter')}">
-      ${chip(null, t('common.all'))}
-      ${state.users.map((u) => chip(u.id, u.display_name)).join('')}
+      ${chip(null, t('common.all'),
+        '<i data-lucide="users" class="icon-md group-toggle__icon" aria-hidden="true"></i>')}
+      ${state.users.map((u) => chip(u.id, u.display_name, personMark(u))).join('')}
     </div>`;
 }
 

--- a/public/styles/tasks.css
+++ b/public/styles/tasks.css
@@ -1855,6 +1855,18 @@
   overflow-x: auto;
 }
 
+/* Die Marke, die bleibt, wenn das Label faellt (#1068).
+ *
+ * Sie darf nicht schrumpfen: die Reihe scrollt (`overflow-x` darueber), und in
+ * einer scrollenden Flex-Zeile gibt ein Kind mit Standard-`flex-shrink` unter
+ * Druck zuerst seine Breite her - dann stuende bei vielen Mitgliedern statt der
+ * Scheibe ein Strich. Die Groesse selbst bringt der Avatar inline mit
+ * (`renderAvatarStack`), hier steht nur, dass sie ihm bleibt. */
+.history-people__mark {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
 /* „Mehr anzeigen" schliesst die Liste ab, mittig unter ihr. */
 .history-more {
   display: flex;

--- a/public/styles/tasks.css
+++ b/public/styles/tasks.css
@@ -1855,12 +1855,29 @@
   overflow-x: auto;
 }
 
-/* Die Marke, die bleibt, wenn das Label faellt (#1068).
+/* WER IN EINER SCROLLENDEN REIHE STEHT, MUSS SICH SELBST GEGEN DAS SCHRUMPFEN
+ * WEHREN - UND ZWAR ALS DIREKTES KIND (#1068).
  *
- * Sie darf nicht schrumpfen: die Reihe scrollt (`overflow-x` darueber), und in
- * einer scrollenden Flex-Zeile gibt ein Kind mit Standard-`flex-shrink` unter
- * Druck zuerst seine Breite her - dann stuende bei vielen Mitgliedern statt der
- * Scheibe ein Strich. Die Groesse selbst bringt der Avatar inline mit
+ * `overflow-x: auto` an der Reihe greift erst, wenn die Flex-Items nicht mehr
+ * nachgeben. Solange sie duerfen, schrumpfen sie ZUERST und die Reihe scrollt
+ * gar nicht: gemessen bei 375px mit neun Mitgliedern fiel der schmalste Chip auf
+ * 40px - unter die Zielgroesse, die dieser Chip als Traeger des Label-Verlusts
+ * gerade zusichern soll. Mit der Regel bleiben alle neun bei 48px und die Reihe
+ * scrollt. Dasselbe Muster steht in dieser Datei schon einmal, an der
+ * Filterzeile: `.tasks-filters-row .tasks-filters > * { flex-shrink: 0 }`.
+ *
+ * Das Flex-Item ist der KNOPF. `.history-people__mark` liegt eine Ebene tiefer
+ * und ist fuer die Reihe unsichtbar - eine Regel dort haette diesen Schutz nie
+ * geleistet, so plausibel sie sich auch liest. */
+.history-people .group-toggle__btn {
+  flex-shrink: 0;
+}
+
+/* Die Marke, die bleibt, wenn das Label faellt.
+ *
+ * Ihr eigenes `flex-shrink: 0` gilt IM KNOPF, nicht in der Reihe: der Knopf ist
+ * selbst eine Flexbox, und ein langes Label neben der Scheibe wuerde sie sonst
+ * zusammendruecken. Die Groesse bringt der Avatar inline mit
  * (`renderAvatarStack`), hier steht nur, dass sie ihm bleibt. */
 .history-people__mark {
   display: inline-flex;

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -11444,6 +11444,58 @@ test('wer sein Label verliert, bleibt ein volles Ziel', () => {
 });
 
 /**
+ * DIE ANDERE HAELFTE DER LABEL-VERLUST-REGEL: WER SEIN LABEL VERLIEREN KANN,
+ * TRAEGT SEINEN NAMEN AM KNOPF (#1068).
+ *
+ * Der Guard darueber prueft, was ein Element beim Label-Verlust an GROESSE
+ * behaelt. Was es an NAMEN behaelt, stand nirgends - und genau das ging
+ * verloren: die Personenauswahl im Aufgaben-Verlauf bestand nur aus
+ * `<span class="group-toggle__label">Name</span>`, und unter 640px nimmt die
+ * Regel dieses Kind weg. Auf dem Telefon stand dort eine Reihe leerer Flaechen.
+ *
+ * `display: none` nimmt den Text auch aus dem Accessibility-Tree. Der Knopf war
+ * also nicht nur fuers Auge namenlos, sondern ebenso fuer eine Vorlesehilfe -
+ * der Verlust sah nach einem reinen Anzeigefehler aus und war keiner.
+ *
+ * Deshalb die Zusage: der Name gehoert an den TRAEGER, nicht in ein Kind, das
+ * eine Media-Query entfernen darf. Geprueft wird `.group-toggle__btn`, weil
+ * genau dessen Label die beiden Regeln in tasks.css ausblenden. Der Guard bleibt
+ * bewusst bei dieser einen Familie statt jedes `__label` im Haus zu verfolgen:
+ * dafuer muesste er CSS und Markup verbinden und raet, sobald eine Klasse
+ * dynamisch zusammengesetzt wird. Eine enge Zusage, die haelt, ist mehr wert als
+ * eine weite, die auf Vermutungen steht.
+ */
+test('ein Umschalt-Knopf traegt seinen Namen selbst, nicht in einem Kind', () => {
+  const dateien = [];
+  const sammle = (verzeichnis) => {
+    for (const eintrag of readdirSync(verzeichnis, { withFileTypes: true })) {
+      const pfad = new URL(`${eintrag.name}${eintrag.isDirectory() ? '/' : ''}`, verzeichnis);
+      if (eintrag.isDirectory()) {
+        if (eintrag.name === 'vendor') continue;
+        sammle(pfad);
+      } else if (/\.(?:js|html)$/.test(eintrag.name)) {
+        dateien.push(pfad);
+      }
+    }
+  };
+  sammle(new URL('../public/', import.meta.url));
+
+  const namenlos = [];
+  for (const datei of dateien) {
+    const quelle = readFileSync(datei, 'utf8');
+    for (const treffer of quelle.matchAll(/<button\b[^>]*group-toggle__btn[^>]*>/g)) {
+      const tag = treffer[0];
+      if (/aria-label(?:ledby)?[=\s]/.test(tag)) continue;
+      const zeile = quelle.slice(0, treffer.index).split('\n').length;
+      namenlos.push(`${datei.pathname.split('/public/')[1]}:${zeile}`);
+    }
+  }
+
+  assert.deepEqual(namenlos, [],
+    `Umschalt-Knopf ohne eigenen Namen - unter 640px faellt sein Label und mit ihm die Beschriftung: ${namenlos.join(', ')}`);
+});
+
+/**
  * REGEL (Redesign Runde 6, Phase 3c): Die Groesse des Icon-Knopfs gehoert der
  * SHELL, und sie schaltet nach der ZEIGERFAEHIGKEIT.
  *


### PR DESCRIPTION
Behebt #1068: auf dem Telefon war die Personenauswahl im Aufgaben-Verlauf eine Reihe leerer Flächen.

## Ursache

Unter 640px entfernt die Label-Verlust-Regel (`tasks.css`) jedes `.group-toggle__label`. Sie ist ausdrücklich dafür gebaut, dass **ein Icon zurückbleibt** - beim Ansichts-Umschalter direkt daneben steht es schon immer neben dem Text, dort stimmt die Annahme. Die Personen-Chips bestanden nur aus

```html
<button class="group-toggle__btn"><span class="group-toggle__label">Name</span></button>
```

also nahm die Regel ihren gesamten Inhalt weg. Übrig blieb die getönte Fläche des aktiven Chips - genau das Bild im Issue.

**Der Verlust war nicht nur ein sichtbarer.** `display: none` nimmt den Text auch aus dem Accessibility-Tree. Ohne eigenen Namen am Knopf war der Filter für eine Vorlesehilfe ebenso namenlos wie fürs Auge; es sah nach einem reinen Anzeigefehler aus und war keiner.

## Fix

- **Jeder Chip bekommt etwas, das bleibt.** Für die Mitglieder ihren Avatar - dieselbe Scheibe, die die Verlaufszeilen darunter schon tragen, also kein neues Zeichen, sondern ein bekanntes. `renderAvatarStack` bringt Bild oder Initialen samt Kontrastrechnung mit; sie hier ein zweites Mal zu bauen war schon einmal falsch (steht so im Kommentar an `renderHistoryEntry`). Für „Alle" ein Icon aus der Familie der Umschalter daneben.
- **Der Name wandert an den Träger** (`aria-label` am Knopf), wo keine Media-Query ihn wegnehmen kann. Der Avatar ist `aria-hidden`, sonst käme der Name zweimal.
- `.history-people__mark` bekommt `flex-shrink: 0`: die Reihe scrollt, und in einer scrollenden Flex-Zeile gäbe ein Kind mit Standard-Shrink unter Druck zuerst seine Breite her.

## Guard

Der bestehende Guard zur Label-Verlust-Regel prüft, was ein Element beim Label-Verlust an **Größe** behält. Was es an **Namen** behält, stand nirgends. Neu in `test-frontend-audit.js`: ein `.group-toggle__btn` trägt seinen Namen selbst.

Gemessen: auf `main` fällt er mit **genau einer** Fundstelle (`pages/tasks.js:2182`) - dieser hier; alle anderen fünf Knöpfe der Familie hatten ihr `aria-label` schon. Gegenprobe per Backup-Kopie gefahren: Name entfernt → rot mit Fundstelle, Name zurück → 380/380 grün.

Der Guard bleibt bewusst bei dieser einen Familie, statt jedes `__label` im Haus zu verfolgen: dafür müsste er CSS und Markup verbinden und rät, sobald eine Klasse dynamisch zusammengesetzt wird.

## Im Browser gemessen

Demo-Seed, 375x812, Verlaufsansicht:

| Chip | Name (a11y) | Label | Marke | Ziel |
|---|---|---|---|---|
| Alle | „Alle" | `none` | `<svg>` (hydriert) | 48x48 |
| Alex Johnson | „Alex Johnson" | `none` | 22px „AJ" | 48x48 |
| Emma Johnson | „Emma Johnson" | `none` | 22px „EJ" | 48x48 |
| Leo Johnson | „Leo Johnson" | `none` | 22px „LJ" | 48x48 |
| Linda Johnson | „Linda Johnson" | `none` | 22px „LJ" | 48x48 |

Bei 1280px stehen die Labels wieder vollständig, die Reihe scrollt nicht.

Keine neuen i18n-Keys: `t('common.all')` und `display_name` gab es bereits.

Volle Kette: **298 Suiten, 0 Fehlschläge.**
