### PR TITLE
fix(calendar): the event detail names the day a multi-day event ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The event detail names the day a multi-day event ends** (#1102). The "When" row showed the
+  start date and, of the end, only the time: an event from 10 September 14:00 to 12 September 11:00
+  read as "14:00 - 11:00" on a single day that ends before it begins, and an all-day event across
+  three days named only the first. When an event ends on another day, the row now carries that day
+  as well - start date and time to end date and time, or first to last day for an all-day event.
+  "Another day" is the rule the calendar grid already uses rather than a second one: a timed event
+  that ends at 00:00 still belongs to the evening it started in (#804), and the end of an all-day
+  event stays inclusive. The range separator now comes from the same locale string as the day
+  view's date range, a hyphen where the time range used to carry an en dash.
+
 - **The Module options settings page describes what it actually contains.** Its description named
   only Budget, Health and Housekeeping - accurate when it was written, but Tasks and Schedule have
   since grown their own sections on the same page without the sentence ever being updated. Reworded

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -3517,6 +3517,11 @@ function eventWhenText(ev) {
   }
   const start = formatDateTime(ev.start_datetime);
   if (!ev.end_datetime) return start;
+  // Das Ende ist der ZEITPUNKT, nicht der letzte Rastertag. Ein Termin vom 1.
+  // 14:00 bis zum 3. 00:00 steht im Raster am 1. und 2., endet aber am 3. um
+  // 00:00 - und genau das steht hier. Das Datum aus `eventEndDate` mit der
+  // rohen Uhrzeit ergaebe "2. 00:00", einen Tag zu frueh; rastertreu waere nur
+  // "2. 24:00", und das kann keine Locale formatieren (Review auf #1114).
   const end = multiDay
     ? formatDateTime(ev.end_datetime)
     : `${formatTime(ev.end_datetime)} ${timeSuffix()}`.trimEnd();

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -3333,6 +3333,7 @@ export const __test = {
   passesPersonFilters,
   eventEndDate,
   isMultiDayEvent,
+  eventWhenText,
   isAllDayLike,
   agendaSegmentKind,
   deepLinkTargetDate,
@@ -3492,6 +3493,37 @@ function reminderSummary(ev, reminders) {
 }
 
 /**
+ * Die „Wann"-Zeile der Detailansicht (#1102).
+ *
+ * Sie nannte das Startdatum und vom Ende nur die Uhrzeit. Ein Termin vom 10.
+ * 14:00 bis zum 12. 11:00 las sich dadurch als „14:00 - 11:00" an einem Tag,
+ * der endet, bevor er beginnt, und ein Ganztags-Termin über drei Tage nannte
+ * nur den ersten. Endet der Termin an einem anderen Tag, steht dieser Tag jetzt
+ * mit da.
+ *
+ * „Anderer Tag" ist die Regel des Rasters, keine zweite: `isMultiDayEvent` über
+ * `eventEndDate`. Ein Zeit-Termin bis 00:00 gehört dem Abend, an dem er begann
+ * (#804), und das Ende eines Ganztags-Termins ist inklusiv. Der Trenner kommt
+ * aus demselben Locale-Key wie der Zeitraum im Tageskopf.
+ */
+function eventWhenText(ev) {
+  const multiDay = isMultiDayEvent(ev);
+  if (ev.all_day) {
+    const startDate = formatPreferredDate(localDate(ev.start_datetime));
+    const dates = multiDay
+      ? t('calendar.dayRangeLabel', { from: startDate, to: formatPreferredDate(eventEndDate(ev)) })
+      : startDate;
+    return `${dates} · ${t('calendar.allDay')}`;
+  }
+  const start = formatDateTime(ev.start_datetime);
+  if (!ev.end_datetime) return start;
+  const end = multiDay
+    ? formatDateTime(ev.end_datetime)
+    : `${formatTime(ev.end_datetime)} ${timeSuffix()}`.trimEnd();
+  return t('calendar.dayRangeLabel', { from: start, to: end });
+}
+
+/**
  * Die Leseinformationen eines Termins.
  *
  * Wiederholung, Erinnerungen und Sichtbarkeit standen bisher nur im
@@ -3499,14 +3531,9 @@ function reminderSummary(ev, reminders) {
  * wiederkehrt, musste ihn zum Bearbeiten öffnen.
  */
 function renderEventDetail(ev, reminders = []) {
-  const timeStr = ev.all_day
-    ? `${formatPreferredDate(localDate(ev.start_datetime))} · ${t('calendar.allDay')}`
-    : formatDateTime(ev.start_datetime)
-      + (ev.end_datetime ? ` – ${formatTime(ev.end_datetime)} ${timeSuffix()}`.trimEnd() : '');
-
   return [
     { icon: 'calendar', label: t('calendar.detailCalendar'), node: calendarChipNode(ev) },
-    { icon: 'clock', label: t('calendar.detailWhen'), value: timeStr },
+    { icon: 'clock', label: t('calendar.detailWhen'), value: eventWhenText(ev) },
     recurrenceRow(ev.recurrence_rule),
     { icon: 'map-pin', label: t('calendar.locationLabel'), value: ev.location ? fmtLocation(ev.location) : '' },
     assignedRow(ev.assigned_users, t('calendar.assignedLabel'), ev.assigned_name || ''),

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -532,6 +532,48 @@ test('eventEndDate: ohne Enddatum gilt der Starttag', () => {
   assert(eventEndDate(ev) === '2026-06-14', 'Kein Ende → Starttag');
 });
 
+// --------------------------------------------------------
+// eventWhenText (#1102): die „Wann"-Zeile der Detailansicht nennt den Endtag,
+// sobald er ein anderer ist - nach derselben Regel wie das Raster.
+//
+// Der i18n-Stub gibt Datum und Uhrzeit unverändert zurück (formatTime also den
+// ganzen Zeitstempel) und hängt die Werte als JSON an den Key. Ein Ende OHNE
+// Datum ist deshalb der blanke Zeitstempel, ein Ende MIT Datum trägt das
+// Datum davor: "2026-09-12 2026-09-12T11:00".
+// --------------------------------------------------------
+const { eventWhenText } = calendarHelpers;
+const whenRange = (text) => JSON.parse(text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1));
+
+test('eventWhenText: eintägiges Zeit-Event nennt vom Ende nur die Uhrzeit', () => {
+  const text = eventWhenText({ start_datetime: '2026-09-10T14:00', end_datetime: '2026-09-10T15:30', all_day: 0 });
+  assert(text.startsWith('calendar.dayRangeLabel'), `Zeitraum über den Locale-Key: ${text}`);
+  assert(whenRange(text).to === '2026-09-10T15:30', `Ende ohne vorangestelltes Datum: ${text}`);
+});
+
+test('eventWhenText: mehrtägiges Zeit-Event nennt Enddatum und Enduhrzeit', () => {
+  const text = eventWhenText({ start_datetime: '2026-09-10T14:00', end_datetime: '2026-09-12T11:00', all_day: 0 });
+  assert(whenRange(text).from === '2026-09-10 2026-09-10T14:00', `Start mit Datum: ${text}`);
+  assert(whenRange(text).to === '2026-09-12 2026-09-12T11:00', `Enddatum steht vor der Uhrzeit: ${text}`);
+});
+
+test('eventWhenText: Zeit-Event bis 00:00 des Folgetags bleibt eintägig', () => {
+  const text = eventWhenText({ start_datetime: '2026-09-10T21:00', end_datetime: '2026-09-11T00:00', all_day: 0 });
+  assert(whenRange(text).to === '2026-09-11T00:00', `21:00-24:00 gehört dem Abend (#804): ${text}`);
+});
+
+test('eventWhenText: mehrtägiges Ganztags-Event nennt beide Tage', () => {
+  const text = eventWhenText({ start_datetime: '2026-09-10T00:00', end_datetime: '2026-09-12T00:00', all_day: 1 });
+  assert(text === 'calendar.dayRangeLabel{"from":"2026-09-10","to":"2026-09-12"} · calendar.allDay',
+    `Ende inklusiv, beide Tage genannt: ${text}`);
+});
+
+test('eventWhenText: eintägiges Ganztags-Event und Termin ohne Ende bleiben unverändert', () => {
+  const allDay = eventWhenText({ start_datetime: '2026-09-10T00:00', end_datetime: '2026-09-10T00:00', all_day: 1 });
+  assert(allDay === '2026-09-10 · calendar.allDay', `Ein Tag, kein Zeitraum: ${allDay}`);
+  const open = eventWhenText({ start_datetime: '2026-09-10T14:00', end_datetime: null, all_day: 0 });
+  assert(open === '2026-09-10 2026-09-10T14:00', `Ohne Ende nur der Start: ${open}`);
+});
+
 test('eventEndDate: Ende vor dem Start fällt auf den Starttag zurück', () => {
   const ev = { start_datetime: '2026-06-14T09:00', end_datetime: '2026-06-13T00:00', all_day: 0 };
   assert(eventEndDate(ev) === '2026-06-14', 'Verdrehtes Ende erzeugt keinen Rückwärtsbereich');

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -561,6 +561,16 @@ test('eventWhenText: Zeit-Event bis 00:00 des Folgetags bleibt eintägig', () =>
   assert(whenRange(text).to === '2026-09-11T00:00', `21:00-24:00 gehört dem Abend (#804): ${text}`);
 });
 
+test('eventWhenText: mehrtägiges Zeit-Event bis 00:00 nennt den echten Endzeitpunkt, nicht den letzten Rastertag', () => {
+  // Review auf #1114, entschieden: das Raster fuehrt den Termin am 1. und 2.,
+  // die Zeile nennt aber, WANN er endet - am 3. um 00:00. Das Datum aus
+  // eventEndDate() mit der rohen Uhrzeit hiesse "2. 00:00", einen Tag zu frueh.
+  const ev = { start_datetime: '2026-01-01T14:00', end_datetime: '2026-01-03T00:00', all_day: 0 };
+  assert(eventEndDate(ev) === '2026-01-02', 'das Raster endet am 2. (#804)');
+  const text = eventWhenText(ev);
+  assert(whenRange(text).to === '2026-01-03 2026-01-03T00:00', `Ende ist der 3. um 00:00: ${text}`);
+});
+
 test('eventWhenText: mehrtägiges Ganztags-Event nennt beide Tage', () => {
   const text = eventWhenText({ start_datetime: '2026-09-10T00:00', end_datetime: '2026-09-12T00:00', all_day: 1 });
   assert(text === 'calendar.dayRangeLabel{"from":"2026-09-10","to":"2026-09-12"} · calendar.allDay',


### PR DESCRIPTION
Closes #1102

The "When" row of the event detail joined the start date with only the end time. A timed event from 10 Sep 14:00 to 12 Sep 11:00 read as "14:00 - 11:00" on a single day, and a three-day all-day event named only its first day.

## Change

`eventWhenText()` in `public/pages/calendar.js` builds the row and adds the end day whenever `isMultiDayEvent()` says the event ends on another day - the grid's rule rather than a second one:

- timed, multi-day: start date and time - end date and time
- timed, ending at 00:00 of the next day: stays single-day (#804)
- all-day, multi-day: first day - last day, end inclusive

The separator comes from `calendar.dayRangeLabel`, which the day view already uses for its date range and which exists in all 24 locales. The time range therefore carries a hyphen now instead of the hard-coded en dash.

## Verification

- `test:calendar`: five new cases on `eventWhenText` (single-day timed, multi-day timed, ending at 00:00, multi-day all-day, single-day all-day plus no end). Counter-check: with the multi-day distinction switched off (`multiDay = false`) exactly the two multi-day cases fail, the other three stay green.
- `test:changelog` 28/28, `test:frontend-audit` 380/380.
- The real module with the real `de` locale in a browser:
  - `10.09.2026 14:00 Uhr - 15:30 Uhr`
  - `10.09.2026 14:00 Uhr - 12.09.2026 11:00 Uhr`
  - `10.09.2026 21:00 Uhr - 00:00 Uhr`
  - `10.09.2026 - 12.09.2026 · Ganztägig`
  - `10.09.2026 · Ganztägig`

Not covered by a test: the call site in `renderEventDetail()` itself, a one-line `value: eventWhenText(ev)`.

Touches the UI, so it rides the next Tuesday release.
