### PR TITLE
fix(tasks): encode a saved filter's axes instead of joining them

### DIFF
--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -2900,8 +2900,31 @@ function getRecentFilters() {
  * Achse dazukommt - und dann still.
  */
 function recentFilterKey(f) {
-  const axis = (values) => [...values].map((v) => String(v).toLowerCase()).sort().join(',');
-  return [f.status, f.priority, f.assigned_to, f.category, f.tags].map(axis).join('|');
+  // STRUKTURELL KODIERT, NICHT MIT TRENNZEICHEN VERKETTET.
+  //
+  // Hier stand `join(',')` INNERHALB einer Achse, und das Komma darf in einem
+  // Wert vorkommen: `normalizeTags` splittet nur eine STRING-Eingabe an
+  // Kommas, ein Array-Element behaelt seines (`normalizeTags(['a,b'])` ->
+  // `['a,b']`), und die Route nimmt Arrays. Damit ergaben der eine Tag `a,b`
+  // und die zwei Tags `a` und `b` denselben Schluessel: `getRecentFilters`
+  // verbarg den einen Chip als Dublette, und `saveRecentFilter` verdraengte
+  // beim Speichern den jeweils anderen.
+  //
+  // Das `join('|')` DARUEBER war dagegen in Ordnung, auch wenn ein Tag ein
+  // `|` tragen darf: die Achsenzahl ist fest, also bleibt jede Position
+  // eindeutig. Eine Probe dafuer stand hier kurz und wurde wieder entfernt -
+  // sie blieb gruen, wenn man den alten Trenner zuruecknahm, und maass damit
+  // nichts. Ersetzt wird er trotzdem mit, weil eine Formel mit zwei Regeln
+  // schwerer zu halten ist als eine ohne.
+  //
+  // Der Server hat dieselbe Frage schon beantwortet und begruendet
+  // (`tagsKey` in server/utils/task-tags.js trennt mit U+0000, "weil ein Tag
+  // Leerzeichen enthalten darf"). JSON braucht die Frage gar nicht erst zu
+  // stellen: es kodiert die Achsen als Struktur, also kann kein Wert seinen
+  // eigenen Trenner tragen. Der Schluessel wird bei jedem Aufruf neu gerechnet
+  // und nirgends gespeichert - die geaenderte Form braucht keine Migration.
+  const axis = (values) => [...values].map((v) => String(v).toLowerCase()).sort();
+  return JSON.stringify([f.status, f.priority, f.assigned_to, f.category, f.tags].map(axis));
 }
 
 function saveRecentFilter(filters) {

--- a/test/test-task-filters.js
+++ b/test/test-task-filters.js
@@ -214,3 +214,38 @@ test('eine stale Achse beschneidet nicht, die frischen schon', () => {
   assert.deepEqual(set.tags, [], 'die frische Tag-Liste beschneidet');
   assert.deepEqual(set.assigned_to, [], 'die frische Mitgliederliste ebenso');
 });
+
+test('ein Tag mit Komma kollidiert nicht mit zwei Tags', () => {
+  // Codex-Befund P2 zu PR #1072, am Code nachgemessen: `normalizeTags`
+  // splittet nur eine STRING-Eingabe an Kommas, ein Array-Element behaelt
+  // seines (`normalizeTags(['a,b'])` -> `['a,b']`), und die Route nimmt
+  // Arrays. Der Schluessel verband die Achse aber mit `,` - der eine Tag
+  // `a,b` und die zwei Tags `a` und `b` ergaben denselben.
+  //
+  // Zwei Schaeden aus einer Ursache, und beide werden hier gemessen: die
+  // Ansicht verbarg den einen Chip als Dublette, und `saveRecentFilter`
+  // verdraengte beim Speichern den jeweils anderen.
+  withKnown({ tags: ['a,b', 'a', 'b'] });
+  put({ tags: ['a,b'] }, { tags: ['a', 'b'] });
+
+  assert.equal(tasks.getRecentFilters().length, 2,
+    'zwei verschiedene Filter, zwei Chips');
+
+  // Und die Speicherseite: das eine Set darf das andere nicht verdraengen.
+  store.clear();
+  tasks.saveRecentFilter({ ...emptySet, tags: ['a,b'] });
+  tasks.saveRecentFilter({ ...emptySet, tags: ['a', 'b'] });
+  assert.equal(raw().length, 2, 'beide Sets stehen im Speicher');
+});
+
+test('derselbe Filter verdraengt sich weiterhin selbst', () => {
+  // Die Gegenrichtung, ohne die der Fix nur "alles ist verschieden" hiesse:
+  // dieselben Werte in anderer Reihenfolge und Schreibweise bleiben EIN Set.
+  withKnown({ tags: ['garten', 'urlaub'] });
+  store.clear();
+  tasks.saveRecentFilter({ ...emptySet, tags: ['garten', 'urlaub'] });
+  tasks.saveRecentFilter({ ...emptySet, tags: ['Urlaub', 'Garten'] });
+
+  assert.equal(raw().length, 1, 'Reihenfolge und Schreibweise machen kein neues Set');
+  assert.equal(tasks.getRecentFilters().length, 1);
+});


### PR DESCRIPTION
Der letzte offene Codex-Befund aus dem #1072-Faden, am Code nachgemessen. Die anderen sieben Threads dort sind durch die Commits vom 09.09. abgedeckt (15:13/15:23 der Buchfuehrungs-Umbau, 15:33 der `metaStale`-Split, 15:54 der P1 zum gecachten Listenwechsel) und nur nie aufgeloest worden - dieser hier stand wirklich noch.

## Der Befund

`recentFilterKey` verband die Werte einer Achse mit `,`:

```js
const axis = (values) => [...values].map((v) => String(v).toLowerCase()).sort().join(',');
```

Das Komma darf aber in einem Tag stehen. `normalizeTags` splittet nur eine **String**-Eingabe an Kommas; ein Array-Element behaelt seines, und die Route nimmt Arrays:

```
normalizeTags(['a,b'])   -> ['a,b']
normalizeTags(['a','b']) -> ['a','b']
```

Der Server unterscheidet die beiden auch korrekt - `tagsKey` trennt mit `U+0000` und begruendet das ausdruecklich damit, dass ein Tag Trennzeichen tragen darf. Nur das Frontend tat es nicht:

| | `['a,b']` | `['a','b']` | |
|---|---|---|---|
| Server `tagsKey` | `a,b` | `a<NUL>b` | verschieden |
| Frontend `axis` | `a,b` | `a,b` | **gleich** |

Zwei Folgen aus einer Ursache, beide in der neuen Probe gemessen: `getRecentFilters` verbarg den einen Chip als vermeintliche Dublette, und `saveRecentFilter` verdraengte beim Speichern den jeweils anderen.

## Die Loesung

Strukturell kodiert (`JSON.stringify` ueber die Achsen-Arrays), damit die Frage nach einem sicheren Trennzeichen gar nicht erst gestellt werden muss. Der Schluessel wird bei jedem Aufruf neu gerechnet und nirgends gespeichert - die geaenderte Form braucht keine Migration.

## Was NICHT kaputt war

Das `join('|')` **zwischen** den Achsen. Ein Tag darf auch ein `|` tragen, aber die Achsenzahl ist fest, also bleibt jede Position eindeutig. Eine Probe dafuer stand hier kurz und ist wieder draussen: sie blieb gruen, wenn man den alten Trenner zurueckgab, und maass damit nichts. Ersetzt wird er trotzdem mit, weil eine Formel mit zwei Regeln schwerer zu halten ist als eine ohne.

## Gegenprobe

| Zurueckgedreht | Rot |
|---|---|
| nur der Achsen-Trenner (`join(',')`) | `ein Tag mit Komma kollidiert nicht mit zwei Tags` |
| die ganze alte Formel (`join(',')` + `join('|')`) | dieselbe |

Dazu die Gegenrichtung, damit der Fix nicht "alles ist verschieden" heisst: `derselbe Filter verdraengt sich weiterhin selbst` - dieselben Werte in anderer Reihenfolge und Schreibweise bleiben EIN Set.

Kein CHANGELOG-Eintrag: die Funktion ist unveroeffentlicht (#1072 steht unter `Unreleased`), der Fehler war also nie zu erleben.

Volle Kette gruen.
