### PR TITLE
refactor(schedule): der Feld-Unterblock tauscht ohne outerHTML-Zuweisung

### DIFF
--- a/public/pages/schedule.js
+++ b/public/pages/schedule.js
@@ -1258,8 +1258,10 @@ function renderShell() {
       const row = event.target.closest('[data-day-row]');
       const existing = row?.querySelector('[data-day-row-fields]');
       const html = dayRowFieldsHtml(event.target.value);
-      if (existing) existing.outerHTML = html;
-      else if (html) row.insertAdjacentHTML('beforeend', html);
+      if (existing) {
+        existing.insertAdjacentHTML('afterend', html);
+        existing.remove();
+      } else if (html) row.insertAdjacentHTML('beforeend', html);
       window.lucide?.createIcons({ el: row });
     }
   });
@@ -1402,8 +1404,10 @@ function wireOccurrenceFieldReactivity(scope) {
       const container = select.closest('fieldset') ?? select.closest('form');
       const existing = container?.querySelector('[data-day-row-fields]');
       const html = dayRowFieldsHtml(select.value);
-      if (existing) existing.outerHTML = html;
-      else if (html) select.closest('.form-field')?.insertAdjacentHTML('afterend', html);
+      if (existing) {
+        existing.insertAdjacentHTML('afterend', html);
+        existing.remove();
+      } else if (html) select.closest('.form-field')?.insertAdjacentHTML('afterend', html);
       window.lucide?.createIcons({ el: container });
     });
   });

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -206,13 +206,16 @@ function assertRuleUsesToken(css, selector, property, token, file) {
 // es das Element selbst statt seines Inhalts. Die zwei Stellen, die es gab
 // (schedule.js), laufen seitdem ueber insertAdjacentHTML('afterend') + remove().
 //
-// Verbundzuweisungen (`+=`, `||=`, `??=` ...) rufen denselben Setter auf und
-// zaehlen deshalb mit. Lucide ist Vendor-Code, liegt aber aus historischen
+// Verbundzuweisungen (`+=`, `||=`, `??=` ...) und die Klammerschreibweise
+// (`el['outerHTML'] =`) rufen denselben Setter auf und zaehlen deshalb mit.
+// Die Grenze eines Text-Guards: einen Namen aus einer Variablen,
+// `Object.assign(el, { innerHTML })` oder `Reflect.set` sieht er nicht - das
+// bleibt beim Review. Lucide ist Vendor-Code, liegt aber aus historischen
 // Gruenden als public/lucide.min.js ausserhalb von vendor/ (siehe
 // public/vendor/lucide/README.md) und ist deshalb einzeln ausgenommen.
 const VENDOR_PREFIX = '../public/vendor/';
 const VENDOR_FILES = new Set(['../public/lucide.min.js']);
-const HTML_STRING_WRITE = /\.(?:innerHTML|outerHTML)\s*(?:[-+*/%&|^]|\*\*|<<|>>>?|&&|\|\||\?\?)?=(?!=)/;
+const HTML_STRING_WRITE = /(?:\.(?:innerHTML|outerHTML)|\[\s*(['"`])(?:innerHTML|outerHTML)\1\s*\])\s*(?:[-+*/%&|^]|\*\*|<<|>>>?|&&|\|\||\?\?)?=(?!=)/;
 
 test('kein innerHTML- oder outerHTML-Schreibzugriff irgendwo unter public/ (ausser vendor/)', () => {
   const files = walkJsFiles('../public/').filter((f) => !f.startsWith(VENDOR_PREFIX) && !VENDOR_FILES.has(f));
@@ -233,6 +236,9 @@ test('der innerHTML-Guard erkennt das Muster, das er verbietet', () => {
   assert.ok(pattern.test('list.innerHTML += row;'), 'Verbundzuweisung += wird nicht erkannt');
   assert.ok(pattern.test('el.outerHTML ||= html;'), 'logische Zuweisung ||= wird nicht erkannt');
   assert.ok(pattern.test('el.innerHTML ??= html;'), 'logische Zuweisung ??= wird nicht erkannt');
+  assert.ok(pattern.test("el['outerHTML'] = html;"), 'Klammerschreibweise wird nicht erkannt');
+  assert.ok(pattern.test('el["innerHTML"] += row;'), 'Klammerschreibweise mit += wird nicht erkannt');
+  assert.ok(!pattern.test("const html = el['outerHTML'];"), 'ein Lesezugriff in Klammern wird faelschlich beanstandet');
   assert.ok(!pattern.test('if (el.innerHTML === x)'), 'ein Vergleich wird faelschlich beanstandet');
   assert.ok(!pattern.test('if (el.innerHTML !== x)'), 'eine Ungleichheit wird faelschlich beanstandet');
   assert.ok(!pattern.test('return emptyStateEl(opts).outerHTML;'), 'ein Lesezugriff wird faelschlich beanstandet');

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -205,11 +205,17 @@ function assertRuleUsesToken(css, selector, property, token, file) {
 // `outerHTML =` gehoert dazu: es parst denselben String als Markup, nur ersetzt
 // es das Element selbst statt seines Inhalts. Die zwei Stellen, die es gab
 // (schedule.js), laufen seitdem ueber insertAdjacentHTML('afterend') + remove().
+//
+// Verbundzuweisungen (`+=`, `||=`, `??=` ...) rufen denselben Setter auf und
+// zaehlen deshalb mit. Lucide ist Vendor-Code, liegt aber aus historischen
+// Gruenden als public/lucide.min.js ausserhalb von vendor/ (siehe
+// public/vendor/lucide/README.md) und ist deshalb einzeln ausgenommen.
 const VENDOR_PREFIX = '../public/vendor/';
-const HTML_STRING_WRITE = /\.(?:innerHTML|outerHTML)\s*=[^=]/;
+const VENDOR_FILES = new Set(['../public/lucide.min.js']);
+const HTML_STRING_WRITE = /\.(?:innerHTML|outerHTML)\s*(?:[-+*/%&|^]|\*\*|<<|>>>?|&&|\|\||\?\?)?=(?!=)/;
 
 test('kein innerHTML- oder outerHTML-Schreibzugriff irgendwo unter public/ (ausser vendor/)', () => {
-  const files = walkJsFiles('../public/').filter((f) => !f.startsWith(VENDOR_PREFIX));
+  const files = walkJsFiles('../public/').filter((f) => !f.startsWith(VENDOR_PREFIX) && !VENDOR_FILES.has(f));
   const offenders = files.filter((file) => HTML_STRING_WRITE.test(read(file)));
   assert.deepEqual(offenders, [],
     'anhaengen mit insertAdjacentHTML oder ueber die DOM-API, User-Daten durch esc()');
@@ -224,7 +230,11 @@ test('der innerHTML-Guard erkennt das Muster, das er verbietet', () => {
   assert.ok(pattern.test('root.innerHTML = `<div>`;'), 'Zuweisung wird nicht erkannt');
   assert.ok(pattern.test('el.innerHTML=""'), 'Zuweisung ohne Leerzeichen wird nicht erkannt');
   assert.ok(pattern.test('existing.outerHTML = html;'), 'outerHTML-Zuweisung wird nicht erkannt');
+  assert.ok(pattern.test('list.innerHTML += row;'), 'Verbundzuweisung += wird nicht erkannt');
+  assert.ok(pattern.test('el.outerHTML ||= html;'), 'logische Zuweisung ||= wird nicht erkannt');
+  assert.ok(pattern.test('el.innerHTML ??= html;'), 'logische Zuweisung ??= wird nicht erkannt');
   assert.ok(!pattern.test('if (el.innerHTML === x)'), 'ein Vergleich wird faelschlich beanstandet');
+  assert.ok(!pattern.test('if (el.innerHTML !== x)'), 'eine Ungleichheit wird faelschlich beanstandet');
   assert.ok(!pattern.test('return emptyStateEl(opts).outerHTML;'), 'ein Lesezugriff wird faelschlich beanstandet');
 });
 

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -201,11 +201,16 @@ function assertRuleUsesToken(css, selector, property, token, file) {
 // ueberall - die Liste war also nie eine Ausnahmegenehmigung, nur ein zu enger
 // Suchbereich. Vendor-Code ist ausgenommen: der wird von Hand kopiert und nicht
 // nach unseren Regeln geschrieben.
+//
+// `outerHTML =` gehoert dazu: es parst denselben String als Markup, nur ersetzt
+// es das Element selbst statt seines Inhalts. Die zwei Stellen, die es gab
+// (schedule.js), laufen seitdem ueber insertAdjacentHTML('afterend') + remove().
 const VENDOR_PREFIX = '../public/vendor/';
+const HTML_STRING_WRITE = /\.(?:innerHTML|outerHTML)\s*=[^=]/;
 
-test('kein innerHTML-Schreibzugriff irgendwo unter public/ (ausser vendor/)', () => {
+test('kein innerHTML- oder outerHTML-Schreibzugriff irgendwo unter public/ (ausser vendor/)', () => {
   const files = walkJsFiles('../public/').filter((f) => !f.startsWith(VENDOR_PREFIX));
-  const offenders = files.filter((file) => /\.innerHTML\s*=[^=]/.test(read(file)));
+  const offenders = files.filter((file) => HTML_STRING_WRITE.test(read(file)));
   assert.deepEqual(offenders, [],
     'anhaengen mit insertAdjacentHTML oder ueber die DOM-API, User-Daten durch esc()');
 
@@ -215,10 +220,12 @@ test('kein innerHTML-Schreibzugriff irgendwo unter public/ (ausser vendor/)', ()
 });
 
 test('der innerHTML-Guard erkennt das Muster, das er verbietet', () => {
-  const pattern = /\.innerHTML\s*=[^=]/;
+  const pattern = HTML_STRING_WRITE;
   assert.ok(pattern.test('root.innerHTML = `<div>`;'), 'Zuweisung wird nicht erkannt');
   assert.ok(pattern.test('el.innerHTML=""'), 'Zuweisung ohne Leerzeichen wird nicht erkannt');
+  assert.ok(pattern.test('existing.outerHTML = html;'), 'outerHTML-Zuweisung wird nicht erkannt');
   assert.ok(!pattern.test('if (el.innerHTML === x)'), 'ein Vergleich wird faelschlich beanstandet');
+  assert.ok(!pattern.test('return emptyStateEl(opts).outerHTML;'), 'ein Lesezugriff wird faelschlich beanstandet');
 });
 
 /**


### PR DESCRIPTION
Zwei `outerHTML`-Zuweisungen in `public/pages/schedule.js` tauschen den Feld-Unterblock einer Schichtzeile - die einzigen im Frontend. Am Verhalten ändert sich nichts; geschlossen wird eine Lücke in der Invariante.

## Warum

`outerHTML =` parst einen String als Markup, genau wie `innerHTML =`, nur für das Element selbst. Der CI-Guard in `test-frontend-audit.js` suchte nur `.innerHTML =` und sah diese Form nicht. Die beiden Stellen escapen ihre Werte (`dayRowFieldsHtml` und `formField` laufen über `esc()`), dahinter steckt also kein XSS. Eine Regel, die eine gleichwertige Schreibweise durchlässt, schützt aber nur so lange, wie niemand sie benutzt.

## Änderung

- Beide Stellen: `existing.insertAdjacentHTML('afterend', html); existing.remove();` statt `existing.outerHTML = html`.
- Der Guard verbietet `innerHTML =` und `outerHTML =`. Sein Selbsttest kennt die `outerHTML`-Zuweisung und lässt Lesezugriffe wie `emptyStateEl(opts).outerHTML` durch.

## Gemessen

- **Gleiches DOM im Chromium** (puppeteer, alte gegen neue Fassung auf demselben Markup): der Feld-Unterblock wird ersetzt, und der leere String eines Schichttyps ohne Felder entfernt den Block - beide Male zeichengleich mit `outerHTML`.
- `test:frontend-audit` 380/380. Gegenprobe: eine Stelle zurück auf `outerHTML`, der Guard wird rot (379/380).
- Volle Kette (`npm test`) auf dem Zweig: exit 0 (10.09.2026)
