### PR TITLE
fix(settings): Module options description no longer omits half its sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Module options settings page describes what it actually contains.** Its description named
+  only Budget, Health and Housekeeping - accurate when it was written, but Tasks and Schedule have
+  since grown their own sections on the same page without the sentence ever being updated. Reworded
+  to describe the page's purpose instead of enumerating its sections, so it can't go stale the same
+  way again the next time a module gains a section here.
+
 - **The person filter in the task history is no longer a row of blank buttons on a phone** (#1068).
   Below 640px the label-loss rule removes every `.group-toggle__label`; it is built on the
   assumption that an icon stays behind, which is true for the view switcher next to it. These chips

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "المطبخ",
         "pageKitchenDescription": "اختر الوجبات الظاهرة في خطة الوجبات.",
         "pageModuleOptions": "خيارات الوحدات",
-        "pageModuleOptionsDescription": "ضبط خيارات مفردة للميزانية والصحة والمساعدة المنزلية.",
+        "pageModuleOptionsDescription": "خيارات إضافية لبعض الوحدات.",
         "pageCalendarModule": "التقويم",
         "pageCalendarModuleDescription": "حدد العطلات وبداية الأسبوع والمدة الافتراضية للموعد.",
         "pageSyncCalendar": "مزامنة التقويم",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Kuchyně",
         "pageKitchenDescription": "Vyberte, která jídla se zobrazí v jídelníčku.",
         "pageModuleOptions": "Volby modulů",
-        "pageModuleOptionsDescription": "Nastavit jednotlivé volby pro Rozpočet, Zdraví a Pomoc v domácnosti.",
+        "pageModuleOptionsDescription": "Doplňkové možnosti pro několik modulů.",
         "pageCalendarModule": "Kalendář",
         "pageCalendarModuleDescription": "Nastavte svátky, začátek týdne a výchozí trvání události.",
         "pageSyncCalendar": "Synchronizace kalendáře",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -2297,7 +2297,7 @@
         "pageKitchen": "Küche",
         "pageKitchenDescription": "Sichtbare Mahlzeiten im Essensplan auswählen.",
         "pageModuleOptions": "Modul-Optionen",
-        "pageModuleOptionsDescription": "Einzelne Optionen für Budget, Gesundheit und Haushaltshilfe festlegen.",
+        "pageModuleOptionsDescription": "Zusätzliche Optionen für einzelne Module.",
         "pageCalendarModule": "Kalender",
         "pageCalendarModuleDescription": "Feiertage, Wochenstart und Standard-Termindauer festlegen.",
         "pageSyncCalendar": "Kalender-Synchronisation",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Κουζίνα",
         "pageKitchenDescription": "Επιλέξτε ποια γεύματα εμφανίζονται στο πρόγραμμα γευμάτων.",
         "pageModuleOptions": "Επιλογές ενοτήτων",
-        "pageModuleOptionsDescription": "Ορισμός μεμονωμένων επιλογών για Προϋπολογισμό, Υγεία και Οικιακή βοήθεια.",
+        "pageModuleOptionsDescription": "Πρόσθετες επιλογές για μερικά modules.",
         "pageCalendarModule": "Ημερολόγιο",
         "pageCalendarModuleDescription": "Ορίστε αργίες, έναρξη εβδομάδας και προεπιλεγμένη διάρκεια συμβάντος.",
         "pageSyncCalendar": "Συγχρονισμός ημερολογίου",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Κουζίνα",
         "pageKitchenDescription": "Επιλέξτε ποια γεύματα εμφανίζονται στο πρόγραμμα γευμάτων.",
         "pageModuleOptions": "Επιλογές ενοτήτων",
-        "pageModuleOptionsDescription": "Πρόσθετες επιλογές για μερικά modules.",
+        "pageModuleOptionsDescription": "Πρόσθετες επιλογές για ορισμένες ενότητες.",
         "pageCalendarModule": "Ημερολόγιο",
         "pageCalendarModuleDescription": "Ορίστε αργίες, έναρξη εβδομάδας και προεπιλεγμένη διάρκεια συμβάντος.",
         "pageSyncCalendar": "Συγχρονισμός ημερολογίου",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2285,7 +2285,7 @@
         "pageKitchen": "Kitchen",
         "pageKitchenDescription": "Choose which meals are visible in the meal planner.",
         "pageModuleOptions": "Module options",
-        "pageModuleOptionsDescription": "Set individual options for Budget, Health and Housekeeping.",
+        "pageModuleOptionsDescription": "Extra options for a few modules.",
         "pageCalendarModule": "Calendar",
         "pageCalendarModuleDescription": "Set holidays, week start, and the default event duration.",
         "pageSyncCalendar": "Calendar sync",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Cocina",
         "pageKitchenDescription": "Elige qué comidas se ven en el plan de comidas.",
         "pageModuleOptions": "Opciones de módulos",
-        "pageModuleOptionsDescription": "Definir opciones concretas de Presupuesto, Salud y Ayuda doméstica.",
+        "pageModuleOptionsDescription": "Opciones adicionales para algunos módulos.",
         "pageCalendarModule": "Calendario",
         "pageCalendarModuleDescription": "Define festivos, inicio de semana y la duración predeterminada del evento.",
         "pageSyncCalendar": "Sincronización de calendarios",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -2274,7 +2274,7 @@
         "pageKitchen": "آشپزخانه",
         "pageKitchenDescription": "انتخاب کنید کدام وعده‌ها در برنامه غذایی نمایش داده شوند.",
         "pageModuleOptions": "گزینه‌های ماژول‌ها",
-        "pageModuleOptionsDescription": "تنظیم گزینه‌های تکی برای بودجه، سلامت و کمک خانه.",
+        "pageModuleOptionsDescription": "گزینه‌های اضافی برای چند ماژول.",
         "pageCalendarModule": "تقویم",
         "pageCalendarModuleDescription": "تعطیلات، آغاز هفته و مدت پیش‌فرض رویداد را تعیین کنید.",
         "pageSyncCalendar": "همگام‌سازی تقویم",

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -2297,7 +2297,7 @@
         "pageKitchen": "Kusina",
         "pageKitchenDescription": "Piliin kung aling mga pagkain ang nakikita sa tagaplano ng pagkain.",
         "pageModuleOptions": "Mga opsyon ng modyul",
-        "pageModuleOptionsDescription": "Magtakda ng indibidwal na opsyon para sa Badyet, Kalusugan at Gawaing-bahay.",
+        "pageModuleOptionsDescription": "Karagdagang opsyon para sa ilang module.",
         "pageCalendarModule": "Kalendaryo",
         "pageCalendarModuleDescription": "Itakda ang mga pista, simula ng linggo at ang default na tagal ng kaganapan.",
         "pageSyncCalendar": "Pag-sync ng kalendaryo",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Cuisine",
         "pageKitchenDescription": "Choisir les repas visibles dans le planificateur de repas.",
         "pageModuleOptions": "Options des modules",
-        "pageModuleOptionsDescription": "Définir des options ponctuelles pour Budget, Santé et Aide ménagère.",
+        "pageModuleOptionsDescription": "Options supplémentaires pour quelques modules.",
         "pageCalendarModule": "Calendrier",
         "pageCalendarModuleDescription": "Définissez les jours fériés, le début de semaine et la durée par défaut d’un événement.",
         "pageSyncCalendar": "Synchronisation des calendriers",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "रसोई",
         "pageKitchenDescription": "चुनें कि भोजन योजना में कौन-से भोजन दिखें।",
         "pageModuleOptions": "मॉड्यूल विकल्प",
-        "pageModuleOptionsDescription": "बजट, स्वास्थ्य और घरेलू सहायता के लिए अलग-अलग विकल्प तय करें।",
+        "pageModuleOptionsDescription": "कुछ मॉड्यूल के लिए अतिरिक्त विकल्प।",
         "pageCalendarModule": "कैलेंडर",
         "pageCalendarModuleDescription": "छुट्टियाँ, सप्ताह की शुरुआत और डिफ़ॉल्ट ईवेंट अवधि तय करें।",
         "pageSyncCalendar": "कैलेंडर सिंक",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Konyha",
         "pageKitchenDescription": "Válassza ki, mely étkezések láthatók az étrendben.",
         "pageModuleOptions": "Modulbeállítások",
-        "pageModuleOptionsDescription": "Egyedi beállítások megadása a Költségvetéshez, Egészséghez és Háztartási segítséghez.",
+        "pageModuleOptionsDescription": "Kiegészítő beállítások néhány modulhoz.",
         "pageCalendarModule": "Naptár",
         "pageCalendarModuleDescription": "Állítsa be az ünnepnapokat, a hét kezdetét és az alapértelmezett esemény-időtartamot.",
         "pageSyncCalendar": "Naptár szinkronizálás",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -2274,7 +2274,7 @@
         "pageKitchen": "Dapur",
         "pageKitchenDescription": "Pilih makanan mana yang tampil di rencana makan.",
         "pageModuleOptions": "Opsi modul",
-        "pageModuleOptionsDescription": "Menetapkan opsi tersendiri untuk Anggaran, Kesehatan, dan Bantuan rumah tangga.",
+        "pageModuleOptionsDescription": "Opsi tambahan untuk beberapa modul.",
         "pageCalendarModule": "Kalender",
         "pageCalendarModuleDescription": "Tetapkan hari libur, awal pekan, dan durasi acara default.",
         "pageSyncCalendar": "Sinkronisasi Kalender",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Cucina",
         "pageKitchenDescription": "Scegli quali pasti sono visibili nel piano pasti.",
         "pageModuleOptions": "Opzioni dei moduli",
-        "pageModuleOptionsDescription": "Impostare singole opzioni per Budget, Salute e Aiuto domestico.",
+        "pageModuleOptionsDescription": "Opzioni aggiuntive per alcuni moduli.",
         "pageCalendarModule": "Calendario",
         "pageCalendarModuleDescription": "Imposta festività, inizio settimana e durata predefinita dell’evento.",
         "pageSyncCalendar": "Sincronizzazione calendario",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "キッチン",
         "pageKitchenDescription": "献立プランに表示する食事を選択します。",
         "pageModuleOptions": "モジュールのオプション",
-        "pageModuleOptionsDescription": "家計・健康・家事サポートの個別オプションを設定します。",
+        "pageModuleOptionsDescription": "いくつかのモジュール向けの追加オプションです。",
         "pageCalendarModule": "カレンダー",
         "pageCalendarModuleDescription": "祝日、週の開始日、予定の既定の長さを設定します。",
         "pageSyncCalendar": "カレンダー同期",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -2274,7 +2274,7 @@
         "pageKitchen": "주방",
         "pageKitchenDescription": "식단 계획에 표시할 식사를 선택합니다.",
         "pageModuleOptions": "모듈 옵션",
-        "pageModuleOptionsDescription": "예산, 건강, 가사 도움의 개별 옵션을 설정합니다.",
+        "pageModuleOptionsDescription": "몇몇 모듈을 위한 추가 옵션입니다.",
         "pageCalendarModule": "캘린더",
         "pageCalendarModuleDescription": "공휴일, 주 시작 요일, 기본 일정 길이를 설정합니다.",
         "pageSyncCalendar": "캘린더 동기화",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Keuken",
         "pageKitchenDescription": "Kies welke maaltijden zichtbaar zijn in het maaltijdplan.",
         "pageModuleOptions": "Module-opties",
-        "pageModuleOptionsDescription": "Losse opties voor Budget, Gezondheid en Huishoudhulp instellen.",
+        "pageModuleOptionsDescription": "Extra opties voor een paar modules.",
         "pageCalendarModule": "Agenda",
         "pageCalendarModuleDescription": "Stel feestdagen, begin van de week en de standaardduur van een afspraak in.",
         "pageSyncCalendar": "Agendasynchronisatie",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -2274,7 +2274,7 @@
         "pageKitchen": "Kuchnia",
         "pageKitchenDescription": "Wybierz, które posiłki są widoczne w planie posiłków.",
         "pageModuleOptions": "Opcje modułów",
-        "pageModuleOptionsDescription": "Ustawić pojedyncze opcje dla Budżetu, Zdrowia i Pomocy domowej.",
+        "pageModuleOptionsDescription": "Dodatkowe opcje dla kilku modułów.",
         "pageCalendarModule": "Kalendarz",
         "pageCalendarModuleDescription": "Ustaw święta, początek tygodnia i domyślny czas trwania wydarzenia.",
         "pageSyncCalendar": "Synchronizacja kalendarza",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Cozinha",
         "pageKitchenDescription": "Escolha quais refeições ficam visíveis no plano de refeições.",
         "pageModuleOptions": "Opções de módulos",
-        "pageModuleOptionsDescription": "Definir opções individuais para Orçamento, Saúde e Ajuda doméstica.",
+        "pageModuleOptionsDescription": "Opções extra para alguns módulos.",
         "pageCalendarModule": "Calendário",
         "pageCalendarModuleDescription": "Defina feriados, início da semana e a duração padrão do evento.",
         "pageSyncCalendar": "Sincronização de calendários",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Кухня",
         "pageKitchenDescription": "Выберите, какие приёмы пищи видны в плане питания.",
         "pageModuleOptions": "Параметры модулей",
-        "pageModuleOptionsDescription": "Задать отдельные параметры для Бюджета, Здоровья и Помощи по дому.",
+        "pageModuleOptionsDescription": "Дополнительные параметры для нескольких модулей.",
         "pageCalendarModule": "Календарь",
         "pageCalendarModuleDescription": "Задайте праздники, начало недели и длительность события по умолчанию.",
         "pageSyncCalendar": "Синхронизация календарей",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Kök",
         "pageKitchenDescription": "Välj vilka måltider som visas i måltidsplanen.",
         "pageModuleOptions": "Modulalternativ",
-        "pageModuleOptionsDescription": "Ange enskilda alternativ för Budget, Hälsa och Hushållshjälp.",
+        "pageModuleOptionsDescription": "Extra alternativ för några moduler.",
         "pageCalendarModule": "Kalender",
         "pageCalendarModuleDescription": "Ange helgdagar, veckostart och standardlängd för en händelse.",
         "pageSyncCalendar": "Kalendersynkronisering",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Mutfak",
         "pageKitchenDescription": "Yemek planında hangi öğünlerin görüneceğini seçin.",
         "pageModuleOptions": "Modül seçenekleri",
-        "pageModuleOptionsDescription": "Bütçe, Sağlık ve Ev yardımı için tek tek seçenekleri belirleme.",
+        "pageModuleOptionsDescription": "Birkaç modül için ek seçenekler.",
         "pageCalendarModule": "Takvim",
         "pageCalendarModuleDescription": "Tatilleri, hafta başlangıcını ve varsayılan etkinlik süresini belirleyin.",
         "pageSyncCalendar": "Takvim eşitleme",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Кухня",
         "pageKitchenDescription": "Виберіть, які прийоми їжі видно в плані харчування.",
         "pageModuleOptions": "Параметри модулів",
-        "pageModuleOptionsDescription": "Задати окремі параметри для Бюджету, Здоров'я та Домашньої допомоги.",
+        "pageModuleOptionsDescription": "Додаткові параметри для кількох модулів.",
         "pageCalendarModule": "Календар",
         "pageCalendarModuleDescription": "Задайте свята, початок тижня та типову тривалість події.",
         "pageSyncCalendar": "Синхронізація календарів",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "Nhà bếp",
         "pageKitchenDescription": "Chọn những bữa ăn hiển thị trong kế hoạch bữa ăn.",
         "pageModuleOptions": "Tùy chọn mô-đun",
-        "pageModuleOptionsDescription": "Đặt từng tùy chọn cho Ngân sách, Sức khỏe và Giúp việc nhà.",
+        "pageModuleOptionsDescription": "Tùy chọn bổ sung cho một vài mô-đun.",
         "pageCalendarModule": "Lịch",
         "pageCalendarModuleDescription": "Đặt ngày lễ, ngày bắt đầu tuần và thời lượng sự kiện mặc định.",
         "pageSyncCalendar": "Đồng bộ lịch",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -2262,7 +2262,7 @@
         "pageKitchen": "厨房",
         "pageKitchenDescription": "选择在膳食计划中显示哪些餐食。",
         "pageModuleOptions": "模块选项",
-        "pageModuleOptionsDescription": "为预算、健康和家务帮手设置单项选项。",
+        "pageModuleOptionsDescription": "为几个模块提供的附加选项。",
         "pageCalendarModule": "日历",
         "pageCalendarModuleDescription": "设置节假日、每周起始日和默认日程时长。",
         "pageSyncCalendar": "日历同步",


### PR DESCRIPTION
## What this is

A one-string fix, found as a side-observation while auditing the Schedule module (unrelated to that work otherwise).

## The problem

Settings → Modules → Module options describes itself as:

> Set individual options for Budget, Health and Housekeeping.

That was accurate when written, but the page has since grown a Tasks section (subtask-expansion default) and a Schedule section (quick-start templates) without this sentence ever being updated - it silently went stale twice.

## The fix

Reworded to describe the page's *purpose* instead of enumerating specific module names:

> Extra options for a few modules.

This can't go stale the same way a third time, since it doesn't name anything that could later be added or removed. Translated into all 24 locales (each with a real, per-language phrasing, not a copy of the English string).

## Test plan

- [x] `npm run test:i18n` / `test:i18n-plural` / `test:i18n-translated` green (all 24 locales)
- [x] `test/test-settings-copy.js` green (the guard that checks every noun in a leaf's description actually appears in what the leaf renders - the first wording I tried tripped this, since it named "settings page" content the page itself never renders; simplified to just "options"/"modules", which the page's own title already contains)
- [x] Full `npm test` exit 0
- [x] Verified live in the browser: the page now reads "Module options / Extra options for a few modules."