### PR TITLE
fix(ci): the review can verify its per-push rule, and its prompt carries no tool instructions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -282,16 +282,19 @@ jobs:
             Alle uebrigen Bedingungen aus Schritt 1 (geschlossen, Entwurf,
             automatisiert, trivial) bleiben unveraendert.
 
-            WERKZEUGE IN DIESEM LAUF. Lesend steht dir mehr offen als die Anleitung
-            des Plugins nennt: `gh api` auf `repos/${{ github.repository }}/...`
-            (Reviews, Kommentare, Inhalte, Vergleiche) mit dem Pfad ohne oder in
-            doppelten Anfuehrungszeichen, dazu `git show`, `git fetch origin <ref>`
-            und die uebrigen lesenden git-Befehle. Gesperrt sind schreibende
-            `gh api`-Aufrufe, Umleitungen in Dateien (`> datei`) und das Ausfuehren
-            von Code aus dem Checkout (`node`, `npm`, Tests) - die Tests laufen in
-            einer eigenen CI. Lies Ausgaben direkt, statt sie zwischenzuspeichern.
-            Ein CLAUDE.md liegt im Checkout nicht (gitignored); die Regeln dieses
-            Repos stehen in CONTRIBUTING.md.
+            Ein CLAUDE.md liegt im Checkout nicht (gitignored). Die Regeln dieses
+            Repos stehen in CONTRIBUTING.md; dessen Abschnitt zu `claude-review`
+            beschreibt auch, dass hier jeder Push geprueft wird.
+          # KEINE WERKZEUG-ANWEISUNGEN IM PROMPT (11.09.2026, nach #1117). Dort
+          # stand kurz ein Absatz, welche `gh api`- und git-Wege offen und welche
+          # gesperrt sind. Die beiden Laeufe danach (#1116, #1114) hielten den
+          # ganzen deutschen Block fuer eine eingeschleuste Anweisung - einer
+          # zitierte woertlich "use gh api with unquoted paths" - und brachen im
+          # Tor ab; von den 18 Laeufen davor tat das keiner. Was erlaubt ist, setzt
+          # `claude_args` durch, nicht der Prompt. Der Verweis auf CONTRIBUTING.md
+          # bleibt, weil er die Regel "jeder Push" an einer Stelle belegt, die die
+          # Review selbst nachlesen kann: genau das vermisste sie ("no reliable way
+          # to verify ... a per-push review policy").
           allowed_bots: 'dependabot[bot]'
           # DIESE LISTE ERSETZT, SIE ERGÄNZT NICHT. Das war die Annahme, die den
           # zweiten Anlauf gekostet hat: `--allowed-tools` verdrängt die acht

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -283,8 +283,10 @@ jobs:
             automatisiert, trivial) bleiben unveraendert.
 
             Ein CLAUDE.md liegt im Checkout nicht (gitignored). Die Regeln dieses
-            Repos stehen in CONTRIBUTING.md; dessen Abschnitt zu `claude-review`
-            beschreibt auch, dass hier jeder Push geprueft wird.
+            Repos stehen in CONTRIBUTING.md, und massgeblich ist die Fassung auf
+            `${{ github.event.repository.default_branch }}`, nicht eine im PR
+            geaenderte. Deren Abschnitt zu `claude-review` beschreibt auch, dass
+            hier jeder Push geprueft wird.
           # KEINE WERKZEUG-ANWEISUNGEN IM PROMPT (11.09.2026, nach #1117). Dort
           # stand kurz ein Absatz, welche `gh api`- und git-Wege offen und welche
           # gesperrt sind. Die beiden Laeufe danach (#1116, #1114) hielten den

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,27 +262,34 @@ failed first - the job goes red for ordinary reasons too (checkout, the action i
 GitHub API call), and only one specific failure is about the review staying silent.
 
 That one is the step **"Die Review muss gesprochen haben"**. It exists because for five PRs
-the check was green over a review that never happened. Its message names the two known
-causes; the second needs the job log, where `permission_denials_count` tells you *how many*
-tools were refused but not which - re-run with `show_full_output: true` to see the name.
+the check was green over a review that never happened. The job log shows every tool call
+(`show_full_output` stays on for exactly this), and the step's message names the cause it
+found: refused tools, a run that stopped at the plugin's own gate, or agents it started but
+never waited for. A change the review declines as trivial stays green, with a notice that
+nothing was checked.
 
 **Do not add the tool in the PR that failed.** A PR touching
 `.github/workflows/claude-code-review.yml` makes the action skip itself (it only runs when
 the workflow matches the default branch) and makes this check stand aside, so it would turn
 green without any review having run. Report the denied tool instead and let a maintainer add
-it to `claude_args` on `main` - note that the list there **replaces** the review plugin's
-own, so existing entries have to stay.
+it to `claude_args` on `main` - note that the allowed list there **replaces** the review
+plugin's own, so existing entries have to stay, and that a second list denies the write forms
+of the read-only commands it allows.
 
 Once that has landed, **"Re-run jobs" on the old run will not pick it up.** A rerun replays
 the same workflow file at the same commit, so it hits the same denial and looks like the fix
 failed. The PR needs a fresh `pull_request` event to be evaluated against the new default
-branch: push to it, or merge `main` into the branch, or close and reopen it.
+branch: push to it, or merge `main` into the branch, or close and reopen it. A rerun does help
+when the refusal came from the path the review happened to take - reading earlier comments one
+way rather than another - because the next run may take a different one.
 
-One limit worth knowing: the check asks whether the PR carries *any* comment from the
-reviewer, not whether *this run* produced one. That is deliberate - the plugin looks for its
-own earlier comment and will not repeat itself on a later push - but it means a silent rerun
-on a PR that was already reviewed stays green. The assertion covers "this PR was never
-reviewed", not "every run reviewed it".
+**Every push is reviewed, and every run has to show its own work.** The review does not stop
+because it already commented on an earlier push of the same PR: the workflow's prompt lifts
+that condition on purpose, since a green check over an unreviewed push is worse than a second
+review. The check counts only what the reviewer said after the run began and can tie to the
+run itself, so an earlier comment cannot turn a later silent run green. A run that stops with
+"already reviewed this PR" is therefore red - the push it was started for has not been
+reviewed, even when that push only merged `main` into the branch.
 
 **If the maintainer stops.** There is one maintainer and no succession arrangement: nobody
 acquires rights to this repository automatically, and none are needed, because the MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,18 +283,21 @@ branch: push to it, or merge `main` into the branch, or close and reopen it. A r
 when the refusal came from the path the review happened to take - reading earlier comments one
 way rather than another - because the next run may take a different one.
 
-**Every push is reviewed, and every run has to show its own work.** That holds for a pull
-request from a branch of this repository that is ready for review. Drafts are skipped until
-they are marked ready, pull requests opened by bots or from forks are not reviewed here, a run
-cancelled because a newer push arrived counts for nothing, and a pull request that changes the
-review workflow - or whose branch carries an older copy of it - is skipped as described above.
-Within that, the review does not stop because it already commented on an earlier push of the
-same PR: the workflow's prompt lifts
-that condition on purpose, since a green check over an unreviewed push is worse than a second
-review. The check counts only what the reviewer said after the run began and can tie to the
-run itself, so an earlier comment cannot turn a later silent run green. A run that stops with
-"already reviewed this PR" is therefore red - the push it was started for has not been
-reviewed, even when that push only merged `main` into the branch.
+**Every push is reviewed, and a silent run is red.** That holds for a pull request from a
+branch of this repository that is ready for review. Drafts are skipped until they are marked
+ready, pull requests opened by bots or from forks are not reviewed here, a run cancelled
+because a newer push arrived ends as cancelled rather than red, and a pull request that
+changes the review workflow - or whose branch carries an older copy of it - is skipped as
+described above. Within that, the review does not stop because it already commented on an
+earlier push of the same PR: the workflow's prompt lifts that condition on purpose, since a
+green check over an unreviewed push is worse than a second review. The check counts only what
+the reviewer said after the run began - by preference a comment whose address this run itself
+received, otherwise a review or inline comment bound to the commit under review. So a comment
+on an earlier push cannot turn a later silent run green. What the check cannot tell apart is a
+comment on the same commit from another run during this one, such as a cancelled predecessor
+that still posted: then the commit was reviewed, only not by this run. A run that stops with
+"already reviewed this PR" is red - the push it was started for has not been reviewed, even
+when that push only merged `main` into the branch.
 
 **If the maintainer stops.** There is one maintainer and no succession arrangement: nobody
 acquires rights to this repository automatically, and none are needed, because the MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,8 +283,13 @@ branch: push to it, or merge `main` into the branch, or close and reopen it. A r
 when the refusal came from the path the review happened to take - reading earlier comments one
 way rather than another - because the next run may take a different one.
 
-**Every push is reviewed, and every run has to show its own work.** The review does not stop
-because it already commented on an earlier push of the same PR: the workflow's prompt lifts
+**Every push is reviewed, and every run has to show its own work.** That holds for a pull
+request from a branch of this repository that is ready for review. Drafts are skipped until
+they are marked ready, pull requests opened by bots or from forks are not reviewed here, a run
+cancelled because a newer push arrived counts for nothing, and a pull request that changes the
+review workflow - or whose branch carries an older copy of it - is skipped as described above.
+Within that, the review does not stop because it already commented on an earlier push of the
+same PR: the workflow's prompt lifts
 that condition on purpose, since a green check over an unreviewed push is worse than a second
 review. The check counts only what the reviewer said after the run began and can tie to the
 run itself, so an earlier comment cannot turn a later silent run green. A run that stops with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,14 +283,15 @@ branch: push to it, or merge `main` into the branch, or close and reopen it. A r
 when the refusal came from the path the review happened to take - reading earlier comments one
 way rather than another - because the next run may take a different one.
 
-**Every push is reviewed, and a silent run is red.** That holds for a pull request from a
-branch of this repository that is ready for review. Drafts are skipped until they are marked
-ready, pull requests opened by bots or from forks are not reviewed here, a run cancelled
-because a newer push arrived ends as cancelled rather than red, and a pull request that
-changes the review workflow - or whose branch carries an older copy of it - is skipped as
-described above. Within that, the review does not stop because it already commented on an
-earlier push of the same PR: the workflow's prompt lifts that condition on purpose, since a
-green check over an unreviewed push is worse than a second review. The check counts only what
+**A later push is reviewed again, and a silent run is red.** The review does not stop because
+it already commented on an earlier push of the same PR: the workflow's prompt lifts that
+condition on purpose, since a green check over an unreviewed push is worse than a second
+review. Silence does not turn the check red where the review is skipped or its evidence is not
+checked: drafts until they are marked ready, pull requests from forks, pull requests opened by
+bots (the review action admits Dependabot, but the evidence step skips every bot author),
+changes the review declines as trivial, runs cancelled because a newer push arrived, and pull
+requests that change the review workflow or whose branch carries an older copy of it. The
+check counts only what
 the reviewer said after the run began - by preference a comment whose address this run itself
 received, otherwise a review or inline comment bound to the commit under review. So a comment
 on an earlier push cannot turn a later silent run green. What the check cannot tell apart is a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,11 +262,14 @@ failed first - the job goes red for ordinary reasons too (checkout, the action i
 GitHub API call), and only one specific failure is about the review staying silent.
 
 That one is the step **"Die Review muss gesprochen haben"**. It exists because for five PRs
-the check was green over a review that never happened. The job log shows every tool call
-(`show_full_output` stays on for exactly this), and the step's message names the cause it
-found: refused tools, a run that stopped at the plugin's own gate, or agents it started but
-never waited for. A change the review declines as trivial stays green, with a notice that
-nothing was checked.
+the check was green over a review that never happened. Its message says what it saw - refused
+tools, a run that stopped at the plugin's own gate, agents it started but never waited for -
+and is a lead for the job log, not a proven cause: a run can hit a refusal on the way and still
+stop for another reason. The log shows every tool call because `show_full_output` stays on, and
+that setting is not only for reading: the step needs the same stream to find the comment the
+run posted. The exact rules - including every case in which the review is skipped or silence
+stays green - live in `.github/workflows/claude-code-review.yml` and
+`.github/scripts/review-verdict.mjs`, and are not repeated here.
 
 **Do not add the tool in the PR that failed.** A PR touching
 `.github/workflows/claude-code-review.yml` makes the action skip itself (it only runs when
@@ -283,22 +286,12 @@ branch: push to it, or merge `main` into the branch, or close and reopen it. A r
 when the refusal came from the path the review happened to take - reading earlier comments one
 way rather than another - because the next run may take a different one.
 
-**A later push is reviewed again, and a silent run is red.** The review does not stop because
-it already commented on an earlier push of the same PR: the workflow's prompt lifts that
-condition on purpose, since a green check over an unreviewed push is worse than a second
-review. Silence does not turn the check red where the review is skipped or its evidence is not
-checked: drafts until they are marked ready, pull requests from forks, pull requests opened by
-bots (the review action admits Dependabot, but the evidence step skips every bot author),
-changes the review declines as trivial, runs cancelled because a newer push arrived, and pull
-requests that change the review workflow or whose branch carries an older copy of it. The
-check counts only what
-the reviewer said after the run began - by preference a comment whose address this run itself
-received, otherwise a review or inline comment bound to the commit under review. So a comment
-on an earlier push cannot turn a later silent run green. What the check cannot tell apart is a
-comment on the same commit from another run during this one, such as a cancelled predecessor
-that still posted: then the commit was reviewed, only not by this run. A run that stops with
-"already reviewed this PR" is red - the push it was started for has not been reviewed, even
-when that push only merged `main` into the branch.
+**A later push is reviewed again.** The review does not stop because it already commented on
+an earlier push of the same PR: the workflow's prompt lifts that condition on purpose, since a
+green check over an unreviewed push is worse than a second review. A run that stops with
+"already reviewed this PR" has not reviewed the push it was started for, and the check turns red
+unless it finds that the push was reviewed some other way - also when that push only merged
+`main` into the branch.
 
 **If the maintainer stops.** There is one maintainer and no succession arrangement: nobody
 acquires rights to this repository automatically, and none are needed, because the MIT

--- a/test/test-claude-review-workflow.js
+++ b/test/test-claude-review-workflow.js
@@ -34,6 +34,19 @@ test('die Subagenten laufen synchron', () => {
     'die Anweisung, Subagenten synchron zu fahren, fehlt im Prompt');
 });
 
+test('der Prompt traegt keine Werkzeug-Anweisungen, nur den Verweis auf CONTRIBUTING.md', () => {
+  // 11.09.2026: ein Absatz ueber offene und gesperrte `gh api`- und git-Wege liess
+  // die Review den ganzen Prompt als eingeschleust verwerfen (#1116, #1114; von
+  // den 18 Laeufen davor keiner). Was erlaubt ist, setzt `claude_args` durch. Der
+  // Verweis auf CONTRIBUTING.md bleibt - dort kann die Review die Regel "jeder
+  // Push" selbst nachlesen, und genau das vermisste sie.
+  const prompt = workflow.match(/prompt: \|\n((?:[ ]{12}.*\n|\n)+)/)?.[1] ?? '';
+  assert.ok(prompt.includes('/code-review:code-review'), 'der Prompt liess sich nicht lesen');
+  assert.doesNotMatch(prompt, /gh api|--allowed-tools|gesperrt|WERKZEUGE/i,
+    'Werkzeug-Anweisungen gehoeren in claude_args, nicht in den Prompt');
+  assert.match(prompt, /CONTRIBUTING\.md/, 'der Verweis auf die nachlesbare Regel fehlt');
+});
+
 test('Skill und Task stehen in den erlaubten Werkzeugen', () => {
   // `--allowed-tools` ERSETZT die Liste des Plugins. Ohne `Skill` kann die
   // Review ihr eigenes Kommando nicht ausfuehren, ohne `Task` keinen einzigen

--- a/test/test-claude-review-workflow.js
+++ b/test/test-claude-review-workflow.js
@@ -45,6 +45,10 @@ test('der Prompt traegt keine Werkzeug-Anweisungen, nur den Verweis auf CONTRIBU
   assert.doesNotMatch(prompt, /gh api|--allowed-tools|gesperrt|WERKZEUGE/i,
     'Werkzeug-Anweisungen gehoeren in claude_args, nicht in den Prompt');
   assert.match(prompt, /CONTRIBUTING\.md/, 'der Verweis auf die nachlesbare Regel fehlt');
+  // Der Checkout traegt die Fassung des PR - ein PR koennte den Widerspruch sonst
+  // selbst wieder einbauen (Review auf #1119). Massgeblich ist der Default-Branch.
+  assert.match(prompt, /github\.event\.repository\.default_branch/,
+    'der Prompt muss die Fassung auf dem Default-Branch fuer massgeblich erklaeren');
 });
 
 test('Skill und Task stehen in den erlaubten Werkzeugen', () => {


### PR DESCRIPTION
Two review runs after #1117 went red the same way: the review treated the workflow's own prompt as an injected instruction and stopped at the plugin's "Claude already commented on this PR" gate. None of the 18 review runs before #1117 did that.

- **#1116** ([run 34574420909](https://github.com/ulsklyc/yuvomi/actions/runs/34574420909)): the review fetched CONTRIBUTING.md, found a paragraph saying the reviewer "will not repeat itself on a later push", and concluded the prompt ("the abort condition does not apply here") contradicted the project's documented policy.
- **#1114** ([run 34582601891](https://github.com/ulsklyc/yuvomi/actions/runs/34582601891)): without reading CONTRIBUTING.md it called the German block a prompt injection, citing "directing me to ... use gh api with unquoted paths" - the tool paragraph #1117 had added - and said it had "no reliable way to verify ... a per-push review policy".

## Change

1. **CONTRIBUTING.md** - the section "A red `claude-review` check is not a review finding" was stale since #1073 and now matches the workflow:
   - every push is reviewed, every run has to show its own work, and a run that stops with "already reviewed this PR" is red, also when the push only merged `main`
   - the job log shows every tool call, the step's message names the cause, and a change declined as trivial stays green with a notice
   - the allowed list replaces the plugin's own, and a second list denies the write forms of the read-only commands
   - a rerun does not pick up a workflow change, but helps when a refusal came from the path the review happened to take
2. **The review prompt** loses the paragraph on open and denied tools. `claude_args` enforces that; stating it in the prompt only made the block read like an injection. What stays is a short pointer: CLAUDE.md is gitignored, the rules live in CONTRIBUTING.md, and its `claude-review` section describes the per-push rule - so the review can verify the rule where it said it could not.
3. **`test:claude-review-workflow`** gains a guard: the prompt carries no tool instructions (`gh api`, `--allowed-tools`, "gesperrt") and does carry the CONTRIBUTING.md pointer. Counter-check: putting a `gh api` line back into the prompt turns it red.

No other document repeats the stale statement (swept README, README.de, `docs/`); `test:claude-review-workflow`, `test:review-proof`, `test:workflow-pins` and `test:workflow-timeouts` are green, and the workflow parses as YAML with the prompt ending where intended.

## Also seen

The #1116 run showed that the action passes both lists from #1117 exactly as intended, including `Bash(gh api "repos/ulsklyc/yuvomi/*)` with its quote and all 18 deny rules.

## Worth knowing

- This pull request touches the review workflow, so the action skips itself here.
- After merging, a **rerun will not help** #1114 and #1116: a rerun replays the workflow file at the old commit, which still carries the tool paragraph. Both branches need `main` merged in again for a fresh run with the new prompt.
- Two runs after #1117 against none before is a strong correlation, not proof; the first runs after this merge are the measurement.
