### PR TITLE
test(infra): hand the OS a file path, not a URL pathname

### DIFF
--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { SETTINGS_DOMAINS, SETTINGS_LEAVES } from '../public/settings/registry.js';
 import { eachRule } from './css-rules.js';
 import { withoutHtmlComments, withoutBlockComments, withoutCommentsKeepingLines } from './source-text.js';
@@ -1118,7 +1119,7 @@ test('jede JS-Datei unter public/ ist syntaktisch gueltiges ESM', () => {
     try {
       // `node --check` liest den Modultyp aus package.json ("type": "module"),
       // parst also als ESM - `import`/`export` auf oberster Ebene sind erlaubt.
-      execFileSync(process.execPath, ['--check', new URL(file, import.meta.url).pathname], { stdio: 'pipe' });
+      execFileSync(process.execPath, ['--check', fileURLToPath(new URL(file, import.meta.url))], { stdio: 'pipe' });
     } catch (err) {
       const detail = String(err.stderr || err.message).split('\n').find((l) => /SyntaxError/.test(l)) || String(err.message).slice(0, 120);
       offenders.push(`${file.replace('../public/', '')}: ${detail.trim()}`);


### PR DESCRIPTION
No issue; found while running the suites on Windows 11.

## Root cause

Two suites turn a file URL into a path with `.pathname`. On Windows that is `/C:/Users/...`, which the OS resolves against the current drive as `C:\C:\Users\...`. The ESM syntax guard in `test/test-frontend-audit.js` passed it to `node --check` and listed all 179 files under `public/` as offenders; in `test/test-caldav-object-urls.js` the three cases that read `server/` failed with ENOENT (18 of 21 still passed, which is why it was easy to miss).

`.pathname` is also percent-encoded, so a checkout under a directory with a space or an umlaut would fail the same way on Linux and macOS. On Linux with an ASCII checkout path `.pathname` and `fileURLToPath` return the same string, so CI (ubuntu-only) never saw this.

## Fix

- `test/test-frontend-audit.js`: pass `fileURLToPath(new URL(file, import.meta.url))` to `node --check`.
- `test/test-caldav-object-urls.js`: build `SERVER_DIR` with `fileURLToPath` instead of `.pathname`.

`fileURLToPath` decodes and returns the native path on every platform; the other suites that need a native path already use it (28 files in `test/`). The guard's offender reporting is untouched: only the argument changed, and a real `SyntaxError` on stderr is still picked up by the existing filter. Nothing changes on Linux.

## Tests

Windows 11, Node 24.16: `npm run test:frontend-audit` 380/380, `npm run test:caldav-object-urls` 21/21. Counter-proved by running the same two suites on `main`: 179 offenders and 3 ENOENT failures.

AI-assisted: Claude Code helped draft and review this; the change and the test runs are mine.
