### PR TITLE
fix(modal): swiping up in a dialog no longer cancels its scroll under Reduce Motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,9 +141,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing. With Reduce Motion the animation is switched off, the write turned the panel's transform
   from `none` into a matrix on every swipe, and iOS dropped the scroll. Measured in the iOS simulator
   with the setting on: the same upward swipe left the content 0 to 30 px down in three runs. An
-  upward movement before the sheet has been pulled is now content scrolling - the gesture lets go
-  and never touches the panel's style. A pull that has already started stays tracked when the
-  finger reverses, so the panel still returns to rest. Under the same setting the swipe now ends
+  upward movement of more than 10 px before the sheet has been pulled is now content scrolling -
+  the gesture lets go and never touches the panel's style. Below that, the same threshold that
+  already applied downwards, nothing is decided, so a finger that wobbles upward as it lands can
+  still pull the sheet closed. A pull that has already started stays tracked when the finger
+  reverses, so the panel still returns to rest. Under the same setting the swipe now ends
   500 to 675 px down.
 
 - **The Module options settings page describes what it actually contains.** Its description named

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dialog content on a phone scrolls again with Reduce Motion turned on** (#981). A freshly opened
+  dialog stands at the top, so every swipe inside it began as a tracked swipe-to-close gesture, and
+  on every upward frame that gesture wrote `translateY(0)` to the panel. Normally the sheet's
+  entrance animation holds its end state and outranks that inline style, so the write changed
+  nothing. With Reduce Motion the animation is switched off, the write turned the panel's transform
+  from `none` into a matrix on every swipe, and iOS dropped the scroll. Measured in the iOS simulator
+  with the setting on: the same upward swipe left the content 0 to 30 px down in three runs. An
+  upward movement before the sheet has been pulled is now content scrolling - the gesture lets go
+  and never touches the panel's style. A pull that has already started stays tracked when the
+  finger reverses, so the panel still returns to rest. Under the same setting the swipe now ends
+  500 to 675 px down.
+
 - **The Module options settings page describes what it actually contains.** Its description named
   only Budget, Health and Housekeeping - accurate when it was written, but Tasks and Schedule have
   since grown their own sections on the same page without the sentence ever being updated. Reworded

--- a/public/components/modal.js
+++ b/public/components/modal.js
@@ -338,6 +338,9 @@ function onEscape(e) {
 function _wireSheetSwipe(panel) {
   let startY = 0;
   let dragging = false;
+  // Hat dieser Finger das Sheet schon nach unten gezogen? Erst dann gehört eine
+  // Aufwärtsbewegung zum Zug; davor ist sie Scrollen des Inhalts (#981).
+  let pulled = false;
 
   // Scroll position is now on the body, not the panel itself
   const scrollBody = panel.querySelector('.modal-panel__body');
@@ -351,15 +354,33 @@ function _wireSheetSwipe(panel) {
     if (!isHandleZone && !isScrolledToTop) return;
     startY = touchY;
     dragging = true;
+    pulled = false;
   }, { passive: true });
 
   panel.addEventListener('touchmove', (e) => {
     if (!dragging) return;
     const dy = e.touches[0].clientY - startY;
-    if (dy < 0) { panel.style.transform = 'translateY(0)'; return; } // Aufwärts: Panel zurücksetzen, dragging bleibt aktiv
+    if (dy < 0) {
+      // RICHTUNGSSPERRE (#981). Ein frisch geöffneter Dialog steht oben, also
+      // begann JEDE Wischgeste im Inhalt als verfolgter Zug, und der schrieb
+      // bei jedem Aufwärts-Frame `translateY(0)` ans Panel - ein Stil-Schreib-
+      // zugriff je Frame am Vorfahren genau des Elements, das gerade scrollen
+      // soll. Gemeldet: der Inhalt scrollt auf iOS gar nicht, im Safari-Tab wie
+      // in der PWA. Aufwärts, bevor das Sheet gezogen wurde, ist deshalb kein
+      // Zug: die Geste gibt ab und fasst das Panel nicht an.
+      if (!pulled) { dragging = false; return; }
+      // Ein begonnener Zug bleibt verfolgt, wenn der Finger zurückkehrt - sonst
+      // endete touchend ohne Rücksetzen und das Panel stünde verschoben
+      // (b7c0312c). Zurückgesetzt wird einmal, nicht in jedem Frame.
+      if (panel.style.transform) panel.style.transform = '';
+      return;
+    }
     // Erst ab 10px Bewegung animieren: Verhindert winzige Transforms durch
     // normale Taps, die danach zurückgesetzt werden müssten.
-    if (dy > 10) panel.style.transform = `translateY(${(dy - 10) * 0.6}px)`;
+    if (dy > 10) {
+      pulled = true;
+      panel.style.transform = `translateY(${(dy - 10) * 0.6}px)`;
+    }
   }, { passive: true });
 
   panel.addEventListener('touchend', (e) => {
@@ -377,6 +398,9 @@ function _wireSheetSwipe(panel) {
     }
   });
 }
+
+/** Nur fuer Tests: die Geste ohne echtes Panel treiben (#981). */
+export const __test = { wireSheetSwipe: _wireSheetSwipe };
 
 // --------------------------------------------------------
 // Suspend/Restore für Dialoge über einem offenen Modal (Audit 1.5)

--- a/public/components/modal.js
+++ b/public/components/modal.js
@@ -335,6 +335,10 @@ function onEscape(e) {
 // Swipe-to-Close (Mobile)
 // --------------------------------------------------------
 
+// Beruehrungs-Schlupf der Wischgeste, in BEIDE Richtungen derselbe: unterhalb
+// davon entscheidet sie weder "Sheet ziehen" noch "Inhalt scrollen".
+const SHEET_SWIPE_SLOP_PX = 10;
+
 function _wireSheetSwipe(panel) {
   let startY = 0;
   let dragging = false;
@@ -363,23 +367,33 @@ function _wireSheetSwipe(panel) {
     if (dy < 0) {
       // RICHTUNGSSPERRE (#981). Ein frisch geöffneter Dialog steht oben, also
       // begann JEDE Wischgeste im Inhalt als verfolgter Zug, und der schrieb
-      // bei jedem Aufwärts-Frame `translateY(0)` ans Panel - ein Stil-Schreib-
-      // zugriff je Frame am Vorfahren genau des Elements, das gerade scrollen
-      // soll. Gemeldet: der Inhalt scrollt auf iOS gar nicht, im Safari-Tab wie
-      // in der PWA. Aufwärts, bevor das Sheet gezogen wurde, ist deshalb kein
-      // Zug: die Geste gibt ab und fasst das Panel nicht an.
-      if (!pulled) { dragging = false; return; }
+      // bei jedem Aufwärts-Frame `translateY(0)` ans Panel. Solange die
+      // Einfahranimation das Panel hält (`forwards`), aendert das nichts; mit
+      // "Bewegung reduzieren" gibt es keine Animation, das Inline-transform
+      // wirkt, und iOS bricht das Scrollen des Inhalts ab - gemessen im
+      // Simulator: 0 bis 30 px statt 500 bis 675 px fuer dieselbe Geste.
+      // Aufwärts, bevor das Sheet gezogen wurde, ist deshalb kein Zug: die
+      // Geste gibt ab und fasst das Panel nicht an.
+      //
+      // Aber erst jenseits derselben Schwelle, die abwärts gilt: ein Finger
+      // zittert beim Aufsetzen, und ein einzelner Pixel nach oben durfte eine
+      // gewollte Schliessgeste nicht verwerfen. Innerhalb der Schwelle
+      // passiert nichts - kein Abbruch, kein Schreibzugriff.
+      if (!pulled) {
+        if (dy < -SHEET_SWIPE_SLOP_PX) dragging = false;
+        return;
+      }
       // Ein begonnener Zug bleibt verfolgt, wenn der Finger zurückkehrt - sonst
       // endete touchend ohne Rücksetzen und das Panel stünde verschoben
       // (b7c0312c). Zurückgesetzt wird einmal, nicht in jedem Frame.
       if (panel.style.transform) panel.style.transform = '';
       return;
     }
-    // Erst ab 10px Bewegung animieren: Verhindert winzige Transforms durch
+    // Erst ab der Schwelle animieren: Verhindert winzige Transforms durch
     // normale Taps, die danach zurückgesetzt werden müssten.
-    if (dy > 10) {
+    if (dy > SHEET_SWIPE_SLOP_PX) {
       pulled = true;
-      panel.style.transform = `translateY(${(dy - 10) * 0.6}px)`;
+      panel.style.transform = `translateY(${(dy - SHEET_SWIPE_SLOP_PX) * 0.6}px)`;
     }
   }, { passive: true });
 

--- a/test/test-modal-utils.js
+++ b/test/test-modal-utils.js
@@ -830,3 +830,64 @@ test('_tryRefocus schreibt das tatsaechlich gesetzte Ziel in den Merker zurueck'
   assert.match(fn, /_lastRestore\.ziel = gesetzt/,
     'ohne das Zurueckschreiben urteilt der naechste Lauf ueber ein Ziel, das es nicht mehr gibt');
 });
+
+// --------------------------------------------------------
+// Sheet-Swipe (#981): eine Aufwaertsbewegung, bevor das Sheet gezogen wurde, ist
+// Scrollen des Inhalts. Die Geste darf das Panel dann nicht anfassen - vorher
+// schrieb sie bei jedem Aufwaerts-Frame `translateY(0)`, und ein frisch
+// geoeffneter Dialog steht immer oben, also begann jede Wischgeste so.
+// --------------------------------------------------------
+const { __test: modalInternals } = await import('../public/components/modal.js');
+
+function fakeSheet() {
+  const handlers = {};
+  const writes = [];
+  let transform = '';
+  const panel = {
+    addEventListener: (type, fn) => { handlers[type] = fn; },
+    querySelector: () => ({ scrollTop: 0 }),
+    getBoundingClientRect: () => ({ top: 100 }),
+    style: {
+      get transform() { return transform; },
+      set transform(v) { writes.push(v); transform = v; },
+    },
+  };
+  modalInternals.wireSheetSwipe(panel);
+  const at = (y) => ({ touches: [{ clientY: y }], changedTouches: [{ clientY: y }] });
+  return {
+    writes,
+    get transform() { return transform; },
+    start: (y) => handlers.touchstart(at(y)),
+    move: (y) => handlers.touchmove(at(y)),
+    end: (y) => handlers.touchend(at(y)),
+  };
+}
+
+test('Sheet-Swipe: aufwaerts im Inhalt schreibt nichts ans Panel (#981)', () => {
+  const sheet = fakeSheet();
+  sheet.start(600); // Inhalt steht oben, der Finger weit unter der Griffzone
+  for (const y of [590, 560, 500, 420, 330]) sheet.move(y);
+  sheet.end(330);
+  assert.deepEqual(sheet.writes, [], 'kein Stil-Schreibzugriff, waehrend eine Aufwaertsgeste den Inhalt scrollt');
+});
+
+test('Sheet-Swipe: ein begonnener Zug bleibt verfolgt und setzt das Panel einmal zurueck', () => {
+  global.requestAnimationFrame = (fn) => fn();
+  try {
+    const sheet = fakeSheet();
+    sheet.start(600);
+    sheet.move(650); // 50px nach unten: das Sheet folgt
+    assert.equal(sheet.transform, 'translateY(24px)');
+    sheet.move(590); // der Finger kehrt ueber den Start zurueck
+    assert.equal(sheet.transform, '', 'zurueckgesetzt, sobald der Finger ueber dem Start steht (b7c0312c)');
+    const writesAfterReset = sheet.writes.length;
+    sheet.move(570);
+    sheet.move(550);
+    assert.equal(sheet.writes.length, writesAfterReset, 'zurueckgesetzt wird einmal, nicht in jedem Frame');
+    sheet.move(640);
+    sheet.end(640); // 40px: kein Schliessen, zurueck in die Ruhelage
+    assert.equal(sheet.transform, '', 'touchend raeumt den Zug ab');
+  } finally {
+    delete global.requestAnimationFrame;
+  }
+});

--- a/test/test-modal-utils.js
+++ b/test/test-modal-utils.js
@@ -871,6 +871,19 @@ test('Sheet-Swipe: aufwaerts im Inhalt schreibt nichts ans Panel (#981)', () => 
   assert.deepEqual(sheet.writes, [], 'kein Stil-Schreibzugriff, waehrend eine Aufwaertsgeste den Inhalt scrollt');
 });
 
+test('Sheet-Swipe: ein Zittern nach oben verwirft eine Schliessgeste nicht', () => {
+  // Die erste Fassung der Sperre griff beim ersten Pixel nach oben: eine
+  // gewollte Abwaertsgeste mit unruhigem Aufsetzen blieb danach tot. Nach oben
+  // gilt dieselbe Schwelle wie nach unten.
+  const sheet = fakeSheet();
+  sheet.start(600);
+  sheet.move(598);
+  sheet.move(592); // 8px nach oben: innerhalb der Schwelle
+  assert.deepEqual(sheet.writes, [], 'innerhalb der Schwelle kein Schreibzugriff');
+  sheet.move(650);
+  assert.equal(sheet.transform, 'translateY(24px)', 'die Geste zieht das Sheet trotz des Zitterns');
+});
+
 test('Sheet-Swipe: ein begonnener Zug bleibt verfolgt und setzt das Panel einmal zurueck', () => {
   global.requestAnimationFrame = (fn) => fn();
   try {


### PR DESCRIPTION
Refs #981

A freshly opened dialog stands at the top, so every swipe inside it began as a tracked swipe-to-close gesture in `_wireSheetSwipe()`, and each upward `touchmove` frame wrote `translateY(0)` to the panel.

## Why it only breaks with Reduce Motion

On a phone the sheet's entrance animation (`glass-sheet-in`, or `modal-sheet-in` without glass) runs with `animation-fill-mode: forwards`. A filled animation outranks inline styles, so the write normally changes nothing: after `getAnimations().finish()` the computed transform stays `matrix(1, 0, 0, 1, 0, 0)` even with `translateY(100px)` set. Under `prefers-reduced-motion: reduce`, `glass.css` section 24 sets `animation: none`, and because it comes after the mobile rule it wins. The write then turns the panel's transform from `none` into a matrix on every swipe, and iOS drops the native scroll of `.modal-panel__body`.

## Measured

iOS 27 simulator, Safari, a probe page that loads the real `modal.js` with 40 rows (scroll range 2088 px). The same upward swipe of 350 pt starting at `scrollTop` 0, read 2.5 s after `touchend`:

| Condition | Before | After |
|---|---|---|
| Reduce Motion on (real setting, `matchMedia` true) | 30 px | 500 px |
| Animation off via `animation: none` (same computed state) | 0 px, 20 px | 649 px, 675 px |
| Default motion | 374 px (read at 800 ms) | not measured |

Style mutations on the panel per swipe: 2 before, 0 after. Measured on `70348d7a`; `ce4b20ee` only adds the 10 px slop below, inside which nothing is written either.

## Change

- An upward movement of more than 10 px before the sheet has been pulled is content scrolling: the gesture lets go and never touches the panel's style.
- Below that threshold - the same one the downward direction already used, now one constant `SHEET_SWIPE_SLOP_PX` - nothing is decided, so a finger that wobbles upward as it lands can still pull the sheet closed (review on this PR).
- A pull that has already started stays tracked when the finger reverses, so `touchend` still resets the panel - the stuck state `b7c0312c` fixed. The reset happens once instead of on every frame.
- `__test.wireSheetSwipe` exposes the gesture to tests.

## Tests

- `test:modal-utils` 48/48 with three new cases: an upward swipe writes nothing to the panel; an 8 px upward wobble still lets the swipe pull the sheet; a started pull stays tracked, is reset once and cleared on `touchend`. Counter-checks: with the old upswing line restored, the first and third fail; with the lock committing on the first upward pixel, only the wobble case fails.
- `test:frontend-audit` 380/380, `test:changelog` 28/28.

Not covered and left alone here: with default motion the filled animation still outranks the inline transform, so the sheet does not visibly follow the finger while pulling down (closing past 80 px works). That predates this change.

Touches the UI, so it rides the next Tuesday release.
