### PR TITLE
fix(ui): put keyboard focus back after confirmations, prompts and the detail popover (#1083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Keyboard focus comes back after a confirmation, an input dialog or the calendar's detail
+  popover** (#1083). Confirm a delete, rename a list or a subtask, pick a folder to move to, and
+  the page reloads its list - which rebuilds the very button you came from. Focus fell to the page
+  body, so keyboard and screen-reader users started over at the top. These paths now put focus back
+  on the rebuilt control, or on the page itself when that control is gone: in Tasks, Shopping,
+  Documents, Health, Subscriptions, Housekeeping, Inventory, Meals, Rewards, the Schedule, Split
+  Expenses, the quick links and several Settings pages (API tokens, invitations, document storage,
+  recipe providers, calendar subscriptions and accounts). On desktop, the calendar's detail popover
+  now returns focus to the event it was opened from when it closes through Escape or one of its
+  actions; a click elsewhere still leaves focus where it went.
+
+  Where a dialog appears on only some paths - rejecting a reward redemption asks, fulfilling it does
+  not - focus is pulled back only on the path that asked. Otherwise it would land on the trigger of
+  some earlier, unrelated dialog. The guard that holds all of this learned three shapes it could not
+  see: dialogs that deliver their answer after closing (`confirmModal`, `promptModal`, `selectModal`,
+  `confirmOverModal`), a reload inside a `try` block or after an `if`, and a callback handed in as a
+  parameter.
+
 - **The event detail names the day a multi-day event ends** (#1102). The "When" row showed the
   start date and, of the end, only the time: an event from 10 September 14:00 to 12 September 11:00
   read as "14:00 - 11:00" on a single day that ends before it begins, and an all-day event across

--- a/public/components/detail-view.js
+++ b/public/components/detail-view.js
@@ -9,7 +9,7 @@
  *
  * API:
  *   openDetailView({ title, accentColor, anchor, sections, actions, edit, size, onClose })
- *   closeDetailView({ force }) → Promise<void>
+ *   closeDetailView({ force, fokus }) → Promise<void>
  *
  * Zwei Präsentationen, eine Aufrufer-API: ab 768px UND mit Anker erscheint die
  * Ansicht als verankertes Popover am Auslöser, sonst als Bottom-Sheet über
@@ -19,7 +19,7 @@
 import { t } from '/i18n.js';
 import {
   openModal, closeModal, mountFooter, refreshDirtySnapshot, forgetRestore,
-  focusFirstField, updateHeaderAction,
+  focusFirstField, updateHeaderAction, rememberFocus, restoreFocusAfterClose,
 } from '/components/modal.js';
 import { pushOverlay, dropOverlay } from '/utils/overlay-history.js';
 
@@ -562,8 +562,8 @@ function openAsPopover(opts) {
   const onKeydown = (e) => {
     if (e.key === 'Escape') {
       e.stopPropagation();
+      // Den Fokus gibt closeDetailView() an den Ausloeser zurueck (#1083).
       closeDetailView();
-      opts.anchor?.focus?.();
       return;
     }
     if (e.key !== 'Tab') return;
@@ -583,12 +583,17 @@ function openAsPopover(opts) {
   };
 
   const onOutsideClick = (e) => {
-    if (!popover.isConnected || !popover.contains(e.target)) closeDetailView();
+    // Ohne Fokus-Rueckgabe: wer daneben klickt, wollte woanders hin, und ein
+    // Sprung zurueck zum Ausloeser naehme ihm das Ziel weg.
+    if (!popover.isConnected || !popover.contains(e.target)) closeDetailView({ fokus: false });
   };
 
   activePopover = {
     el: popover,
     anchor: opts.anchor,
+    // Wie `openModal` den Ausloeser merkt - damit das Schliessen ihn auch nach
+    // einem Neuaufbau wiederfindet (#1083).
+    merker: rememberFocus(opts.anchor),
     onClose: opts.onClose,
     // Die Sheet-Praesentation erbt den Marker der Zurueck-Geste von modal.js;
     // das Popover ist der zweite Weg dieser API und braucht deshalb seinen
@@ -650,7 +655,8 @@ export function openDetailView(opts = {}) {
   // und löschte sonst gerade den, den wir eben ausgegeben haben.
   // Ohne activePopover-Prüfung würde closeDetailView() blind closeModal()
   // rufen und ein fremdes, offenes Modal schließen.
-  if (activePopover) closeDetailView();
+  // Ohne Fokus-Rueckgabe: die neue Ansicht nimmt den Fokus selbst.
+  if (activePopover) closeDetailView({ fokus: false });
 
   const token = ++viewSeq;
   activeViewToken = token;
@@ -698,22 +704,29 @@ export function openDetailView(opts = {}) {
  * und ein nicht abgewartetes Schließen ließ das Löschen bereits laufen, während
  * die Rückfrage noch im Slot hing.
  *
- * @param {{force?: boolean}} [opts]
+ * `fokus: false` gibt den Fokus im Popover NICHT an den Auslöser zurück - für
+ * den Klick daneben und für eine neue Ansicht, die ihn selbst nimmt. Das Sheet
+ * läuft über `closeModal()` und dessen eigenen Restore.
+ *
+ * @param {{force?: boolean, fokus?: boolean}} [opts]
  * @returns {Promise<void>}
  */
-export function closeDetailView({ force = false } = {}) {
+export function closeDetailView({ force = false, fokus = true } = {}) {
   activeViewToken = 0;
   if (activePopover) {
-    const { el, teardown, onClose, overlayToken } = activePopover;
+    const { el, teardown, onClose, overlayToken, merker } = activePopover;
     activePopover = null;
     teardown();
     el.remove();
     dropOverlay(overlayToken);
     if (typeof onClose === 'function') onClose();
-    // Hier wurde AN modal.js VORBEI geschlossen. Ohne dieses Verwerfen bliebe
-    // dessen Merker des vorigen Dialogs stehen, und ein spaeteres
-    // `refocusAfterRender()` setzte den Fokus in einen fremden Zusammenhang.
-    forgetRestore();
+    // Hier wurde AN modal.js VORBEI geschlossen. Der Fokus geht an den Ausloeser
+    // zurueck, mit einem eigenen Merker, damit ein `refocusAfterRender()` nach
+    // dem Neuaufbau ihn wiederfindet (#1083). Ohne Rueckgabe wird der Merker nur
+    // verworfen - der des vorigen Dialogs setzte den Fokus sonst in einen
+    // fremden Zusammenhang.
+    if (fokus && merker) restoreFocusAfterClose(merker);
+    else forgetRestore();
     return Promise.resolve();
   }
   return closeModal({ force });

--- a/public/components/modal.js
+++ b/public/components/modal.js
@@ -910,6 +910,31 @@ export function forgetRestore() {
   _lastRestore = null;
 }
 
+/**
+ * Den Fokus nach einem Schliessen AN dieser Schicht vorbei zurueckgeben - mit
+ * demselben Merker wie `_doClose` (#1083).
+ *
+ * Das Popover der Detailansicht schliesst ohne `closeModal()`. Bisher verwarf es
+ * dabei nur den fremden Merker: der Fokus fiel mit dem entfernten Popover auf
+ * `body`, und ein `refocusAfterRender()` nach dem Neuaufbau hatte nichts, worauf
+ * es sich beziehen konnte. Hier laeuft derselbe Weg wie beim Modal - Ziel
+ * bestimmen, mit Rueckfall fokussieren, Merker setzen, einen Frame spaeter
+ * nachfassen.
+ *
+ * @param {ReturnType<typeof rememberFocus>} memo  der beim Oeffnen gemerkte Ausloeser
+ * @returns {HTMLElement|null} das Element, das den Fokus tatsaechlich bekam
+ */
+export function restoreFocusAfterClose(memo) {
+  _lastRestore = null;
+  if (!memo) return null;
+  const gesetzt = _fokussiereMitRueckfall(focusRestoreTarget(memo));
+  if (gesetzt) {
+    _lastRestore = { memo, ziel: gesetzt };
+    _refocusIfDropped(memo, gesetzt);
+  }
+  return gesetzt;
+}
+
 function _doClose(overlayEl) {
   const target = overlayEl ?? activeOverlay;
   if (!target) return;

--- a/public/components/quick-links-manager.js
+++ b/public/components/quick-links-manager.js
@@ -346,6 +346,7 @@ function openQuickLinkForm(link, onDone) {
           await api.delete(`/quick-links/${link.id}`);
           window.yuvomi?.showToast(t('quickLinks.deleted'), 'success');
           await onDone();
+          refocusAfterRender();
         } catch (err) {
           window.yuvomi?.showToast(err.data?.error ?? t('common.unknownError'), 'danger');
         }

--- a/public/components/task-detail.js
+++ b/public/components/task-detail.js
@@ -132,6 +132,7 @@ export async function addSubtask(parentId, { onChanged = () => {} } = {}) {
     // Wie beim Abhaken daneben: die Umgebung trägt den Fortschrittsbalken der
     // Elternkarte, aber sie muss nichts davon zeigen.
     await onChanged();
+    refocusAfterRender();
     return res.data ?? null;
   } catch (err) {
     window.yuvomi.showToast(err.message, 'danger');

--- a/public/pages/documents.js
+++ b/public/pages/documents.js
@@ -1031,6 +1031,7 @@ async function moveFolder(folder) {
     persistExpandedFolders();
     await Promise.all([loadFolders(), loadDocuments()]);
     renderAll();
+    refocusAfterRender();
   } catch (err) {
     window.yuvomi?.showToast(err.data?.error ?? t('common.unknownError'), 'danger');
   }
@@ -1072,6 +1073,7 @@ async function renameFolder(folder) {
     // auf den Karten weiter mit dem alten Namen.
     await Promise.all([loadFolders(), loadDocuments()]);
     renderAll();
+    refocusAfterRender();
   } catch (err) {
     window.yuvomi?.showToast(err.data?.error ?? t('common.unknownError'), 'danger');
   }
@@ -1200,6 +1202,7 @@ async function deleteFolder(folder) {
   try {
     const result = await commitFolderDeletion(folder, impact, choice);
     await applyFolderDeleteResult(result, choice, selectedSubtree);
+    refocusAfterRender();
   } catch (err) {
     await handleFolderDeleteError(err, folder);
   }
@@ -1639,6 +1642,7 @@ async function moveSelected() {
     window.yuvomi?.showToast(t('documents.bulkMovedToast', { count: docs.length }), 'success');
     await loadDocuments();
     renderAll();
+    refocusAfterRender();
   } catch (err) {
     window.yuvomi?.showToast(err.data?.error ?? t('common.unknownError'), 'danger');
   }

--- a/public/pages/health.js
+++ b/public/pages/health.js
@@ -1721,7 +1721,8 @@ async function handlePrnDose(btn) {
   // Beipackzettel, kein Schloss - und wer eine Dosis wirklich frueher nimmt,
   // soll sie eintragen koennen, statt sie zu verschweigen. Der Dialog nennt
   // den Zeitpunkt, um den es geht.
-  if (!state.allowed && state.nextAllowedAt) {
+  const fruehGefragt = Boolean(!state.allowed && state.nextAllowedAt);
+  if (fruehGefragt) {
     const ok = await confirmModal(t('health.meds.prn.earlyConfirm'), {
       detail: t('health.meds.prn.earlyDetail', {
         time: prnWhenLabel(state.nextAllowedAt),
@@ -1780,6 +1781,10 @@ async function handlePrnDose(btn) {
   // Seitenaufbau.
   await reloadMedViews();
   setDoseBusy(medId, false);
+  // Nur nach der Rueckfrage: ohne sie wurde auf diesem Weg kein Dialog
+  // geschlossen, und das Nachfassen griffe auf den Merker eines frueheren zurueck
+  // (#1083). Nach `setDoseBusy`, sonst traefe es den noch gesperrten Knopf.
+  if (fruehGefragt) refocusAfterRender();
 }
 
 /**
@@ -2355,6 +2360,7 @@ async function deleteMed(med) {
     await api.delete(`/health/medications/${med.id}`);
     window.yuvomi?.showToast(t('health.meds.deleted'), 'success');
     await reloadMedViews();
+    refocusAfterRender();
   } catch (err) {
     console.error('[Health] med delete error:', err);
     window.yuvomi?.showToast(err?.data?.error || t('health.meds.deleteError'), 'danger');
@@ -2983,6 +2989,7 @@ async function deleteLabReport(report) {
     window.yuvomi?.showToast(t('health.labs.deleted'), 'success');
     if (labs.selectedReportId === report.id) labs.selectedReportId = null;
     await reloadLabs();
+    refocusAfterRender();
   } catch (err) {
     console.error('[Health] lab delete error:', err);
     window.yuvomi?.showToast(err?.data?.error || t('health.labs.deleteError'), 'danger');
@@ -3581,6 +3588,7 @@ async function deleteActivity(row) {
     await api.delete(`/health/activities/${row.id}`);
     window.yuvomi?.showToast(t('health.activity.deleted'), 'success');
     await reloadActivity();
+    refocusAfterRender();
   } catch (err) {
     console.error('[Health] activity delete error:', err);
     window.yuvomi?.showToast(err?.data?.error || t('health.activity.deleteError'), 'danger');
@@ -5219,6 +5227,7 @@ async function deletePeriod(period) {
     await api.delete(`/health/cycle/periods/${period.id}`);
     window.yuvomi?.showToast(t('health.cycle.deleted'), 'success');
     await reloadCycle();
+    refocusAfterRender();
   } catch (err) {
     console.error('[Health] cycle period delete error:', err);
     window.yuvomi?.showToast(err?.data?.error || t('health.cycle.deleteError'), 'danger');
@@ -5370,6 +5379,7 @@ async function deleteDayLog(log) {
     await api.delete(`/health/cycle/logs/${log.id}`);
     window.yuvomi?.showToast(t('health.cycle.deleted'), 'success');
     await reloadCycle();
+    refocusAfterRender();
   } catch (err) {
     console.error('[Health] cycle log delete error:', err);
     window.yuvomi?.showToast(err?.data?.error || t('health.cycle.deleteError'), 'danger');

--- a/public/pages/housekeeping.js
+++ b/public/pages/housekeeping.js
@@ -528,6 +528,7 @@ function renderTasks(content) {
         window.yuvomi?.showToast(t('housekeeping.taskDeletedToast'), 'success');
         await loadData();
         renderTasks(content);
+        refocusAfterRender();
       } catch (err) {
         window.yuvomi?.showToast(err.message, 'danger');
       }
@@ -770,6 +771,7 @@ function renderStaff(content) {
         await loadData();
         await loadStaffVisits();
         renderStaff(content);
+        refocusAfterRender();
       } catch (err) {
         window.yuvomi?.showToast(err.message, 'danger');
       }

--- a/public/pages/inventory.js
+++ b/public/pages/inventory.js
@@ -1530,6 +1530,7 @@ async function removeItem(item) {
     await api.delete(`/inventory/items/${item.id}`);
     await loadItems();
     renderList();
+    refocusAfterRender();
     updateAttentionBadge();
     window.yuvomi?.showToast(t('inventory.deleted'), 'success');
   } catch (err) {

--- a/public/pages/meals.js
+++ b/public/pages/meals.js
@@ -823,6 +823,9 @@ function wireGrid(grid) {
       if (!confirmed) return;
     }
     await addRecipeToSlot(recipe, slot.dataset.date, slot.dataset.type, { replaceMeals: slotMeals });
+    // Nur nach der Rueckfrage: in einen leeren Platz gezogen schliesst kein
+    // Dialog, und das Nachfassen griffe auf den Merker eines frueheren zurueck (#1083).
+    if (slotMeals.length) refocusAfterRender();
   });
 
   wireDragDrop(grid);
@@ -1721,6 +1724,7 @@ async function deleteMeal(mealId) {
         await api.delete(`/meals/${mealId}?scope=${choice}`);
         await loadWeek(state.currentWeek);
         renderWeekGrid();
+        refocusAfterRender();
         window.yuvomi?.showToast(
           choice === 'future' ? t('meals.seriesEndedToast') : t('meals.seriesDeletedToast'),
           'success',

--- a/public/pages/rewards.js
+++ b/public/pages/rewards.js
@@ -662,7 +662,8 @@ async function openRedeemModal(memberId, presetItemId = null) {
 }
 
 async function decideRedemption(id, action, btn) {
-  if (action === 'reject' || action === 'cancel') {
+  const gefragt = action === 'reject' || action === 'cancel';
+  if (gefragt) {
     // Kein `danger`: der Server bucht die reservierten Punkte per `reversal`
     // zurück (routes/rewards.js), es geht also kein Guthaben verloren. Die
     // Anfrage bleibt als entschieden stehen und lässt sich neu stellen, solange
@@ -684,6 +685,9 @@ async function decideRedemption(id, action, btn) {
       : action === 'reject' ? t('rewards.toastRejected') : t('rewards.toastCancelled');
     toast(msg, action === 'fulfill' ? 'success' : 'default');
     await refreshActiveTab();
+    // Nur nach der Rueckfrage: "Einloesen" fragt nicht, schliesst also keinen
+    // Dialog, und das Nachfassen griffe auf den Merker eines frueheren zurueck (#1083).
+    if (gefragt) refocusAfterRender();
   } catch (err) {
     if (btn) btn.disabled = false;
     await confirmModal(err?.message || t('common.error'), { confirmLabel: t('rewards.gotIt') });
@@ -790,6 +794,7 @@ function openRewardModal(item) {
         await api.delete(`/rewards/catalog/${item.id}`);
         toast(t('rewards.toastRewardDeleted'), 'default');
         await refreshActiveTab();
+        refocusAfterRender();
       });
       panel.querySelector('#rw-reward-form').addEventListener('submit', async (e) => {
         e.preventDefault();

--- a/public/pages/schedule.js
+++ b/public/pages/schedule.js
@@ -2,7 +2,7 @@ import { api } from '/api.js';
 import { t, formatDate, formatDayMonth } from '/i18n.js';
 import { esc } from '/utils/html.js';
 import { todayKey, addLocalDays, parseLocalDateKey, weekStartIndex, startOfLocalWeekKey } from '/utils/date.js';
-import { openModal, closeModal, confirmModal, advancedSection } from '/components/modal.js';
+import { openModal, closeModal, confirmModal, advancedSection, refocusAfterRender } from '/components/modal.js';
 import { makeSortable } from '/utils/sortable.js';
 import { createPageFab, setPageFabAction } from '/utils/fab.js';
 import { emptyStateHTML } from '/utils/empty-state.js';
@@ -1819,6 +1819,10 @@ async function action(event) {
       if (group) openOverrideEditModal(group);
       return;
     }
+    // Ob auf diesem Weg eine Rueckfrage geschlossen wurde. Das gemeinsame
+    // `renderPage()` am Ende erreichen auch Zweige ohne Dialog - dort griffe
+    // `refocusAfterRender()` auf den Merker eines frueheren zurueck (#1083).
+    let gefragt = false;
     if (button.dataset.action === 'delete-shift') await api.delete(`/schedule/shift-types/${button.dataset.id}`);
     if (button.dataset.action === 'open-create-custom-field') {
       openCustomFieldModal();
@@ -1842,6 +1846,7 @@ async function action(event) {
         { danger: true, confirmLabel: t('schedule.delete'), detail: t('schedule.deleteCustomFieldDetail', { count: affected }) },
       );
       if (!confirmed) return;
+      gefragt = true;
       await api.delete(`/schedule/custom-fields/${button.dataset.id}`);
     }
     // Ein Muster loeschen nimmt seine Zyklustage mit (ON DELETE CASCADE): eine
@@ -1859,6 +1864,7 @@ async function action(event) {
         },
       );
       if (!confirmed) return;
+      gefragt = true;
       await api.delete(`/schedule/patterns/${button.dataset.id}`);
     }
     // Ein Bereich kann viele Tage tragen, darum fragt das Loeschen hier nach,
@@ -1872,6 +1878,7 @@ async function action(event) {
         { danger: true, confirmLabel: t('schedule.delete'), detail: t('schedule.deleteOverrideRangeDetail', { from: formatDate(from), to: formatDate(to), user: userName(userId) }) },
       );
       if (!confirmed) return;
+      gefragt = true;
       await api.delete(`/schedule/overrides?user_id=${userId}&from=${from}&to=${to}`);
     }
     if (button.dataset.action === 'open-create-extra') {
@@ -1897,6 +1904,7 @@ async function action(event) {
         { danger: true, confirmLabel: t('schedule.delete'), detail: t('schedule.deleteOverrideRangeDetail', { from: formatDate(from), to: formatDate(to), user: userName(userId) }) },
       );
       if (!confirmed) return;
+      gefragt = true;
       for (const id of button.dataset.ids.split(',')) {
         await api.delete(`/schedule/extras/${id}`);
       }
@@ -1970,6 +1978,7 @@ async function action(event) {
     }
     await load();
     renderPage();
+    if (gefragt) refocusAfterRender();
     window.yuvomi?.showToast(button.dataset.action.startsWith('delete') ? t('schedule.deleted') : t('schedule.saved'), 'success');
   } catch (error) {
     window.yuvomi?.showToast(error.data?.error ?? t('common.errorGeneric'), 'danger');

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -2364,6 +2364,7 @@ function wireTabBar(container) {
         const data = await api.post('/shopping', { name });
         state.lists.push({ ...data.data, item_total: 0, item_checked: 0 });
         await switchList(data.data.id, container);
+        refocusAfterRender();
       } catch (err) {
         window.yuvomi.showToast(err.data?.error ?? t('common.errorGeneric'), 'danger');
       }
@@ -2462,6 +2463,7 @@ function wireListContentEvents(container) {
         renderTabs(container);
         renderListContent(container);
         wireListContentEvents(container);
+        refocusAfterRender();
       } catch (err) {
         window.yuvomi.showToast(err.data?.error ?? t('common.errorGeneric'), 'danger');
       }
@@ -2503,6 +2505,7 @@ function wireListContentEvents(container) {
       state.activeListId = state.lists[0]?.id ?? null;
       if (state.activeListId) {
         await switchList(state.activeListId, container);
+        refocusAfterRender();
       } else {
         clearItems();
         state.activeList = null;

--- a/public/pages/split-expenses.js
+++ b/public/pages/split-expenses.js
@@ -502,6 +502,7 @@ async function archiveGroup(groupId) {
   await loadGroups();
   await loadGroupData();
   renderAll();
+  refocusAfterRender();
 }
 
 /**
@@ -536,6 +537,7 @@ async function deleteGroup(groupId) {
   await loadGroups();
   await loadGroupData();
   renderAll();
+  refocusAfterRender();
 }
 
 function memberOptions(selectedId = '', source = state.groupMembers.length ? state.groupMembers : state.members) {

--- a/public/pages/subscriptions.js
+++ b/public/pages/subscriptions.js
@@ -1340,6 +1340,7 @@ async function renewSubscription(subscription) {
   try {
     const response = await api.post(`/budget/subscriptions/${subscription.id}/renew`, {});
     await reload();
+    refocusAfterRender();
     const completed = response.data?.status === 'completed';
     window.yuvomi?.showToast(t(completed ? 'subscriptions.completedToast' : 'subscriptions.renewedToast'), 'success');
   } catch (err) {
@@ -1354,6 +1355,7 @@ async function deleteSubscription(subscription) {
   try {
     await api.delete(`/budget/subscriptions/${subscription.id}`);
     await reload();
+    refocusAfterRender();
     window.yuvomi?.showToast(t('subscriptions.deletedToast'), 'success');
   } catch (err) {
     window.yuvomi?.showToast(err.data?.error || t('common.unknownError'), 'danger');
@@ -1642,6 +1644,7 @@ function openMetadataModal() {
           try {
             await api.delete(`/budget/subscriptions/${isCat ? 'categories' : 'payment-methods'}/${id}`);
             await reload();
+            refocusAfterRender();
             window.yuvomi?.showToast(t('subscriptions.metaDeletedToast'), 'success');
           } catch (err) {
             window.yuvomi?.showToast(err.data?.error || err.message || t('common.unknownError'), 'danger');

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -1786,6 +1786,7 @@ async function handleRenameSubtask(id, currentTitle, container) {
   try {
     await api.put(`/tasks/${id}`, { title: title.trim() });
     await loadTasks(container);
+    refocusAfterRender();
   } catch (err) {
     window.yuvomi.showToast(err.message, 'danger');
   }
@@ -1803,6 +1804,7 @@ async function handleDeleteSubtask(id, title, container) {
   try {
     await api.delete(`/tasks/${id}`);
     await loadTasks(container);
+    refocusAfterRender();
   } catch (err) {
     window.yuvomi.showToast(err.message, 'danger');
   }

--- a/public/settings/pages/admin-api.js
+++ b/public/settings/pages/admin-api.js
@@ -1,7 +1,7 @@
 import { api } from '/api.js';
 import { formatDate, formatTime, t } from '/i18n.js';
 import { esc } from '/utils/html.js';
-import { confirmModal } from '/components/modal.js';
+import { confirmModal, refocusAfterRender } from '/components/modal.js';
 import { createRetryState, toggleRowHtml } from '/settings/components.js';
 import { getExtensionModules } from '/utils/extension-widgets.js';
 import { moduleDisplayLabel } from '/utils/extension-i18n.js';
@@ -287,6 +287,7 @@ function bindEvents(container, initialTokens, users, currentUserId) {
         token.id === id ? { ...token, revoked_at: new Date().toISOString() } : token
       ));
       renderApiTokenList(container, tokens);
+      refocusAfterRender();
       window.yuvomi?.showToast(t('settings.apiTokenRevokedToast'), 'default');
     } catch (err) {
       window.yuvomi?.showToast(err.message, 'danger');

--- a/public/settings/pages/admin-family.js
+++ b/public/settings/pages/admin-family.js
@@ -8,7 +8,7 @@ import {
 import { esc } from '/utils/html.js';
 import { prefersInkText } from '/utils/contrast.js';
 import { AVATAR_COLORS } from '/utils/color.js';
-import { openModal, closeModal, confirmModal } from '/components/modal.js';
+import { openModal, closeModal, confirmModal, refocusAfterRender } from '/components/modal.js';
 import { createRetryState, toggleRowHtml } from '/settings/components.js';
 import {
   renderUserMultiSelect, getSelectedUserIds, bindUserMultiSelect,
@@ -541,6 +541,7 @@ function bindInviteEvents(container, initialInvites) {
       await auth.revokeInvite(id);
       invites = invites.filter((i) => i.id !== id);
       renderInviteList(container, invites);
+      refocusAfterRender();
       window.yuvomi?.showToast(t('settings.invites.revoked'), 'default');
     } catch (err) {
       window.yuvomi?.showToast(err.message || t('common.errorGeneric'), 'danger');

--- a/public/settings/pages/documents-dms.js
+++ b/public/settings/pages/documents-dms.js
@@ -1,6 +1,6 @@
 import { api } from '/api.js';
 import { t } from '/i18n.js';
-import { confirmModal } from '/components/modal.js';
+import { confirmModal, refocusAfterRender } from '/components/modal.js';
 import {
   createDisclosure,
   createInlineError,
@@ -118,6 +118,7 @@ function renderAccount(listEl, account, reload) {
     try {
       await api.delete(`/documents/dms/accounts/${account.id}`);
       await reload();
+      refocusAfterRender();
     } catch (err) {
       showToast(err.message ?? t('common.errorGeneric'), 'danger');
     }

--- a/public/settings/pages/documents-storage.js
+++ b/public/settings/pages/documents-storage.js
@@ -1,6 +1,6 @@
 import { api } from "/api.js";
 import { formatDate, formatTime, t } from "/i18n.js";
-import { confirmModal } from "/components/modal.js";
+import { confirmModal, refocusAfterRender } from "/components/modal.js";
 import {
   createDisclosure,
   createInfoList,
@@ -280,7 +280,8 @@ function bindConnectionForm(container, form, reload) {
     event.preventDefault();
     const saveBtn = form.querySelector("#document-storage-save-btn");
     const payload = documentStoragePayload(form);
-    if (hasProtectedDocumentStorageChange(form, payload)) {
+    const gefragt = hasProtectedDocumentStorageChange(form, payload);
+    if (gefragt) {
       const confirmed = await confirmModal(t("settings.documentStorageConfirmExisting"), {
         confirmLabel: t("common.confirm")
       });
@@ -295,6 +296,9 @@ function bindConnectionForm(container, form, reload) {
       await api.put("/documents/storage/config", payload);
       showToast(t("settings.documentStorageSaved"), "success");
       await reload();
+      // Nur nach der Rueckfrage: ohne sie schliesst auf diesem Weg kein Dialog,
+      // und das Nachfassen griffe auf den Merker eines frueheren zurueck (#1083).
+      if (gefragt) refocusAfterRender();
     } catch (err) {
       showToast(err.message ?? t("common.errorGeneric"), "danger");
     } finally {
@@ -523,6 +527,7 @@ function buildGoogleDriveProvider(data, reload) {
           "success"
         );
         await reload();
+        refocusAfterRender();
       } catch (error) {
         showToast(error.message ?? t("common.errorGeneric"), "danger");
         disconnect.disabled = false;

--- a/public/settings/pages/modules-kitchen.js
+++ b/public/settings/pages/modules-kitchen.js
@@ -212,6 +212,7 @@ function renderProviderAccount(container, account, refresh) {
       await recipeProviders.deleteAccount(account.id);
       showToast(t('settings.recipeProviderAccountDeleted'), 'success');
       await refresh();
+      refocusAfterRender();
     } catch (err) {
       showToast(err.message || t('common.errorGeneric'), 'danger');
     }
@@ -254,6 +255,7 @@ function openProviderLinkModal(account, refresh) {
           closeModal({ force: true });
           showToast(t('settings.recipeProviderAccountUpdated'), 'success');
           await refresh();
+          refocusAfterRender();
         } catch (err) {
           errorEl.textContent = err.message || t('common.errorGeneric');
           errorEl.hidden = false;

--- a/public/settings/pages/personal-calendar-subscriptions.js
+++ b/public/settings/pages/personal-calendar-subscriptions.js
@@ -24,7 +24,7 @@
 import { api } from '/api.js';
 import { formatDate, formatTime, t } from '/i18n.js';
 import { esc } from '/utils/html.js';
-import { closeModal, confirmModal, openModal } from '/components/modal.js';
+import { closeModal, confirmModal, openModal, refocusAfterRender } from '/components/modal.js';
 import { toggleRowHtml } from '/settings/components.js';
 import { loadFamilyUsers } from '/settings/family-users.js';
 
@@ -247,6 +247,7 @@ function buildIcsActions(container, sub, subs, user) {
       const idx = subs.findIndex((s) => s.id === sub.id);
       if (idx >= 0) subs.splice(idx, 1);
       renderIcsList(container, subs, user);
+      refocusAfterRender();
       showToast(t('settings.ics.deletedToast'), 'default');
     } catch (err) {
       showToast(err.message || t('common.errorGeneric'), 'danger');

--- a/public/settings/pages/sync-calendar.js
+++ b/public/settings/pages/sync-calendar.js
@@ -373,6 +373,7 @@ function renderCalDAVAccount(container, account, calendars, refresh, user) {
           'success',
         );
         await refresh();
+        refocusAfterRender();
       } catch (err) {
         showToast(err.message || t('common.errorGeneric'), 'danger');
       }
@@ -1093,6 +1094,7 @@ function buildOutlookAccountCard(account, refresh, user) {
         await api.delete(`/calendar/outlook/accounts/${account.id}`);
         showToast(t('settings.disconnectedToast', { provider: 'Outlook' }), 'default');
         await refresh();
+        refocusAfterRender();
       } catch (err) {
         showToast(err.message || t('common.errorGeneric'), 'danger');
       }

--- a/test/test-detail-view.js
+++ b/test/test-detail-view.js
@@ -159,7 +159,7 @@ test('nachgereichte Zeilen landen nie in einer fremden Ansicht', async () => {
   assert.doesNotMatch(popoverHead, /closeDetailView\(\)/, 'openAsPopover darf sich nicht selbst die Nummer löschen');
 
   const api = src.slice(src.indexOf('export function openDetailView'));
-  const close = api.indexOf('closeDetailView()');
+  const close = api.indexOf('closeDetailView(');
   const assign = api.indexOf('activeViewToken = token');
   assert.ok(close > -1 && assign > close, 'erst die alte Ansicht schließen, dann nummerieren');
 });
@@ -196,7 +196,10 @@ test('das Popover ist bedienbar ohne Maus und gibt den Fokus zurück', async () 
   assert.match(popover, /aria-labelledby/, 'mit dem Titel verknüpft');
   assert.match(popover, /'Escape'/, 'Escape schließt');
   assert.match(popover, /e\.key !== 'Tab'|'Tab'/, 'Tab bleibt im Popover');
-  assert.match(popover, /opts\.anchor\?\.focus\?\.\(\)/, 'Fokus kehrt zum Auslöser zurück');
+  // Der Fokus kehrt zum Auslöser zurück - über den Merker der Modal-Schicht, damit
+  // er auch nach einem Neuaufbau wiedergefunden wird (#1083).
+  assert.match(popover, /merker: rememberFocus\(opts\.anchor\)/, 'der Auslöser wird beim Öffnen gemerkt');
+  assert.match(popover, /restoreFocusAfterClose\(merker\)/, 'und beim Schließen zurückgegeben');
 });
 
 test('die Detailansicht öffnet ohne Autofokus', async () => {

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -16058,8 +16058,21 @@ test('dashboard: Timer und Listener haengen am Signal des eigenen Aufbaus, nicht
  */
 const SCHLIESS_FASSADEN = ['closeDetailView'];
 
+/**
+ * Dialoge, die ihr Ergebnis erst NACH dem Schliessen liefern (#1083).
+ *
+ * `promptModal`, `confirmModal` und `selectModal` rufen in `finish()` zuerst
+ * `closeModal({ force: true })` und loesen dann auf; `confirmOverModal` schliesst
+ * das geparkte Formular, bevor es `true` zurueckgibt. Wer danach etwas abwartet
+ * und neu baut, reisst den Fokus weg wie nach jedem anderen Schliessen - fuer den
+ * Guard sah das bis hierher nach gar keinem Schliessen aus: der Unterteil-Umbenennen-
+ * Weg in tasks.js und das Ablehnen einer Einloesung in rewards.js (Review zu
+ * #1070).
+ */
+const ERGEBNIS_DIALOGE = ['promptModal', 'confirmModal', 'selectModal', 'confirmOverModal'];
+
 function schliessNamen(lines) {
-  const namen = new Set(['closeModal', ...SCHLIESS_FASSADEN]);
+  const namen = new Set(['closeModal', ...SCHLIESS_FASSADEN, ...ERGEBNIS_DIALOGE]);
   const quelle = lines.join('\n');
   const block = quelle.match(/import\s*\{([\s\S]*?)\}\s*from\s*'\/components\/modal\.js'/);
   if (block) {
@@ -16118,7 +16131,31 @@ function rendererIn(lines) {
     }
     if (!gewachsen) break;
   }
+  for (const p of abgewarteteParameter(lines)) namen.add(p);
   return namen;
+}
+
+/**
+ * Rueckrufe, die als PARAMETER hereinkommen und abgewartet werden (#1083).
+ *
+ * `renderProviderAccount(container, account, refresh)` in modules-kitchen.js
+ * bekommt `loadProviderAccounts` unter dem Namen `refresh`, und der Link-Dialog
+ * schliesst und wartet dann `await refresh()` ab - das leert die Kontenliste und
+ * baut sie neu. `AWAIT_RUECKRUF` kennt nur `on…`-Namen und `opts.…`, ein
+ * gewoehnlicher Name fiel durch (Review zu #1070).
+ *
+ * Dieselbe Begruendung wie dort: wer einen hereingereichten Rueckruf abwartet,
+ * weiss nicht, was er umbaut. Gesammelt werden die Namen aus den Parameterlisten
+ * von Deklarationen und Pfeilfunktionen, die irgendwo in der Datei abgewartet
+ * aufgerufen werden.
+ */
+function abgewarteteParameter(lines) {
+  const quelle = lines.join('\n');
+  const params = new Set();
+  for (const m of quelle.matchAll(/function\s*\w*\s*\(([^)]*)\)|\(([^()]*)\)\s*=>/g)) {
+    for (const id of (m[1] ?? m[2] ?? '').matchAll(/[A-Za-z_]\w*/g)) params.add(id[0]);
+  }
+  return [...params].filter((p) => new RegExp(`\\bawait\\s+${p}\\s*\\(`).test(quelle));
 }
 
 /**
@@ -16166,6 +16203,69 @@ function blockAb(lines, i, grenze = 40) {
   return out;
 }
 
+/**
+ * Die Zeilen, die nach dem Anker auf DEMSELBEN Weg folgen (#1083).
+ *
+ * `blockAb` endet am Ende des Blocks - und das ist zu frueh, sobald das Schliessen
+ * selbst in einem `if` steht: `if (action === 'reject') { const ok = await
+ * confirmModal(…); if (!ok) return; }` und DANACH `await refreshActiveTab()` in
+ * rewards.js. Bis zum Ende der Funktion zu lesen ist dagegen zu weit: in
+ * shopping.js folgt auf den Umbenennen-Zweig `if (action === 'rename-list') {…}`
+ * der Loeschen-Zweig, und dessen Neuaufbau gehoert nicht zum Umbenennen.
+ *
+ * Deshalb waechst das Fenster von innen nach aussen: erst der eigene Block. Endet
+ * er, OHNE dass darin neu gebaut wurde, geht es im umgebenden Block weiter - bis
+ * zur Funktion um den Anker (eine Deklaration oder ein Rueckruf `=> {`). Hat es
+ * einen Neuaufbau gesehen, ist an der naechsten schliessenden Klammer auf der
+ * Ebene des Fensters Schluss; das faengt auch `} catch (err) {` und `} else {`,
+ * deren Zweige ein anderer Weg sind.
+ *
+ * Was in einem verschachtelten Rueckruf steht, sortiert der Aufrufer ueber
+ * `inVerschachtelterFunktion` aus - und `baut` entscheidet, was ein Neuaufbau ist.
+ * Mit Zeilennummer, weil genau diese Pruefung sie braucht.
+ */
+function rumpfAb(lines, i, baut, grenze = 120) {
+  const einzug = (j) => lines[j].match(/^\s*/)[0].length;
+  let tiefe = einzug(i);
+  let oeffner = -1;
+  for (let j = i - 1; j >= 0; j--) {
+    if (lines[j].trim() === '' || einzug(j) >= tiefe) continue;
+    if (/=>\s*\{\s*$|\bfunction\b[^{]*\{\s*$/.test(lines[j])) { oeffner = j; break; }
+  }
+  const ende = oeffner === -1 ? -1 : einzug(oeffner);
+  const out = [];
+  // Einrueckung des ersten Neuaufbaus; -1 heisst: noch keiner gesehen.
+  let gebautBei = -1;
+  for (let j = i + 1; j < lines.length && out.length < grenze; j++) {
+    const l = lines[j];
+    if (l.trim() === '') { out.push({ x: l, j }); continue; }
+    const t = einzug(j);
+    if (t <= ende) break;
+    if (/^\s*\}/.test(l)) {
+      if (t < tiefe) {
+        // Der Block, in dem das Fenster gerade liest, endet hier.
+        if (gebautBei !== -1) break;
+        // Endet er mit `return` oder `throw`, geht es danach auf diesem Weg
+        // nicht weiter: in documents.js kehrt der DMS-Zweig nach seiner Auswahl
+        // zurueck, und das `deleteDocuments()` darunter ist ein anderer Weg ohne
+        // jeden Dialog - ein Aufruf dort griffe ins Leere.
+        const davor = out.map(({ x }) => x).filter((x) => x.trim() !== '').pop() ?? lines[i];
+        if (/^\s*(?:return|throw)\b/.test(davor)) break;
+        tiefe = t;
+      } else if (/^\s*\}\s*(?:else|catch|finally)\b/.test(l) && gebautBei > t) {
+        // Im Zweig darueber wurde neu gebaut; was jetzt kommt, ist ein anderer
+        // Weg durch dasselbe `if`/`try`. Ein `} else {` einer Verzweigung, die
+        // erst NACH dem Anker aufging und in der noch nichts gebaut wurde, ist
+        // dagegen keine Grenze - so steht es in `openBudgetModal()` in budget.js.
+        break;
+      }
+    }
+    out.push({ x: l, j });
+    if (gebautBei === -1 && baut(l) && !inVerschachtelterFunktion(lines, i, j)) gebautBei = t;
+  }
+  return out;
+}
+
 /* WER NACH DEM SCHLIESSEN RENDERT, MUSS DEN FOKUS NACHZIEHEN.
  *
  * `closeModal()` gibt den Fokus an den Ausloeser zurueck. Rendert der Handler
@@ -16209,17 +16309,27 @@ test('jede Seite, die nach einem await neu rendert, zieht den Fokus nach', () =>
         // koennte dort also nichts bewirken, und ihn zu verlangen hiesse, toten
         // Code zu fordern (Review zu #1070).
         if (/\bsetTimeout\s*\(/.test(zeile)) return;
-        // NUR DIE EIGENE EBENE. Alles Tiefere steht in einem Callback, der auf
-        // diesem Weg gar nicht laeuft - der Undo-Zweig eines Toasts etwa. Wer
-        // ihn mitzaehlt, haelt `deletePlan()` in budget-plans.js fuer gedeckt,
-        // weil im Undo-Callback ein Aufruf steht, waehrend der Hauptpfad ohne
-        // blieb (Review zu #1070).
-        const ankerTiefe = zeile.match(/^\s*/)[0].length;
-        const fenster = blockAb(lines, i)
-          .filter((x) => x.trim() === '' || x.match(/^\s*/)[0].length <= ankerTiefe);
+        // NICHTS AUS EINEM VERSCHACHTELTEN RUECKRUF. Der steht auf diesem Weg gar
+        // nicht an - der Undo-Zweig eines Toasts etwa. Wer ihn mitzaehlt, haelt
+        // `deletePlan()` in budget-plans.js fuer gedeckt, weil im Undo-Callback ein
+        // Aufruf steht, waehrend der Hauptpfad ohne blieb (Review zu #1070).
+        //
+        // VERSCHACHTELUNG, NICHT EINRUECKUNG (#1083). Die fruehere Fassung las nur
+        // Zeilen auf der Ebene des Ankers und hielt damit jeden `try`- und
+        // `if`-Rumpf fuer einen Rueckruf: `const title = await promptModal(…);
+        // try { await api.put(…); await loadTasks(container); }` in tasks.js war
+        // unsichtbar. Dieselbe Unterscheidung wie im Guard darunter (#1087).
+        const fenster = rumpfAb(lines, i, (x) => istNeuaufbau(x, wrapper))
+          .filter(({ j }) => !inVerschachtelterFunktion(lines, i, j))
+          .map(({ x }) => x);
         let letzte = -1;
         fenster.forEach((x, k) => { if (istNeuaufbau(x, wrapper)) letzte = k; });
         if (letzte === -1) return;
+        // Folgt dem Neuaufbau noch ein Schliessen, setzt DESSEN Restore den Fokus
+        // auf den frisch gebauten Knopf - so rendert `saveCreatedSchedule()` in
+        // schedule.js vor seinem `closeModal()`. Ein Aufruf davor waere tot, und
+        // der Guard darunter meldet ihn als solchen.
+        if (fenster.slice(letzte + 1).some((x) => istSchliessen(x, schliesst))) return;
         // Ohne `await` davor rendert die Seite synchron - das deckt der Frame ab.
         if (!fenster.slice(0, letzte + 1).some((x) => /\bawait\b/.test(x))) return;
         // Der Aufruf muss auf der EBENE des Neuaufbaus liegen. Ein
@@ -16577,6 +16687,146 @@ test('wer refocusAfterRender importiert, ruft es auch', () => {
     `Diese Dateien importieren refocusAfterRender, ohne es zu rufen:\n  ${tot.join('\n  ')}`);
 });
 
+
+/* DAS FENSTER NACH DEM SCHLIESSEN FOLGT DEM WEG, NICHT DER EINRUECKUNG (#1083).
+ *
+ * An kuenstlichen Quellen, eine je Form, die im Repo vorkommt. So faellt die
+ * Sonde auch dann, wenn die echte Stelle umgebaut wird.
+ */
+test('rumpfAb liest bis zum Neuaufbau auf demselben Weg (#1083)', () => {
+  const baut = (x) => /\brender[A-Z]\w*\s*\(|\bawait\s+load[A-Z]\w*\s*\(/.test(x);
+  const zeilen = (quelle, anker) => {
+    const i = quelle.findIndex((l) => l.includes(anker));
+    assert.ok(i !== -1, `Anker ${anker} fehlt in der Probe`);
+    return rumpfAb(quelle, i, baut)
+      .filter(({ j }) => !inVerschachtelterFunktion(quelle, i, j))
+      .map(({ x }) => x.trim());
+  };
+
+  // tasks.js: der Neuaufbau steht im try-Rumpf, der catch-Zweig ist ein anderer Weg.
+  const imTry = zeilen([
+    'async function umbenennen(id) {',
+    '  const titel = await promptModal(label);',
+    '  if (!titel) return;',
+    '  try {',
+    '    await api.put(url, { titel });',
+    '    await loadTasks(container);',
+    '  } catch (err) {',
+    '    renderFehler(err);',
+    '  }',
+    '}',
+  ], 'promptModal');
+  assert.ok(imTry.includes('await loadTasks(container);'), 'ein try-Rumpf ist kein Rueckruf');
+  assert.ok(!imTry.includes('renderFehler(err);'), 'der catch-Zweig gehoert nicht zum Weg nach dem Speichern');
+
+  // rewards.js: das Schliessen steht in einem if, der Neuaufbau danach.
+  const nachDemIf = zeilen([
+    'async function entscheiden(action) {',
+    '  if (action === "reject") {',
+    '    const ok = await confirmModal(frage);',
+    '    if (!ok) return;',
+    '  }',
+    '  try {',
+    '    await api.patch(url, { action });',
+    '    renderTab();',
+    '  } catch (err) {',
+    '    zeige(err);',
+    '  }',
+    '}',
+  ], 'confirmModal');
+  assert.ok(nachDemIf.includes('renderTab();'), 'nach dem if geht derselbe Weg weiter');
+
+  // shopping.js: der naechste if-Zweig ist ein anderer Weg.
+  const geschwister = zeilen([
+    'function verdrahten() {',
+    '  root.addEventListener("click", async () => {',
+    '    if (action === "rename") {',
+    '      const name = await promptModal(label);',
+    '      if (!name) return;',
+    '      renderTabs(container);',
+    '    }',
+    '    if (action === "delete") {',
+    '      renderLeer(container);',
+    '    }',
+    '  });',
+    '}',
+  ], 'promptModal');
+  assert.ok(geschwister.includes('renderTabs(container);'));
+  assert.ok(!geschwister.includes('renderLeer(container);'), 'der Loeschen-Zweig gehoert nicht zum Umbenennen');
+
+  // documents.js: ein Zweig, der mit return endet, fuehrt nicht weiter.
+  const mitReturn = zeilen([
+    'async function aktion(action) {',
+    '  if (action === "push") {',
+    '    const konto = await selectModal(label, optionen);',
+    '    if (!konto) return;',
+    '    await api.post(url, { konto });',
+    '    return;',
+    '  }',
+    '  if (action === "delete") renderListe();',
+    '}',
+  ], 'selectModal');
+  assert.ok(!mitReturn.includes('if (action === "delete") renderListe();'), 'nach return endet der Weg');
+
+  // budget.js: ein if/else, das erst nach dem Anker aufgeht, beendet das Fenster nicht.
+  const elseDanach = zeilen([
+    'async function speichern() {',
+    '  if (serie) {',
+    '    closeModal({ force: true });',
+    '    const scope = await frageScope();',
+    '    if (scope === "series") {',
+    '      await api.put(serienUrl, body);',
+    '    } else {',
+    '      await api.put(url, body);',
+    '    }',
+    '    await loadMonth(monat);',
+    '    renderBody();',
+    '    refocusAfterRender();',
+    '  } else {',
+    '    renderAnders();',
+    '  }',
+    '}',
+  ], 'closeModal');
+  assert.ok(elseDanach.includes('refocusAfterRender();'), 'das else der Scope-Frage ist keine Grenze');
+  assert.ok(!elseDanach.includes('renderAnders();'), 'das else des aeusseren if schon');
+
+  // Ein verschachtelter Rueckruf nach dem Schliessen steht auf diesem Weg nicht an.
+  const rueckruf = zeilen([
+    'async function loeschen() {',
+    '  if (!await confirmModal(frage)) return;',
+    '  zeigeToast({',
+    '    undo: async () => {',
+    '      renderUndo();',
+    '    },',
+    '  });',
+    '}',
+  ], 'confirmModal');
+  assert.ok(!rueckruf.includes('renderUndo();'), 'der Undo-Rueckruf ist ein anderer Weg');
+});
+
+test('Ergebnis-Dialoge zaehlen als Schliessen, abgewartete Parameter als Neuaufbau (#1083)', () => {
+  const namen = schliessNamen(['import { promptModal } from \'/components/modal.js\';']);
+  for (const n of ['promptModal', 'confirmModal', 'selectModal', 'confirmOverModal']) {
+    assert.ok(namen.has(n), `${n} schliesst den Dialog, bevor es aufloest`);
+  }
+  assert.ok(istSchliessen('  if (!await confirmModal(frage)) return;', namen));
+
+  const quelle = [
+    'function renderKonto(container, konto, refresh) {',
+    '  knopf.addEventListener("click", async () => {',
+    '    closeModal({ force: true });',
+    '    await refresh();',
+    '  });',
+    '}',
+    'function speichern(save) {',
+    '  return save;',
+    '}',
+  ];
+  const param = abgewarteteParameter(quelle);
+  assert.ok(param.includes('refresh'), 'ein abgewarteter Parameter baut Unbekanntes um');
+  assert.ok(!param.includes('save'), 'ein Parameter, der nie abgewartet aufgerufen wird, zaehlt nicht');
+  assert.ok(istNeuaufbau('    await refresh();', rendererIn(quelle)));
+});
 
 /* VERSCHACHTELUNG, NICHT REIHENFOLGE - direkt geprueft.
  *

--- a/test/test-modal-utils.js
+++ b/test/test-modal-utils.js
@@ -10,7 +10,10 @@ import { readFileSync } from 'node:fs';
 import { eachRule } from './css-rules.js';
 
 // /i18n.js wird durch test-browser-loader.mjs gemockt (--loader Flag)
-const { wireBlurValidation, btnSuccess, btnError, focusRestoreTarget, rememberFocus } = await import('../public/components/modal.js');
+const {
+  wireBlurValidation, btnSuccess, btnError, focusRestoreTarget, rememberFocus,
+  restoreFocusAfterClose, refocusAfterRender, forgetRestore,
+} = await import('../public/components/modal.js');
 
 // matchMedia und document.createElementNS werden von btnSuccess/btnError benötigt
 global.matchMedia = () => ({ matches: false });
@@ -774,6 +777,58 @@ test('closeDetailView verwirft den Merker, wenn es am Modal vorbei schliesst', (
   assert.match(fn, /forgetRestore\(\)/,
     'der Popover-Zweig kehrt ohne closeModal() zurueck - ohne Verwerfen bliebe der Merker '
     + 'des vorigen Dialogs stehen');
+});
+
+/* DAS POPOVER GIBT DEN FOKUS UEBER DENSELBEN MERKER ZURUECK WIE EIN MODAL (#1083).
+ *
+ * Bis hierher verwarf `closeDetailView()` im Popover-Zweig nur den fremden
+ * Merker. Der Fokus fiel mit dem entfernten Popover auf `body`, und ein
+ * `refocusAfterRender()` nach dem Neuaufbau - etwa nach dem Zuruecksetzen eines
+ * ICS-Termins, der das Raster neu zeichnet - hatte nichts, worauf es sich
+ * beziehen konnte. Gemessen am ERGEBNIS, nicht an der Schreibweise.
+ */
+test('der Merker aus dem Popover traegt auch den Neuaufbau danach (#1083)', () => {
+  const vorher = { active: global.document.activeElement, body: global.document.body };
+  global.document.body = makeNode('body');
+  const fokussierbar = (n) => { n.focus = () => { global.document.activeElement = n; }; return n; };
+  const wurzel = fokussierbar(makeNode('main', { id: 'main-content' }));
+  const anker = fokussierbar(makeNode('div', { cls: 'calendar-chip', data: { eventId: '7' } }));
+  try {
+    const merker = rememberFocus(anker);
+    withDom({ byId: { 'main-content': wurzel } }, () => {
+      global.document.activeElement = global.document.body;
+      assert.equal(restoreFocusAfterClose(merker), anker,
+        'haengt der Ausloeser noch, bekommt er den Fokus selbst');
+      assert.equal(global.document.activeElement, anker);
+    });
+
+    // Die Seite zeichnet das Raster neu: der alte Chip ist weg, ein gleicher steht da.
+    anker.isConnected = false;
+    const neu = fokussierbar(makeNode('div', { cls: 'calendar-chip', data: { eventId: '7' } }));
+    withDom({ byTag: { DIV: [neu] }, byId: { 'main-content': wurzel } }, () => {
+      global.document.activeElement = global.document.body;
+      refocusAfterRender();
+      assert.equal(global.document.activeElement, neu,
+        'ohne den Merker aus dem Popover bliebe der Fokus nach dem Neuaufbau auf body');
+    });
+
+    assert.equal(restoreFocusAfterClose(null), null, 'ohne Merker gibt es nichts zurueckzugeben');
+  } finally {
+    forgetRestore();
+    global.document.activeElement = vorher.active;
+    global.document.body = vorher.body;
+  }
+});
+
+test('das Popover gibt den Fokus nur zurueck, wo niemand woanders hin wollte (#1083)', () => {
+  const src = readFileSync(new URL('../public/components/detail-view.js', import.meta.url), 'utf8');
+  const fn = src.match(/export function closeDetailView\([\s\S]*?\n\}/)?.[0] ?? '';
+  assert.match(fn, /if \(fokus && merker\) restoreFocusAfterClose\(merker\);\s*else forgetRestore\(\);/,
+    'Rueckgabe mit eigenem Merker, sonst verwerfen - nie einen fremden stehen lassen');
+  assert.match(src, /!popover\.contains\(e\.target\)\) closeDetailView\(\{ fokus: false \}\)/,
+    'ein Klick daneben wollte woanders hin - der Fokus springt nicht zurueck');
+  assert.match(src, /if \(activePopover\) closeDetailView\(\{ fokus: false \}\)/,
+    'eine neue Ansicht nimmt den Fokus selbst');
 });
 
 /* REVIEW ZU #1070: die Klasse ist Darstellung, keine Identitaet.


### PR DESCRIPTION
Keyboard focus comes back after confirmations, prompts and the calendar's detail popover. Covers the three open items of #1083. Item 4 was fixed in #1087.

## The guard (`test/test-frontend-audit.js`)

Three shapes were invisible to the ratchet "jede Seite, die nach einem await neu rendert, zieht den Fokus nach":

1. **Dialogs that close before they resolve.** `ERGEBNIS_DIALOGE` = `promptModal`, `confirmModal`, `selectModal`, `confirmOverModal` now count as a close in `schliessNamen()`. Each calls `closeModal({ force: true })` in `finish()` before `resolve()`, or closes the parked form before returning `true`.
2. **The window follows the path, not the indentation.** The old filter read only lines at the anchor's indentation, which treats every `try` and `if` body like a callback. `handleRenameSubtask` in tasks.js (`try { await api.put(); await loadTasks(); }`) was invisible because of that. The new `rumpfAb()` reads its own block first and moves outwards only while no rebuild has been seen. It stops at a `}` that closes a block once a rebuild was seen, at a `} catch`/`} else` whose branch held the rebuild, and after a block ending in `return`/`throw`. Nested callbacks stay excluded through `inVerschachtelterFunktion()`, the same distinction as #1087. A rebuild followed by another close is skipped, because that close restores focus itself (`saveCreatedSchedule` in schedule.js).
3. **Awaited callback parameters.** `abgewarteteParameter()` adds names from parameter lists that are called with `await name()`. The codex case is `refresh` in modules-kitchen.js.

Synthetic probes cover each shape: try body, code after an if, sibling branch, return branch, an else opened after the anchor (the `openBudgetModal` shape), the catch branch and a nested callback.

## The 40 call sites

The widened guard listed 40 paths. I did not fill them in mechanically, which is the warning in #1083. An insertion script used the guard's own helpers to place each call, and every hunk was then read against its code. Two guard rules came out of that review, the `return` boundary and "a close follows the rebuild", after a first pass had placed calls in a sibling branch, a catch branch and in front of a later `closeModal()`.

**Five paths close a dialog on only some branches.** An unconditional call there would reuse the memo of an earlier, unrelated dialog and put focus on its trigger. There the call carries the same condition as the dialog:

- `decideRedemption` in rewards.js: "fulfill" asks nothing, "reject"/"cancel" do.
- `handlePrnDose` in health.js: asks only before the minimum interval. The call comes after `setDoseBusy(false)`, otherwise it would hit the still-disabled button.
- The recipe drop in meals.js asks only for a filled slot.
- The document storage save asks only for a protected change.
- The shared delete handler in schedule.js: four branches ask, `delete-shift` and the save branches do not.

The other 35 close on every path before the rebuild. `folderDeleteChoice` in documents.js is a dialog too, so both branches before it close.

## The detail popover (item 1)

`closeDetailView()` closed the popover past modal.js and only dropped the memo. The popover now remembers its anchor at open (`rememberFocus(opts.anchor)`), and closing returns focus through the new `restoreFocusAfterClose()` in modal.js: find the target, focus it with fallback, set the memo, retry one frame later. The same path as `_doClose`. Two cases pass `{ fokus: false }`: a click outside, where the user wanted to go elsewhere, and a view that replaces the popover and takes focus itself. Escape no longer needs its own `anchor.focus()`.

## Tests

- `npm test` on this branch: EXIT=0.
- `test:frontend-audit` 382/382, `test:modal-utils` 50/50, `test:detail-view` 50/50, `test:changelog` 28/28.
- Counterproofs, done by neutralising a call rather than deleting it:
  - try body (tasks.js:1782): red; with the old indentation rule, green again.
  - result dialog (split-expenses.js:496): red; without `ERGEBNIS_DIALOGE` the guard lets it through.
  - parameter callback (modules-kitchen.js:255): red; without `abgewarteteParameter` it passes.
  - `return` boundary disabled: the synthetic probe and the guard (documents.js:1498) go red.
- `restoreFocusAfterClose` has a behaviour probe in `test:modal-utils`. It measures where focus ends up when the anchor is still connected, and that the memo carries a later rebuild.

## In the browser

Local servers on this branch (3083) and on main plus #1110 (3110), same demo DB, same steps, 1280x800:

| Step | main | this branch |
|---|---|---|
| Agenda view, event "Elternabend" focused, popover open, back gesture (`history.back()`) | focus on `BODY` | focus on **the event row** |
| Month view, popover, Escape | `#main-content` | `#main-content` |

The month chip (`.month-day__event`) has no tabindex, and `focus()` does nothing on it (measured), so both versions fall back to the page root there. Making month chips keyboard-reachable is a separate question.

**Found in passing, not caused by this branch:** popover → "Bearbeiten" → Escape in the edit form navigates back to the overview. It happened 3/3 on main and 3/3 here, and looks like the overlay-history marker between the popover's drop and the form's push. It is filed as a separate task and not touched here.

## Left open, measured

The `close` parameter of detail-view actions (`onClick: async ({ close }) => …`) is still not recognised as a close. Treating it as one adds 3 sites: contacts.js:896, inventory.js:803, and a false positive at calendar.js:3596, where `renderEventDetail` only builds rows. That is the next widening, and it deserves the same site-by-site pass, so it is not appended here.

User-facing, so it ships with the Tuesday release.

Refs #1083
