### PR TITLE
fix(ci): read every mention of "already reviewed" for the gate diagnosis (#1101)

### DIFF
--- a/.github/scripts/review-verdict.mjs
+++ b/.github/scripts/review-verdict.mjs
@@ -101,6 +101,28 @@ export function bejaht(text, muster) {
 }
 
 /**
+ * Wie `bejaht`, aber JEDER Treffer zaehlt: reicht einer ohne Verneiner davor?
+ *
+ * Fuer die Abbruch-Diagnose `schon-kommentiert` (#1101). "Claude has not
+ * already reviewed this HEAD. Claude has already reviewed this PR, so I should
+ * stop here." verneint die erste Erwaehnung und bejaht die zweite; `bejaht`
+ * las nur die erste und machte daraus `unbekannt`. Dieselbe Form wie in
+ * `hoertAuf`, dasselbe Fenster wie in `bejaht`.
+ *
+ * NICHT fuer die Tor-Ausnahme. Die kann gruen machen, und dort ist die engere
+ * Lesart die sichere Richtung - diese hier waehlt nur zwischen roten Diagnosen.
+ */
+export function bejahtIrgendwo(text, muster) {
+  const roh = String(text ?? '');
+  const flags = muster.flags.includes('g') ? muster.flags : `${muster.flags}g`;
+  for (const treffer of roh.matchAll(new RegExp(muster.source, flags))) {
+    const von = Math.max(0, treffer.index - FENSTER);
+    if (!VERNEINER.test(roh.slice(von, treffer.index + treffer[0].length))) return true;
+  }
+  return false;
+}
+
+/**
  * Sagt der Text, dass er aufhoert - und verneint er das NICHT?
  *
  * Nicht ueber `bejaht`, und der Unterschied ist Absicht. Zwei der Aufhoer-Formeln
@@ -350,10 +372,12 @@ export function beurteile({
   // Stand geprueft hat und am Posten scheiterte, galt damit als Abbruch im Tor,
   // und die Meldung schickte den Leser zum Prompt statt zur Werkzeugsperre.
   // Geprueft ueber `hoertAuf` und nicht ueber `bejaht` - warum, steht dort.
+  // Die Erwaehnung selbst ebenso ueber JEDEN Treffer (`bejahtIrgendwo`, #1101):
+  // eine verneinte erste Erwaehnung verdeckte sonst eine bejahte spaetere.
   if (
     gepostet.erfolge === 0 &&
     zahl.gebunden === 0 &&
-    bejaht(text, SCHON_KOMMENTIERT) &&
+    bejahtIrgendwo(text, SCHON_KOMMENTIERT) &&
     hoertAuf(text)
   ) {
     return stumm('schon-kommentiert', neu, seit, ergebnis, zahl.gebunden, gepostet.erfolge);

--- a/.github/scripts/review-verdict.mjs
+++ b/.github/scripts/review-verdict.mjs
@@ -111,13 +111,18 @@ export function bejaht(text, muster) {
  *
  * NICHT fuer die Tor-Ausnahme. Die kann gruen machen, und dort ist die engere
  * Lesart die sichere Richtung - diese hier waehlt nur zwischen roten Diagnosen.
+ *
+ * DAS FENSTER ENDET AM SATZENDE DAVOR, wie in `hoertAuf` (Codex zu #1121). Ein
+ * kurzer verneinter Satz liegt sonst noch in den 30 Zeichen vor der naechsten
+ * Erwaehnung: "Claude has not already reviewed. Has already reviewed, so I
+ * should stop here." verneinte beide.
  */
 export function bejahtIrgendwo(text, muster) {
   const roh = String(text ?? '');
   const flags = muster.flags.includes('g') ? muster.flags : `${muster.flags}g`;
   for (const treffer of roh.matchAll(new RegExp(muster.source, flags))) {
-    const von = Math.max(0, treffer.index - FENSTER);
-    if (!VERNEINER.test(roh.slice(von, treffer.index + treffer[0].length))) return true;
+    const davor = roh.slice(Math.max(0, treffer.index - FENSTER), treffer.index).split(/[.!?\n]/).pop();
+    if (!VERNEINER.test(davor + treffer[0])) return true;
   }
   return false;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A review run that stopped at its gate is named as such, even when it first denied having
+  reviewed** (#1101). The check behind the automated review reads the run's closing text to say
+  why a silent run went red. It only looked at the first mention of "already reviewed", so a text
+  that negated it once and then affirmed it ("has not already reviewed this HEAD ... has already
+  reviewed this PR, so I should stop here") was diagnosed as unknown, pointing at a missing post
+  instead of the gate. Every mention now counts, the way every "stop" already did. The check was
+  red either way; only its message changes. The one exception that can turn it green still reads
+  the narrower way.
+
 - **The event detail names the day a multi-day event ends** (#1102). The "When" row showed the
   start date and, of the end, only the time: an event from 10 September 14:00 to 12 September 11:00
   read as "14:00 - 11:00" on a single day that ends before it begins, and an all-day event across

--- a/test/test-review-proof.js
+++ b/test/test-review-proof.js
@@ -30,7 +30,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import {
-  adressenImStrom, beurteile, bejaht, zaehleBelege, zaehleSeit
+  adressenImStrom, beurteile, bejaht, bejahtIrgendwo, zaehleBelege, zaehleSeit
 } from '../.github/scripts/review-verdict.mjs';
 
 const fixture = JSON.parse(
@@ -1094,4 +1094,35 @@ test('ein spaeteres bejahtes Aufhoeren zaehlt auch nach einem verneinten (#1096,
     gepostet: NICHTS
   });
   assert.equal(urteil.grund, 'schon-kommentiert');
+});
+
+test('eine spaetere bejahte Erwaehnung zaehlt auch nach einer verneinten (#1101)', () => {
+  // Dieselbe Luecke wie beim Aufhoeren, eine Bedingung weiter vorn: `bejaht`
+  // sah nur die ERSTE Erwaehnung von "schon geprueft". Verneint im ersten Satz,
+  // bejaht im zweiten, und der Lauf hat aufgehoert - die Diagnose lautete
+  // trotzdem `unbekannt` und schickte den Leser zum fehlenden `--comment` statt
+  // zum Tor, das den Lauf angehalten hat. Rot war der Haken in beiden Faellen.
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: {
+      num_turns: 4, subtype: 'success', is_error: false, permission_denials: [],
+      result: 'Claude has not already reviewed this HEAD. Claude has already reviewed this PR, so I should stop here.'
+    },
+    aeusserungen: [],
+    gepostet: NICHTS
+  });
+  assert.equal(urteil.grund, 'schon-kommentiert');
+});
+
+test('bejahtIrgendwo liest jede Erwaehnung, bejaht weiter nur die erste (#1101)', () => {
+  const muster = /already\s+(?:left\s+a\s+comment|commented|posted|reviewed)/i;
+  const gemischt = 'Claude has not already reviewed this HEAD. Claude has already reviewed this PR.';
+  assert.equal(bejahtIrgendwo(gemischt, muster), true);
+  // Die Tor-Ausnahme, die GRUEN machen kann, prueft weiter ueber `bejaht`: dort
+  // bleibt die engere Lesart die sichere Richtung.
+  assert.equal(bejaht(gemischt, muster), false);
+  assert.equal(bejahtIrgendwo('Claude has not already commented. It has never already posted.', muster), false);
+  assert.equal(bejahtIrgendwo('', muster), false);
+  assert.equal(bejahtIrgendwo(undefined, muster), false);
 });

--- a/test/test-review-proof.js
+++ b/test/test-review-proof.js
@@ -1125,4 +1125,21 @@ test('bejahtIrgendwo liest jede Erwaehnung, bejaht weiter nur die erste (#1101)'
   assert.equal(bejahtIrgendwo('Claude has not already commented. It has never already posted.', muster), false);
   assert.equal(bejahtIrgendwo('', muster), false);
   assert.equal(bejahtIrgendwo(undefined, muster), false);
+  // Das Fenster endet am Satzende davor (Codex zu #1121): ein kurzer verneinter
+  // Satz lag sonst noch in den 30 Zeichen vor der naechsten Erwaehnung.
+  assert.equal(bejahtIrgendwo('Claude has not already reviewed. Has already reviewed, so I should stop here.', muster), true);
+});
+
+test('ein kurzer verneinter Satz verneint die naechste Erwaehnung nicht mit (#1121, Codex P2)', () => {
+  const urteil = beurteile({
+    seit: seit(ABBRUCH_LAUF),
+    kopf: kopf(ABBRUCH_LAUF),
+    ergebnis: {
+      num_turns: 4, subtype: 'success', is_error: false, permission_denials: [],
+      result: 'Claude has not already reviewed. Has already reviewed, so I should stop here.'
+    },
+    aeusserungen: [],
+    gepostet: NICHTS
+  });
+  assert.equal(urteil.grund, 'schon-kommentiert');
 });


### PR DESCRIPTION
Part 1 of #1101: the gate diagnosis reads every mention of "already reviewed", not just the first.

## What changed

`beurteile()` chose `schon-kommentiert` only if `bejaht(text, SCHON_KOMMENTIERT)` held, and `bejaht` looks at the first match. A closing text that negated the mention once and affirmed it later fell through to `unbekannt`:

> Claude has not already reviewed this HEAD. Claude has already reviewed this PR, so I should stop here.

The new `bejahtIrgendwo()` reads every match with the same 30-character window as `bejaht`, the shape `hoertAuf()` already has. Only the `schon-kommentiert` branch uses it. That branch chooses between red diagnoses; the trivial exception, the one path that can turn the check green, keeps the narrower reading.

The check was red in both cases. What changes is the message: it now points at the prompt gate instead of a missing post.

## Tests

- Follow-up from review (f5ccc8e3): the negation window ends at the sentence before each mention, as in `hoertAuf`. Counterproof: without the cut, the two new assertions go red.

- `test:review-proof` 60/60, `test:claude-review-workflow` 23/23, `test:changelog` 28/28.
- Counterproof: with the branch back on `bejaht`, exactly the new test `eine spaetere bejahte Erwaehnung zaehlt auch nach einer verneinten (#1101)` goes red (58/59 at the time; the sentence-boundary follow-up from review adds one more case, see f5ccc8e3).

## Part 2 of the issue, measured and deliberately not built

The issue asked for a measurement before carrying `updated_at` for an edited summary (`gh pr comment --edit-last`). Measured today, read-only:

- **What moves `updated_at`:** 307 comments on the last 100 PRs. 7 have `updatedAt != createdAt`, and all 7 carry `lastEditedAt`. Of the 5 comments with reactions, 4 have `updatedAt == createdAt`; the fifth was edited. So a reaction does not move `updated_at`, an edit does. No minimized comment was in the sample, so minimizing stays unmeasured.
- **Does the review ever edit its summary:** 59 claude comments in that sample, 0 edited. The logs of the last 52 `claude-code-review` runs contain `edit-last` exactly once, in run 34360513636 (#1085), and that hit is prose inside a review finding ("exclude `--help`/`--delete-last`/`--edit-last`"), not a command. The same logs show `gh pr comment` invocations, so the search does reach commands.

The false red this would fix has not happened once. Carrying `updated_at` would widen the evidence window for a case with zero occurrences, and this module errs towards red. My recommendation: leave it, and close #1101 with this measurement. If a run ever edits its summary, the red check will name it.

Refs #1101

