### PR TITLE
feat(calendar): open an event's location in a map (#1110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **An event's location opens in a map** (#1110, from discussion #1047). The event detail carries
+  an "Open in Maps" action whenever the event has a location; it opens an OpenStreetMap search for
+  that text in a new tab, the same search Contacts already uses for an address. It is an explicit
+  action rather than a link on the location itself, because the field is free text: "Zoom" or
+  "Room 3B" is not an address, and the action never claims it is. The link is built on the device
+  and used only when tapped - no geocoding, nothing looked up in advance. An address imported over
+  CalDAV with escaped line breaks is searched as one line.
+
 - **A shopping item can carry a price and the shop it was bought at** (#1003, first cut). Both sit
   in the item dialog, where the item is already open - the checkbox stays the fastest gesture in the
   app and gains no second step. The price is stored in whole minor units (cents, yen, fils) rather

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "عامل تصفية واحد نشط",
         "filtersReset": "إزالة كل عوامل التصفية",
         "filtersDisplay": "العرض",
-        "agendaDayEmpty": "لا شيء مُخطط"
+        "agendaDayEmpty": "لا شيء مُخطط",
+        "openInMap": "فتح في الخرائط"
     },
     "noteCategories": {
         "permissionLabel": "إدارة فئات ملاحظات الأسرة"

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 aktivní filtr",
         "filtersReset": "Zrušit všechny filtry",
         "filtersDisplay": "Zobrazení",
-        "agendaDayEmpty": "Nic naplánováno"
+        "agendaDayEmpty": "Nic naplánováno",
+        "openInMap": "Otevřít v Mapách"
     },
     "noteCategories": {
         "permissionLabel": "Spravovat domácí kategorie poznámek"

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -959,7 +959,8 @@
         "filtersActive_one": "1 Filter aktiv",
         "filtersReset": "Alle Filter aufheben",
         "filtersDisplay": "Darstellung",
-        "agendaDayEmpty": "Nichts geplant"
+        "agendaDayEmpty": "Nichts geplant",
+        "openInMap": "In Maps öffnen"
     },
     "noteCategories": {
         "permissionLabel": "Gemeinsame Notizkategorien verwalten"

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 ενεργό φίλτρο",
         "filtersReset": "Κατάργηση όλων των φίλτρων",
         "filtersDisplay": "Εμφάνιση",
-        "agendaDayEmpty": "Τίποτα προγραμματισμένο"
+        "agendaDayEmpty": "Τίποτα προγραμματισμένο",
+        "openInMap": "Άνοιγμα στους Χάρτες"
     },
     "noteCategories": {
         "permissionLabel": "Διαχείριση κοινόχρηστων κατηγοριών σημειώσεων"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filter active",
         "filtersReset": "Clear all filters",
         "filtersDisplay": "Display",
-        "agendaDayEmpty": "Nothing planned"
+        "agendaDayEmpty": "Nothing planned",
+        "openInMap": "Open in Maps"
     },
     "noteCategories": {
         "permissionLabel": "Manage household note categories"

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filtro activo",
         "filtersReset": "Quitar todos los filtros",
         "filtersDisplay": "Visualización",
-        "agendaDayEmpty": "Nada planeado"
+        "agendaDayEmpty": "Nada planeado",
+        "openInMap": "Abrir en Maps"
     },
     "noteCategories": {
         "permissionLabel": "Gestionar categorías de notas del hogar"

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -959,7 +959,8 @@
         "filtersActive_one": "۱ فیلتر فعال",
         "filtersReset": "برداشتن همه فیلترها",
         "filtersDisplay": "نمایش",
-        "agendaDayEmpty": "چیزی برنامه‌ریزی نشده"
+        "agendaDayEmpty": "چیزی برنامه‌ریزی نشده",
+        "openInMap": "باز کردن در نقشه"
     },
     "noteCategories": {
         "permissionLabel": "مدیریت دسته‌بندی‌های یادداشت خانوادگی"

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -959,7 +959,8 @@
         "filtersActive_one": "1 aktibong filter",
         "filtersReset": "Alisin ang lahat ng filter",
         "filtersDisplay": "Pagpapakita",
-        "agendaDayEmpty": "Walang nakaplano"
+        "agendaDayEmpty": "Walang nakaplano",
+        "openInMap": "Buksan sa Maps"
     },
     "noteCategories": {
         "permissionLabel": "Pamahalaan ang mga kategorya ng tala ng sambahayan"

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filtre actif",
         "filtersReset": "Effacer tous les filtres",
         "filtersDisplay": "Affichage",
-        "agendaDayEmpty": "Rien de prévu"
+        "agendaDayEmpty": "Rien de prévu",
+        "openInMap": "Ouvrir dans Maps"
     },
     "noteCategories": {
         "permissionLabel": "Gérer les catégories de notes du foyer"

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 फ़िल्टर सक्रिय",
         "filtersReset": "सभी फ़िल्टर हटाएँ",
         "filtersDisplay": "प्रदर्शन",
-        "agendaDayEmpty": "कुछ भी नियोजित नहीं"
+        "agendaDayEmpty": "कुछ भी नियोजित नहीं",
+        "openInMap": "मानचित्र में खोलें"
     },
     "noteCategories": {
         "permissionLabel": "घर की नोट श्रेणियाँ प्रबंधित करें"

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 aktív szűrő",
         "filtersReset": "Összes szűrő törlése",
         "filtersDisplay": "Megjelenítés",
-        "agendaDayEmpty": "Semmi sincs tervezve"
+        "agendaDayEmpty": "Semmi sincs tervezve",
+        "openInMap": "Megnyitás a Térképen"
     },
     "noteCategories": {
         "permissionLabel": "Háztartási jegyzetkategóriák kezelése"

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -959,7 +959,8 @@
         "filtersActive_one": "1 filter aktif",
         "filtersReset": "Hapus semua filter",
         "filtersDisplay": "Tampilan",
-        "agendaDayEmpty": "Tidak ada rencana"
+        "agendaDayEmpty": "Tidak ada rencana",
+        "openInMap": "Buka di Maps"
     },
     "noteCategories": {
         "permissionLabel": "Kelola kategori catatan rumah tangga"

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filtro attivo",
         "filtersReset": "Rimuovi tutti i filtri",
         "filtersDisplay": "Visualizzazione",
-        "agendaDayEmpty": "Niente in programma"
+        "agendaDayEmpty": "Niente in programma",
+        "openInMap": "Apri in Maps"
     },
     "noteCategories": {
         "permissionLabel": "Gestisci le categorie delle note di casa"

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "フィルター 1 件が有効",
         "filtersReset": "すべてのフィルターを解除",
         "filtersDisplay": "表示",
-        "agendaDayEmpty": "予定なし"
+        "agendaDayEmpty": "予定なし",
+        "openInMap": "地図で開く"
     },
     "noteCategories": {
         "permissionLabel": "世帯のメモカテゴリーを管理"

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -959,7 +959,8 @@
         "filtersActive_one": "필터 1개 적용됨",
         "filtersReset": "모든 필터 해제",
         "filtersDisplay": "표시",
-        "agendaDayEmpty": "예정된 일정 없음"
+        "agendaDayEmpty": "예정된 일정 없음",
+        "openInMap": "지도에서 열기"
     },
     "noteCategories": {
         "permissionLabel": "가정 메모 카테고리 관리"

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filter actief",
         "filtersReset": "Alle filters wissen",
         "filtersDisplay": "Weergave",
-        "agendaDayEmpty": "Niets gepland"
+        "agendaDayEmpty": "Niets gepland",
+        "openInMap": "Openen in Maps"
     },
     "noteCategories": {
         "permissionLabel": "Notitiecategorieën voor het huishouden beheren"

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -959,7 +959,8 @@
         "filtersActive_one": "1 aktywny filtr",
         "filtersReset": "Wyczyść wszystkie filtry",
         "filtersDisplay": "Wyświetlanie",
-        "agendaDayEmpty": "Nic zaplanowane"
+        "agendaDayEmpty": "Nic zaplanowane",
+        "openInMap": "Otwórz w mapach"
     },
     "noteCategories": {
         "permissionLabel": "Zarządzaj domowymi kategoriami notatek"

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filtro ativo",
         "filtersReset": "Limpar todos os filtros",
         "filtersDisplay": "Apresentação",
-        "agendaDayEmpty": "Nada planeado"
+        "agendaDayEmpty": "Nada planeado",
+        "openInMap": "Abrir no Maps"
     },
     "noteCategories": {
         "permissionLabel": "Gerir categorias de notas do agregado familiar"

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 активный фильтр",
         "filtersReset": "Снять все фильтры",
         "filtersDisplay": "Отображение",
-        "agendaDayEmpty": "Ничего не запланировано"
+        "agendaDayEmpty": "Ничего не запланировано",
+        "openInMap": "Открыть в Картах"
     },
     "noteCategories": {
         "permissionLabel": "Управлять семейными категориями заметок"

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filter aktivt",
         "filtersReset": "Rensa alla filter",
         "filtersDisplay": "Visning",
-        "agendaDayEmpty": "Inget planerat"
+        "agendaDayEmpty": "Inget planerat",
+        "openInMap": "Öppna i Kartor"
     },
     "noteCategories": {
         "permissionLabel": "Hantera hushållets anteckningskategorier"

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 filtre etkin",
         "filtersReset": "Tüm filtreleri kaldır",
         "filtersDisplay": "Görünüm",
-        "agendaDayEmpty": "Planlanmış bir şey yok"
+        "agendaDayEmpty": "Planlanmış bir şey yok",
+        "openInMap": "Haritada aç"
     },
     "noteCategories": {
         "permissionLabel": "Ev notu kategorilerini yönet"

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 активний фільтр",
         "filtersReset": "Зняти всі фільтри",
         "filtersDisplay": "Відображення",
-        "agendaDayEmpty": "Нічого не заплановано"
+        "agendaDayEmpty": "Нічого не заплановано",
+        "openInMap": "Відкрити на картах"
     },
     "noteCategories": {
         "permissionLabel": "Керувати сімейними категоріями нотаток"

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 bộ lọc đang bật",
         "filtersReset": "Xóa tất cả bộ lọc",
         "filtersDisplay": "Hiển thị",
-        "agendaDayEmpty": "Không có kế hoạch"
+        "agendaDayEmpty": "Không có kế hoạch",
+        "openInMap": "Mở trong Bản đồ"
     },
     "noteCategories": {
         "permissionLabel": "Quản lý danh mục ghi chú gia đình"

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -947,7 +947,8 @@
         "filtersActive_one": "1 个筛选条件生效",
         "filtersReset": "清除所有筛选",
         "filtersDisplay": "显示",
-        "agendaDayEmpty": "没有安排"
+        "agendaDayEmpty": "没有安排",
+        "openInMap": "在地图中打开"
     },
     "noteCategories": {
         "permissionLabel": "管理家庭笔记分类"

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -3331,6 +3331,7 @@ export const __test = {
   tasksOnDay,
   eventsOnDay,
   passesPersonFilters,
+  eventMapUrl,
   eventEndDate,
   isMultiDayEvent,
   eventWhenText,
@@ -3529,6 +3530,18 @@ function eventWhenText(ev) {
 }
 
 /**
+ * Die Kartensuche zu einem Ortstext, oder '' wenn es nichts zu suchen gibt.
+ *
+ * Über `fmtLocation`, damit eine ICS-escapte, mehrzeilige Adresse als eine
+ * Zeile gesucht wird. Gebaut wird lokal; nichts verlässt das Gerät, bevor
+ * jemand die Aktion antippt (#1110).
+ */
+function eventMapUrl(location) {
+  const query = fmtLocation(location ?? '').trim();
+  return query ? `https://www.openstreetmap.org/search?query=${encodeURIComponent(query)}` : '';
+}
+
+/**
  * Die Leseinformationen eines Termins.
  *
  * Wiederholung, Erinnerungen und Sichtbarkeit standen bisher nur im
@@ -3595,6 +3608,21 @@ async function openEventDetail(ev, anchor = null) {
     // Dialog, und das Shared-Modal kennt kein Stacking.
     onClick: async ({ close }) => { await close({ force: true }); await requestDeleteEvent(ev); },
   }];
+
+  // Ort in einer Karte öffnen (#1110) - als ausdrückliche Aktion, nicht als Link
+  // auf dem Ortstext: `location` ist Freitext, und "Zoom" oder "Raum 3B" sind
+  // keine Adresse. Die Aktion behauptet das nie, der Link wird erst beim Antippen
+  // benutzt. Dieselbe Suche wie die Adresse in Kontakte.
+  const mapUrl = eventMapUrl(ev.location);
+  if (mapUrl) {
+    actions.push({
+      id: 'detail-open-map',
+      label: t('calendar.openInMap'),
+      variant: 'ghost',
+      icon: 'map-pin',
+      onClick: () => window.open(mapUrl, '_blank', 'noopener'),
+    });
+  }
 
   // ICS-Abos: Ein lokal geänderter Termin lässt sich auf das Original
   // zurücksetzen. Die Aktion gehört zum Objekt, also in die Fußzeile.

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1876,6 +1876,31 @@ test('renderDayView: zwei ueberlappende Schichten am selben Tag bekommen untersc
   });
 });
 
+test('eventMapUrl: eine Kartensuche nur, wo ein Ortstext uebrig bleibt (#1110)', () => {
+  const { eventMapUrl } = calendarHelpers;
+  assert(typeof eventMapUrl === 'function', 'eventMapUrl muss ueber __test erreichbar sein');
+  const gleich = (ist, soll, was) => assert(ist === soll, `${was}: ${JSON.stringify(ist)} statt ${JSON.stringify(soll)}`);
+  gleich(
+    eventMapUrl('Hauptstraße 5, Berlin'),
+    'https://www.openstreetmap.org/search?query=Hauptstra%C3%9Fe%205%2C%20Berlin',
+    'Adresse als Suchtext',
+  );
+  // Zeichen, die eine URL zerlegen koennten, bleiben im Suchtext.
+  gleich(
+    eventMapUrl('A&B?x=1#2'),
+    'https://www.openstreetmap.org/search?query=A%26B%3Fx%3D1%232',
+    'URL-Sonderzeichen',
+  );
+  // Ohne Ort: keine Aktion.
+  for (const leer of [null, undefined, '', '   ']) {
+    gleich(eventMapUrl(leer), '', `kein Link fuer ${JSON.stringify(leer)}`);
+  }
+  // NICHT HIER: die ICS-escapte Adresse. Der Browser-Loader ersetzt
+  // `/utils/html.js` durch einen Stub, dessen `fmtLocation` die Identitaet ist -
+  // ein Fall, der das Aufraeumen braucht, waere hier rot aus dem falschen Grund.
+  // Er steht in test:detail-view gegen das echte fmtLocation.
+});
+
 // --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------

--- a/test/test-detail-view.js
+++ b/test/test-detail-view.js
@@ -46,7 +46,7 @@ const rruleJs    = () => read('public/rrule-ui.js');
 // `common` steht bewusst nicht dabei: Der Kopf-Button nutzt mit `common.back`
 // einen Bestandskey, die Ansicht braucht dort nichts Neues.
 const NEW_KEYS = {
-  calendar:  ['detailWhen', 'detailCalendar'],
+  calendar:  ['detailWhen', 'detailCalendar', 'openInMap'],
   reminders: ['sectionTitlePlural'],
   rrule:     ['summaryUntil', 'summaryCount', 'summaryCount_one'],
   tasks:     ['statusLabel', 'detailStart', 'detailFinish', 'detailReopen', 'subtasksLabel', 'swipeView'],
@@ -315,6 +315,41 @@ test('die Termin-Detailansicht zeigt, was das alte Popup verschwieg', async () =
   assert.match(fn, /reminderSummary\(/, 'Erinnerungen im Klartext');
   assert.match(fn, /visibilityRow\(ev\.visibility\)/, 'Sichtbarkeit');
   assert.match(fn, /assignedRow\(ev\.assigned_users/, 'Zugewiesene über die geteilte Zeile');
+});
+
+test('der Ort öffnet sich als ausdrückliche Aktion in einer Karte, nicht als Link auf dem Text (#1110)', async () => {
+  const src = await calendarJs();
+  const fn = src.slice(src.indexOf('async function openEventDetail'), src.indexOf('async function loadReminderForEvent'));
+  // Die Aktion hängt an der Karten-URL, und die entsteht nur aus einem Ortstext,
+  // der nach fmtLocation etwas übrig lässt. Kodierung und Leerfall misst
+  // test:calendar, das Aufräumen der Test gleich darunter.
+  assert.match(fn, /const mapUrl = eventMapUrl\(ev\.location\);\s*if \(mapUrl\) \{\s*actions\.push\(\{/,
+    'nur mit Ort gibt es die Aktion');
+  assert.match(fn, /id: 'detail-open-map'/);
+  assert.match(fn, /label: t\('calendar\.openInMap'\)/);
+  assert.match(fn, /window\.open\(mapUrl, '_blank', 'noopener'\)/,
+    'neuer Tab ohne Zugriff zurück auf die App - wie der vCard-Export in Kontakte');
+
+  // Die Zeile "Ort" bleibt reiner Text: Freitext wie "Zoom" ist keine Adresse.
+  const detail = src.slice(src.indexOf('function renderEventDetail'), src.indexOf('async function openEventDetail'));
+  assert.match(detail, /\{ icon: 'map-pin', label: t\('calendar\.locationLabel'\), value: ev\.location \? fmtLocation\(ev\.location\) : '' \}/);
+});
+
+test('die Kartensuche räumt den Ortstext über das ECHTE fmtLocation auf (#1110)', async () => {
+  // test:calendar läuft mit dem Browser-Loader, und der ersetzt `/utils/html.js`
+  // durch einen Stub mit `fmtLocation = Identität`. Was das Aufräumen braucht,
+  // lässt sich dort nicht messen - hier ohne Loader, gegen die echte Funktion.
+  const { fmtLocation } = await import('../public/utils/html.js');
+  assert.equal(fmtLocation('Rathaus\\nMarktplatz 1\\, 12345 Musterstadt'), 'Rathaus, Marktplatz 1, 12345 Musterstadt',
+    'eine ICS-escapte, mehrzeilige Adresse wird EINE Suchzeile');
+  assert.equal(fmtLocation('\\n'), '', 'nur ein escapter Umbruch: nichts zu suchen, also keine Aktion');
+  assert.equal(fmtLocation(' , ; '), '', 'nur Trenner: ebenso');
+
+  // Und eventMapUrl benutzt genau diese Funktion, bevor es kodiert.
+  const src = await calendarJs();
+  const fn = src.slice(src.indexOf('function eventMapUrl'), src.indexOf('function renderEventDetail'));
+  assert.match(fn, /const query = fmtLocation\(location \?\? ''\)\.trim\(\);/);
+  assert.match(fn, /return query \? `https:\/\/www\.openstreetmap\.org\/search\?query=\$\{encodeURIComponent\(query\)\}` : '';/);
 });
 
 test('die Weiterleitung für Haushaltshilfe-Besuche greift vor der Detailansicht', async () => {


### PR DESCRIPTION
An "Open in Maps" action in the event detail, as specified in #1110 (from discussion #1047).

## What changed

- `eventMapUrl(location)` in `public/pages/calendar.js` builds the OpenStreetMap search Contacts already uses for an address. The text goes through `fmtLocation()` first, so an ICS-escaped multi-line address becomes one line. An empty result means no action.
- `openEventDetail()` adds a footer action `detail-open-map` (ghost, `map-pin`) only when that URL exists. It opens with `window.open(url, '_blank', 'noopener')`, the same call the vCard export in the contact detail uses. The detail view stays open.
- The location row stays plain text. The field is free text, and "Zoom" or "Room 3B" is not an address, so the action never suggests one.
- New key `calendar.openInMap` in all 24 locales. Each locale takes its existing `contacts.mapsLabel`, so Calendar and Contacts use the same wording.
- CHANGELOG entry under Added.

Nothing is looked up in advance: no geocoding, no stored coordinates, and the link is built locally.

## Tests

- `test:calendar` 141/0: encoding (`&`, `?`, `#`, non-ASCII) and the empty cases.
- `test:detail-view` 52/52: the action hangs on the URL, uses the locale key and `noopener`, and the location row stays text. The escaped-address case runs here against the real `fmtLocation`. `test:calendar` runs under the browser loader, which stubs `/utils/html.js` with `fmtLocation = identity`, so that case would have been red there for the wrong reason. I first wrote it there and caught exactly that.
- `test:frontend-audit` 380/380, `test:i18n`, `test:i18n-translated`, `test:lucide-icons`, `test:changelog` green.
- Counterproofs: `eventMapUrl` without `fmtLocation` turns only the real-`fmtLocation` test red; without `encodeURIComponent`, only the `test:calendar` test; the action without its `if (mapUrl)` guard, only the wiring test.

## In the browser

Local server on this branch, demo seed, 1280x800. Clicking "Zahnarzt - Familie" (location "Zahnarztpraxis Müller") opens the popover with Edit, Delete and "In Maps öffnen" with its icon. With `window.open` intercepted, the click passes `https://www.openstreetmap.org/search?query=Zahnarztpraxis%20M%C3%BCller`, `_blank`, `noopener`, and the popover stays open.

User-facing, so it ships with the Tuesday release.

Closes #1110
