### PR TITLE
feat(calendar): filter by calendar and subscription, and show unassigned events (#1064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the loaded range, each with its colour and a switch. Hiding one removes its events from all
   four views and the agenda, remembered on the device like the layers. A hidden calendar stays in
   the list under its name even when none of its events is on screen, so it can always be switched
-  back on. The person axis gains "Unassigned": on its own it shows only the events and tasks nobody
+  back on. A new event created for a hidden calendar stays out right away, not only once it has
+  synced. The person axis gains "Unassigned": on its own it shows only the events and tasks nobody
   is assigned to, together with people it adds them. A person filter saved before this update keeps
   its behaviour - it does not contain the new entry, so unassigned events stay out, as they did.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The calendar filter can hide a connected calendar or subscription, and show the events nobody
+  is assigned to** (#1064). The filter sheet lists every calendar and ICS subscription with events
+  in the loaded range, each with its colour and a switch. Hiding one removes its events from all
+  four views and the agenda, remembered on the device like the layers. A hidden calendar stays in
+  the list under its name even when none of its events is on screen, so it can always be switched
+  back on. The person axis gains "Unassigned": on its own it shows only the events and tasks nobody
+  is assigned to, together with people it adds them. A person filter saved before this update keeps
+  its behaviour - it does not contain the new entry, so unassigned events stay out, as they did.
+
 - **An event's location opens in a map** (#1110, from discussion #1047). The event detail carries
   an "Open in Maps" action whenever the event has a location; it opens an OpenStreetMap search for
   that text in a new tab, the same search Contacts already uses for an address. It is an explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The calendar filter can hide a connected calendar or subscription, and show the events nobody
   is assigned to** (#1064). The filter sheet lists every calendar and ICS subscription with events
   in the loaded range, each with its colour and a switch. Hiding one removes its events from all
-  four views and the agenda, remembered on the device like the layers. A hidden calendar stays in
+  four views and the agenda, remembered on the device for each account. A hidden calendar stays in
   the list under its name even when none of its events is on screen, so it can always be switched
   back on. A new event created for a hidden calendar stays out right away, not only once it has
   synced. The person axis gains "Unassigned": on its own it shows only the events and tasks nobody

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -948,7 +948,9 @@
         "filtersReset": "إزالة كل عوامل التصفية",
         "filtersDisplay": "العرض",
         "agendaDayEmpty": "لا شيء مُخطط",
-        "openInMap": "فتح في الخرائط"
+        "openInMap": "فتح في الخرائط",
+        "filtersSources": "التقويمات",
+        "filterUnassigned": "غير مُسندة"
     },
     "noteCategories": {
         "permissionLabel": "إدارة فئات ملاحظات الأسرة"

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -948,7 +948,9 @@
         "filtersReset": "Zrušit všechny filtry",
         "filtersDisplay": "Zobrazení",
         "agendaDayEmpty": "Nic naplánováno",
-        "openInMap": "Otevřít v Mapách"
+        "openInMap": "Otevřít v Mapách",
+        "filtersSources": "Kalendáře",
+        "filterUnassigned": "Nepřiřazeno"
     },
     "noteCategories": {
         "permissionLabel": "Spravovat domácí kategorie poznámek"

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -960,7 +960,9 @@
         "filtersReset": "Alle Filter aufheben",
         "filtersDisplay": "Darstellung",
         "agendaDayEmpty": "Nichts geplant",
-        "openInMap": "In Maps öffnen"
+        "openInMap": "In Maps öffnen",
+        "filtersSources": "Kalender",
+        "filterUnassigned": "Nicht zugewiesen"
     },
     "noteCategories": {
         "permissionLabel": "Gemeinsame Notizkategorien verwalten"

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -948,7 +948,9 @@
         "filtersReset": "Κατάργηση όλων των φίλτρων",
         "filtersDisplay": "Εμφάνιση",
         "agendaDayEmpty": "Τίποτα προγραμματισμένο",
-        "openInMap": "Άνοιγμα στους Χάρτες"
+        "openInMap": "Άνοιγμα στους Χάρτες",
+        "filtersSources": "Ημερολόγια",
+        "filterUnassigned": "Χωρίς ανάθεση"
     },
     "noteCategories": {
         "permissionLabel": "Διαχείριση κοινόχρηστων κατηγοριών σημειώσεων"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -948,7 +948,9 @@
         "filtersReset": "Clear all filters",
         "filtersDisplay": "Display",
         "agendaDayEmpty": "Nothing planned",
-        "openInMap": "Open in Maps"
+        "openInMap": "Open in Maps",
+        "filtersSources": "Calendars",
+        "filterUnassigned": "Unassigned"
     },
     "noteCategories": {
         "permissionLabel": "Manage household note categories"

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -948,7 +948,9 @@
         "filtersReset": "Quitar todos los filtros",
         "filtersDisplay": "Visualización",
         "agendaDayEmpty": "Nada planeado",
-        "openInMap": "Abrir en Maps"
+        "openInMap": "Abrir en Maps",
+        "filtersSources": "Calendarios",
+        "filterUnassigned": "Sin asignar"
     },
     "noteCategories": {
         "permissionLabel": "Gestionar categorías de notas del hogar"

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -960,7 +960,9 @@
         "filtersReset": "برداشتن همه فیلترها",
         "filtersDisplay": "نمایش",
         "agendaDayEmpty": "چیزی برنامه‌ریزی نشده",
-        "openInMap": "باز کردن در نقشه"
+        "openInMap": "باز کردن در نقشه",
+        "filtersSources": "تقویم‌ها",
+        "filterUnassigned": "واگذارنشده"
     },
     "noteCategories": {
         "permissionLabel": "مدیریت دسته‌بندی‌های یادداشت خانوادگی"

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -960,7 +960,9 @@
         "filtersReset": "Alisin ang lahat ng filter",
         "filtersDisplay": "Pagpapakita",
         "agendaDayEmpty": "Walang nakaplano",
-        "openInMap": "Buksan sa Maps"
+        "openInMap": "Buksan sa Maps",
+        "filtersSources": "Mga kalendaryo",
+        "filterUnassigned": "Walang nakatalaga"
     },
     "noteCategories": {
         "permissionLabel": "Pamahalaan ang mga kategorya ng tala ng sambahayan"

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -948,7 +948,9 @@
         "filtersReset": "Effacer tous les filtres",
         "filtersDisplay": "Affichage",
         "agendaDayEmpty": "Rien de prévu",
-        "openInMap": "Ouvrir dans Maps"
+        "openInMap": "Ouvrir dans Maps",
+        "filtersSources": "Calendriers",
+        "filterUnassigned": "Non attribués"
     },
     "noteCategories": {
         "permissionLabel": "Gérer les catégories de notes du foyer"

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -948,7 +948,9 @@
         "filtersReset": "सभी फ़िल्टर हटाएँ",
         "filtersDisplay": "प्रदर्शन",
         "agendaDayEmpty": "कुछ भी नियोजित नहीं",
-        "openInMap": "मानचित्र में खोलें"
+        "openInMap": "मानचित्र में खोलें",
+        "filtersSources": "कैलेंडर",
+        "filterUnassigned": "किसी को नहीं सौंपे गए"
     },
     "noteCategories": {
         "permissionLabel": "घर की नोट श्रेणियाँ प्रबंधित करें"

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -948,7 +948,9 @@
         "filtersReset": "Összes szűrő törlése",
         "filtersDisplay": "Megjelenítés",
         "agendaDayEmpty": "Semmi sincs tervezve",
-        "openInMap": "Megnyitás a Térképen"
+        "openInMap": "Megnyitás a Térképen",
+        "filtersSources": "Naptárak",
+        "filterUnassigned": "Senkihez sincs rendelve"
     },
     "noteCategories": {
         "permissionLabel": "Háztartási jegyzetkategóriák kezelése"

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -960,7 +960,9 @@
         "filtersReset": "Hapus semua filter",
         "filtersDisplay": "Tampilan",
         "agendaDayEmpty": "Tidak ada rencana",
-        "openInMap": "Buka di Maps"
+        "openInMap": "Buka di Maps",
+        "filtersSources": "Kalender",
+        "filterUnassigned": "Belum ditugaskan"
     },
     "noteCategories": {
         "permissionLabel": "Kelola kategori catatan rumah tangga"

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -948,7 +948,9 @@
         "filtersReset": "Rimuovi tutti i filtri",
         "filtersDisplay": "Visualizzazione",
         "agendaDayEmpty": "Niente in programma",
-        "openInMap": "Apri in Maps"
+        "openInMap": "Apri in Maps",
+        "filtersSources": "Calendari",
+        "filterUnassigned": "Non assegnati"
     },
     "noteCategories": {
         "permissionLabel": "Gestisci le categorie delle note di casa"

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -948,7 +948,9 @@
         "filtersReset": "すべてのフィルターを解除",
         "filtersDisplay": "表示",
         "agendaDayEmpty": "予定なし",
-        "openInMap": "地図で開く"
+        "openInMap": "地図で開く",
+        "filtersSources": "カレンダー",
+        "filterUnassigned": "割り当てなし"
     },
     "noteCategories": {
         "permissionLabel": "世帯のメモカテゴリーを管理"

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -960,7 +960,9 @@
         "filtersReset": "모든 필터 해제",
         "filtersDisplay": "표시",
         "agendaDayEmpty": "예정된 일정 없음",
-        "openInMap": "지도에서 열기"
+        "openInMap": "지도에서 열기",
+        "filtersSources": "캘린더",
+        "filterUnassigned": "할당되지 않음"
     },
     "noteCategories": {
         "permissionLabel": "가정 메모 카테고리 관리"

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -948,7 +948,9 @@
         "filtersReset": "Alle filters wissen",
         "filtersDisplay": "Weergave",
         "agendaDayEmpty": "Niets gepland",
-        "openInMap": "Openen in Maps"
+        "openInMap": "Openen in Maps",
+        "filtersSources": "Agenda's",
+        "filterUnassigned": "Niet toegewezen"
     },
     "noteCategories": {
         "permissionLabel": "Notitiecategorieën voor het huishouden beheren"

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -960,7 +960,9 @@
         "filtersReset": "Wyczyść wszystkie filtry",
         "filtersDisplay": "Wyświetlanie",
         "agendaDayEmpty": "Nic zaplanowane",
-        "openInMap": "Otwórz w mapach"
+        "openInMap": "Otwórz w mapach",
+        "filtersSources": "Kalendarze",
+        "filterUnassigned": "Nieprzypisane"
     },
     "noteCategories": {
         "permissionLabel": "Zarządzaj domowymi kategoriami notatek"

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -948,7 +948,9 @@
         "filtersReset": "Limpar todos os filtros",
         "filtersDisplay": "Apresentação",
         "agendaDayEmpty": "Nada planeado",
-        "openInMap": "Abrir no Maps"
+        "openInMap": "Abrir no Maps",
+        "filtersSources": "Calendários",
+        "filterUnassigned": "Não atribuídos"
     },
     "noteCategories": {
         "permissionLabel": "Gerir categorias de notas do agregado familiar"

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -948,7 +948,9 @@
         "filtersReset": "Снять все фильтры",
         "filtersDisplay": "Отображение",
         "agendaDayEmpty": "Ничего не запланировано",
-        "openInMap": "Открыть в Картах"
+        "openInMap": "Открыть в Картах",
+        "filtersSources": "Календари",
+        "filterUnassigned": "Не назначенные"
     },
     "noteCategories": {
         "permissionLabel": "Управлять семейными категориями заметок"

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -948,7 +948,9 @@
         "filtersReset": "Rensa alla filter",
         "filtersDisplay": "Visning",
         "agendaDayEmpty": "Inget planerat",
-        "openInMap": "Öppna i Kartor"
+        "openInMap": "Öppna i Kartor",
+        "filtersSources": "Kalendrar",
+        "filterUnassigned": "Ej tilldelade"
     },
     "noteCategories": {
         "permissionLabel": "Hantera hushållets anteckningskategorier"

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -948,7 +948,9 @@
         "filtersReset": "Tüm filtreleri kaldır",
         "filtersDisplay": "Görünüm",
         "agendaDayEmpty": "Planlanmış bir şey yok",
-        "openInMap": "Haritada aç"
+        "openInMap": "Haritada aç",
+        "filtersSources": "Takvimler",
+        "filterUnassigned": "Atanmamış"
     },
     "noteCategories": {
         "permissionLabel": "Ev notu kategorilerini yönet"

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -948,7 +948,9 @@
         "filtersReset": "Зняти всі фільтри",
         "filtersDisplay": "Відображення",
         "agendaDayEmpty": "Нічого не заплановано",
-        "openInMap": "Відкрити на картах"
+        "openInMap": "Відкрити на картах",
+        "filtersSources": "Календарі",
+        "filterUnassigned": "Не призначені"
     },
     "noteCategories": {
         "permissionLabel": "Керувати сімейними категоріями нотаток"

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -948,7 +948,9 @@
         "filtersReset": "Xóa tất cả bộ lọc",
         "filtersDisplay": "Hiển thị",
         "agendaDayEmpty": "Không có kế hoạch",
-        "openInMap": "Mở trong Bản đồ"
+        "openInMap": "Mở trong Bản đồ",
+        "filtersSources": "Lịch",
+        "filterUnassigned": "Chưa được giao"
     },
     "noteCategories": {
         "permissionLabel": "Quản lý danh mục ghi chú gia đình"

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -948,7 +948,9 @@
         "filtersReset": "清除所有筛选",
         "filtersDisplay": "显示",
         "agendaDayEmpty": "没有安排",
-        "openInMap": "在地图中打开"
+        "openInMap": "在地图中打开",
+        "filtersSources": "日历",
+        "filterUnassigned": "未分配"
     },
     "noteCategories": {
         "permissionLabel": "管理家庭笔记分类"

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1099,15 +1099,18 @@ function calendarSources() {
     const key = eventSourceKey(ev);
     if (!key) continue;
     const bekannt = quellen.get(key);
-    // Ein noch nicht hochgeladener Termin kennt Name und Farbe seines Ziels
-    // nicht (`cal_name` folgt `calendar_ref_id`); ein anderer Termin derselben
-    // Quelle oder der Merker fuellt sie nach.
+    // Name und Farbe der QUELLE: `source_calendar_*` loest der Server auch fuer
+    // einen noch nicht hochgeladenen Termin ueber sein Ziel auf, `cal_name` und
+    // `cal_color` folgen nur `calendar_ref_id` - und tragen bei Abos die Werte
+    // des Abos. Fehlt beides, fuellt ein anderer Termin oder der Merker nach.
+    const name = ev.source_calendar_name || ev.cal_name || '';
+    const color = ev.source_calendar_color || ev.cal_color || null;
     if (bekannt) {
-      bekannt.name ||= ev.cal_name || '';
-      bekannt.color ||= ev.cal_color || null;
+      bekannt.name ||= name;
+      bekannt.color ||= color;
       continue;
     }
-    quellen.set(key, { key, name: ev.cal_name || '', color: ev.cal_color || null });
+    quellen.set(key, { key, name, color });
   }
   for (const [key, merk] of state.hiddenSources ?? []) {
     const bekannt = quellen.get(key);

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -342,6 +342,13 @@ const SCHEDULE_DISPLAY_KEY = 'yuvomi:calendar:schedule-display';
 const MONTH_TITLES_KEY = 'yuvomi:calendar:month-titles';
 const ASSIGNED_TO_ME_KEY  = 'yuvomi:calendar:assignedToMe';
 const PEOPLE_FILTER_KEY   = 'yuvomi:calendar:people';
+// Ausgeblendete Kalender und Abos (#1064), geraeteweit wie die Ebenen. Mit Name
+// und Farbe gemerkt: eine ausgeblendete Quelle muss im Blatt auch dann wieder
+// einzuschalten sein, wenn im geladenen Zeitraum kein Termin von ihr liegt.
+const HIDDEN_SOURCES_KEY  = 'yuvomi:calendar:sources-hidden';
+// Der Eintrag „Nicht zugewiesen" auf der Personenachse (#1064). Ein String,
+// damit er mit keiner Nutzer-ID zusammenfallen kann.
+const UNASSIGNED = 'none';
 
 /* DIE FEIERTAGSFARBEN, WENN DER HAUSHALT KEINE GEWAEHLT HAT.
  *
@@ -620,6 +627,7 @@ let state = {
   // `assigned_users`, ihre Farbe gehoert ihr, und in einem FAMILIENplaner ist
   // „wessen Termin ist das" die Frage, die der Filter beantworten soll.
   people:        new Set(),
+  hiddenSources: new Map(), // Quellschluessel -> { name, color }, siehe calendarSources()
 };
 let _container = null;
 const calendarLoads = createCalendarLoadCoordinator();
@@ -1020,13 +1028,17 @@ function belongsToMe(item) {
  * herausfuehrt: wer alle Haekchen entfernt, saehe nichts mehr und haette
  * ausserhalb des Blatts keinen Hinweis darauf, warum.
  *
- * Termine OHNE Zuweisung fallen bei aktivem Filter heraus. Das ist Absicht:
- * der Filter beantwortet „wessen Termin", und ein Termin ohne Person ist
- * keine Antwort darauf. Der Rueckweg steht im Blatt.
+ * Termine OHNE Zuweisung haben seit #1064 einen eigenen Eintrag auf dieser
+ * Achse: `UNASSIGNED`, die Antwort „niemandes" auf „wessen Termin". Steht er in
+ * der Auswahl, bleiben sie stehen; allein gewaehlt zeigt er nur sie. Ein Filter,
+ * der VOR #1064 gespeichert wurde, kennt den Eintrag nicht und behaelt damit
+ * sein Verhalten: ein Termin ohne Person faellt heraus.
  */
 function matchesPeopleFilter(item) {
   if (state.people.size === 0) return true;
-  return (item.assigned_users ?? []).some((u) => state.people.has(u.id));
+  const zugewiesen = item.assigned_users ?? [];
+  if (zugewiesen.length === 0) return state.people.has(UNASSIGNED);
+  return zugewiesen.some((u) => state.people.has(u.id));
 }
 
 /**
@@ -1044,11 +1056,53 @@ function passesPersonFilters(item) {
   return belongsToMe(item) && matchesPeopleFilter(item);
 }
 
+/**
+ * Die Quelle eines Termins als Schluessel, oder null fuer einen eigenen (#1064).
+ *
+ * CalDAV-, Google- und Apple-Kalender haengen ueber `calendar_ref_id` an
+ * `external_calendars`, ICS-Abos ueber `subscription_id`. Outlook schreibt nur
+ * hinaus und bringt keine Termine mit, die eine Quelle haetten.
+ */
+function eventSourceKey(ev) {
+  if (ev?.subscription_id) return `sub:${ev.subscription_id}`;
+  if (ev?.calendar_ref_id) return `cal:${ev.calendar_ref_id}`;
+  return null;
+}
+
+/** True, solange die Quelle des Termins nicht ausgeblendet ist. Eigene Termine haben keine. */
+function passesSourceFilter(item) {
+  const key = eventSourceKey(item);
+  return !key || !state.hiddenSources?.has(key);
+}
+
+/**
+ * Die Kalender und Abos fuer das Filterblatt (#1064).
+ *
+ * Aus den geladenen Terminen, dazu jede ausgeblendete Quelle, auch ohne Termin
+ * im Zeitraum - sonst liesse sich nur zurueckholen, was gerade zu sehen waere.
+ * Keine eigene Route: Name und Farbe liefert der Server an jedem Termin
+ * (`cal_name`, `cal_color`), und die Verwaltungsrouten der Quellen sind
+ * `requireAdmin` - ein Mitglied kaeme dort nicht durch.
+ */
+function calendarSources() {
+  const quellen = new Map();
+  for (const ev of state.events ?? []) {
+    const key = eventSourceKey(ev);
+    if (!key || quellen.has(key)) continue;
+    quellen.set(key, { key, name: ev.cal_name || '', color: ev.cal_color || null });
+  }
+  for (const [key, merk] of state.hiddenSources ?? []) {
+    if (!quellen.has(key)) quellen.set(key, { key, name: merk.name || '', color: merk.color || null });
+  }
+  return [...quellen.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
 /** Wie viele Filter gerade etwas wegnehmen - die Zahl am Filterknopf. */
 function activeFilterCount() {
   let n = 0;
   if (state.assignedToMe) n += 1;
   if (state.people.size > 0) n += 1;
+  if (state.hiddenSources?.size > 0) n += 1;
   const hp = state.holidayPrefs ?? {};
   if (hp.holiday_show_public && !state.layerHolidays) n += 1;
   if (hp.holiday_show_school && !state.layerSchool) n += 1;
@@ -1087,7 +1141,9 @@ function eventsOnDay(dateStr) {
         return start <= dateStr && end >= dateStr;
       });
   const layered = state.layerBirthdays ? list : list.filter(isVisibleLayer);
-  return layered.filter(passesPersonFilters);
+  // Quelle UND Person (#1064), wie Ebenen und Personen schon zusammenwirken.
+  // Hier und nicht in passesPersonFilters: Aufgaben und Schichten haben keine Quelle.
+  return layered.filter((e) => passesSourceFilter(e) && passesPersonFilters(e));
 }
 
 /**
@@ -1476,6 +1532,7 @@ export async function render(container, { user }) {
   state.user          = user ?? null;
   state.assignedToMe  = localStorage.getItem(ASSIGNED_TO_ME_KEY) === '1';
   state.people = restorePeopleFilter(state.users);
+  state.hiddenSources = restoreHiddenSources();
 
   renderToolbar();
   renderView();
@@ -2905,12 +2962,23 @@ function personInitials(name) {
 function openCalendarFilters() {
   const layers = availableLayers();
   const people = state.users ?? [];
+  const sources = calendarSources();
 
   const layerRows = layers.map((row) => toggleRowHtml({
     label: row.label,
     checked: row.checked,
     swatchColor: row.color,
     attrs: { 'data-filter-layer': row.key },
+  })).join('');
+
+  // Je Kalender und Abo ein Schalter (#1064), mit der Farbe, die seine Termine
+  // tragen. Neben den Ebenen, nicht in ihnen: eine Ebene ist eine Sorte Eintrag,
+  // eine Quelle ist, woher ein gewoehnlicher Termin kommt.
+  const sourceRows = sources.map((s) => toggleRowHtml({
+    label: s.name || t('calendar.detailCalendar'),
+    checked: !state.hiddenSources.has(s.key),
+    swatchColor: s.color,
+    attrs: { 'data-filter-source': s.key },
   })).join('');
 
   // Der Anzeigemodus des Schichtplans ist KEIN Filter - er nimmt nichts weg,
@@ -2962,6 +3030,14 @@ function openCalendarFilters() {
     attrs: { 'data-filter-person': String(u.id) },
   })).join('');
 
+  // „Nicht zugewiesen" als Eintrag der Personenachse (#1064): dieselbe Lesart
+  // wie eine Person - leeres Set heisst alle, also steht er dann auf „an".
+  const unassignedRow = people.length ? toggleRowHtml({
+    label: t('calendar.filterUnassigned'),
+    checked: state.people.size === 0 || state.people.has(UNASSIGNED),
+    attrs: { 'data-filter-person': UNASSIGNED },
+  }) : '';
+
   const content = `
     <div class="cal-filters">
       ${layerRows ? `
@@ -2970,11 +3046,18 @@ function openCalendarFilters() {
           ${layerRows}
         </section>
       ` : ''}
+      ${sourceRows ? `
+        <section class="cal-filters__group">
+          <h3 class="cal-filters__heading">${t('calendar.filtersSources')}</h3>
+          ${sourceRows}
+        </section>
+      ` : ''}
       ${(meRow || personRows) ? `
         <section class="cal-filters__group">
           <h3 class="cal-filters__heading">${t('calendar.filtersPeople')}</h3>
           ${meRow}
           ${personRows}
+          ${unassignedRow}
         </section>
       ` : ''}
       ${(scheduleDisplayRow || monthTitlesRow) ? `
@@ -3020,19 +3103,31 @@ function openCalendarFilters() {
     } else if (input.dataset.filterMine) {
       state.assignedToMe = input.checked;
       try { localStorage.setItem(ASSIGNED_TO_ME_KEY, input.checked ? '1' : '0'); } catch {}
+    } else if (input.dataset.filterSource) {
+      const key = input.dataset.filterSource;
+      if (input.checked) {
+        state.hiddenSources.delete(key);
+      } else {
+        const quelle = sources.find((s) => s.key === key);
+        state.hiddenSources.set(key, { name: quelle?.name ?? '', color: quelle?.color ?? null });
+      }
+      persistHiddenSources();
     } else if (input.dataset.filterPerson) {
-      const id = Number(input.dataset.filterPerson);
+      const raw = input.dataset.filterPerson;
+      const id = raw === UNASSIGNED ? UNASSIGNED : Number(raw);
       // Der Sprung aus „alle" heraus: das erste Abwaehlen macht aus dem leeren
       // Set die Menge der UEBRIGEN. Ohne diesen Schritt haette ein Klick auf
-      // ein Haekchen, das „alle" bedeutet, gar nichts getan.
+      // ein Haekchen, das „alle" bedeutet, gar nichts getan. „Nicht zugewiesen"
+      // gehoert zu den uebrigen (#1064).
       if (state.people.size === 0) {
         for (const u of state.users ?? []) state.people.add(u.id);
+        state.people.add(UNASSIGNED);
       }
       if (input.checked) state.people.add(id);
       else state.people.delete(id);
       // Wieder ALLE gewaehlt heisst wieder „kein Filter" - sonst bliebe ein
       // Filter aktiv, der nichts wegnimmt, und der Zaehler am Knopf loege.
-      if (state.people.size === (state.users ?? []).length) state.people.clear();
+      if (state.people.size === (state.users ?? []).length + 1) state.people.clear();
       persistPeopleFilter();
     } else {
       return;
@@ -3049,6 +3144,8 @@ function openCalendarFilters() {
     state.layerBirthdays = true;
     state.assignedToMe = false;
     state.people.clear();
+    state.hiddenSources.clear();
+    persistHiddenSources();
     try {
       localStorage.setItem(LAYER_HOLIDAYS_KEY, 'true');
       localStorage.setItem(LAYER_SCHOOL_KEY, 'true');
@@ -3075,10 +3172,13 @@ function openCalendarFilters() {
  */
 function restorePeopleFilter(users) {
   const known = new Set((users ?? []).map((u) => u.id));
+  // „Nicht zugewiesen" gehoert zur Achse (#1064) - ohne diesen Eintrag fiele er
+  // beim Laden als unbekannte ID weg.
+  known.add(UNASSIGNED);
   let stored;
   try { stored = JSON.parse(localStorage.getItem(PEOPLE_FILTER_KEY) ?? '[]'); } catch { stored = []; }
   if (!Array.isArray(stored)) return new Set();
-  const valid = stored.map(Number).filter((id) => known.has(id));
+  const valid = stored.map((id) => (id === UNASSIGNED ? id : Number(id))).filter((id) => known.has(id));
   if (valid.length === 0 || valid.length === known.size) return new Set();
   return new Set(valid);
 }
@@ -3087,6 +3187,36 @@ function persistPeopleFilter() {
   try {
     if (state.people.size === 0) localStorage.removeItem(PEOPLE_FILTER_KEY);
     else localStorage.setItem(PEOPLE_FILTER_KEY, JSON.stringify([...state.people]));
+  } catch {}
+}
+
+/**
+ * Die ausgeblendeten Quellen aus dem Geraet (#1064).
+ *
+ * Anders als beim Personenfilter gibt es hier keine Liste, gegen die sich
+ * pruefen liesse: die Quellen kennt die Seite nur ueber die geladenen Termine.
+ * Eine inzwischen geloeschte Quelle bleibt deshalb unter ihrem gemerkten Namen
+ * im Blatt stehen, bis jemand sie wieder einschaltet oder alle Filter aufhebt -
+ * sichtbar und mit Rueckweg, statt still weiter zu filtern.
+ */
+function restoreHiddenSources() {
+  let stored;
+  try { stored = JSON.parse(localStorage.getItem(HIDDEN_SOURCES_KEY) ?? '[]'); } catch { stored = []; }
+  const quellen = new Map();
+  if (!Array.isArray(stored)) return quellen;
+  for (const eintrag of stored) {
+    if (!eintrag || !/^(?:cal|sub):\d+$/.test(String(eintrag.key))) continue;
+    // Die Farbe landet als Scheibe im Blatt; aus dem Speicher nur, was eine Farbe ist.
+    const color = /^#[0-9a-f]{3,8}$/i.test(String(eintrag.color ?? '')) ? eintrag.color : null;
+    quellen.set(eintrag.key, { name: String(eintrag.name ?? ''), color });
+  }
+  return quellen;
+}
+
+function persistHiddenSources() {
+  try {
+    if (state.hiddenSources.size === 0) localStorage.removeItem(HIDDEN_SOURCES_KEY);
+    else localStorage.setItem(HIDDEN_SOURCES_KEY, JSON.stringify([...state.hiddenSources].map(([key, merk]) => ({ key, ...merk }))));
   } catch {}
 }
 
@@ -3332,6 +3462,13 @@ export const __test = {
   eventsOnDay,
   passesPersonFilters,
   eventMapUrl,
+  eventSourceKey,
+  passesSourceFilter,
+  calendarSources,
+  restorePeopleFilter,
+  restoreHiddenSources,
+  activeFilterCount,
+  UNASSIGNED,
   eventEndDate,
   isMultiDayEvent,
   eventWhenText,

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1062,10 +1062,16 @@ function passesPersonFilters(item) {
  * CalDAV-, Google- und Apple-Kalender haengen ueber `calendar_ref_id` an
  * `external_calendars`, ICS-Abos ueber `subscription_id`. Outlook schreibt nur
  * hinaus und bringt keine Termine mit, die eine Quelle haetten.
+ *
+ * `source_calendar_ref_id` loest der Server auf: `calendar_ref_id`, sonst der
+ * gewaehlte Zielkalender. Ein neuer Termin fuer einen ausgeblendeten Kalender
+ * traegt `calendar_ref_id` erst nach dem Hochladen - ohne das Ziel bliebe er
+ * bis dahin stehen, bei scheiterndem Sync auf Dauer.
  */
 function eventSourceKey(ev) {
   if (ev?.subscription_id) return `sub:${ev.subscription_id}`;
-  if (ev?.calendar_ref_id) return `cal:${ev.calendar_ref_id}`;
+  const ref = ev?.source_calendar_ref_id ?? ev?.calendar_ref_id;
+  if (ref) return `cal:${ref}`;
   return null;
 }
 
@@ -1088,11 +1094,26 @@ function calendarSources() {
   const quellen = new Map();
   for (const ev of state.events ?? []) {
     const key = eventSourceKey(ev);
-    if (!key || quellen.has(key)) continue;
+    if (!key) continue;
+    const bekannt = quellen.get(key);
+    // Ein noch nicht hochgeladener Termin kennt Name und Farbe seines Ziels
+    // nicht (`cal_name` folgt `calendar_ref_id`); ein anderer Termin derselben
+    // Quelle oder der Merker fuellt sie nach.
+    if (bekannt) {
+      bekannt.name ||= ev.cal_name || '';
+      bekannt.color ||= ev.cal_color || null;
+      continue;
+    }
     quellen.set(key, { key, name: ev.cal_name || '', color: ev.cal_color || null });
   }
   for (const [key, merk] of state.hiddenSources ?? []) {
-    if (!quellen.has(key)) quellen.set(key, { key, name: merk.name || '', color: merk.color || null });
+    const bekannt = quellen.get(key);
+    if (!bekannt) {
+      quellen.set(key, { key, name: merk.name || '', color: merk.color || null });
+    } else {
+      bekannt.name ||= merk.name || '';
+      bekannt.color ||= merk.color || null;
+    }
   }
   return [...quellen.values()].sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -342,9 +342,12 @@ const SCHEDULE_DISPLAY_KEY = 'yuvomi:calendar:schedule-display';
 const MONTH_TITLES_KEY = 'yuvomi:calendar:month-titles';
 const ASSIGNED_TO_ME_KEY  = 'yuvomi:calendar:assignedToMe';
 const PEOPLE_FILTER_KEY   = 'yuvomi:calendar:people';
-// Ausgeblendete Kalender und Abos (#1064), geraeteweit wie die Ebenen. Mit Name
+// Ausgeblendete Kalender und Abos (#1064), auf dem Geraet und je Nutzer. Mit Name
 // und Farbe gemerkt: eine ausgeblendete Quelle muss im Blatt auch dann wieder
-// einzuschalten sein, wenn im geladenen Zeitraum kein Termin von ihr liegt.
+// einzuschalten sein, wenn im geladenen Zeitraum kein Termin von ihr liegt. Genau
+// deshalb nicht geraeteweit wie die Ebenen: ein privates Abo sieht nur, wer es
+// angelegt hat, und ein geteilter Browser zeigte seinen Namen sonst dem naechsten
+// Konto (Codex-Review zu #1124). Schluessel siehe hiddenSourcesKey().
 const HIDDEN_SOURCES_KEY  = 'yuvomi:calendar:sources-hidden';
 // Der Eintrag „Nicht zugewiesen" auf der Personenachse (#1064). Ein String,
 // damit er mit keiner Nutzer-ID zusammenfallen kann.
@@ -1553,7 +1556,7 @@ export async function render(container, { user }) {
   state.user          = user ?? null;
   state.assignedToMe  = localStorage.getItem(ASSIGNED_TO_ME_KEY) === '1';
   state.people = restorePeopleFilter(state.users);
-  state.hiddenSources = restoreHiddenSources();
+  state.hiddenSources = restoreHiddenSources(state.user?.id);
 
   renderToolbar();
   renderView();
@@ -3211,8 +3214,13 @@ function persistPeopleFilter() {
   } catch {}
 }
 
+/** Der Speicherschluessel je Nutzer; ohne angemeldeten Nutzer wird nichts gemerkt. */
+function hiddenSourcesKey(userId) {
+  return userId == null ? null : `${HIDDEN_SOURCES_KEY}:${userId}`;
+}
+
 /**
- * Die ausgeblendeten Quellen aus dem Geraet (#1064).
+ * Die ausgeblendeten Quellen dieses Nutzers aus dem Geraet (#1064).
  *
  * Anders als beim Personenfilter gibt es hier keine Liste, gegen die sich
  * pruefen liesse: die Quellen kennt die Seite nur ueber die geladenen Termine.
@@ -3220,10 +3228,12 @@ function persistPeopleFilter() {
  * im Blatt stehen, bis jemand sie wieder einschaltet oder alle Filter aufhebt -
  * sichtbar und mit Rueckweg, statt still weiter zu filtern.
  */
-function restoreHiddenSources() {
-  let stored;
-  try { stored = JSON.parse(localStorage.getItem(HIDDEN_SOURCES_KEY) ?? '[]'); } catch { stored = []; }
+function restoreHiddenSources(userId) {
   const quellen = new Map();
+  const schluessel = hiddenSourcesKey(userId);
+  if (!schluessel) return quellen;
+  let stored;
+  try { stored = JSON.parse(localStorage.getItem(schluessel) ?? '[]'); } catch { stored = []; }
   if (!Array.isArray(stored)) return quellen;
   for (const eintrag of stored) {
     if (!eintrag || !/^(?:cal|sub):\d+$/.test(String(eintrag.key))) continue;
@@ -3235,9 +3245,11 @@ function restoreHiddenSources() {
 }
 
 function persistHiddenSources() {
+  const schluessel = hiddenSourcesKey(state.user?.id);
+  if (!schluessel) return;
   try {
-    if (state.hiddenSources.size === 0) localStorage.removeItem(HIDDEN_SOURCES_KEY);
-    else localStorage.setItem(HIDDEN_SOURCES_KEY, JSON.stringify([...state.hiddenSources].map(([key, merk]) => ({ key, ...merk }))));
+    if (state.hiddenSources.size === 0) localStorage.removeItem(schluessel);
+    else localStorage.setItem(schluessel, JSON.stringify([...state.hiddenSources].map(([key, merk]) => ({ key, ...merk }))));
   } catch {}
 }
 
@@ -3488,6 +3500,7 @@ export const __test = {
   calendarSources,
   restorePeopleFilter,
   restoreHiddenSources,
+  persistHiddenSources,
   activeFilterCount,
   UNASSIGNED,
   eventEndDate,

--- a/server/routes/calendar/crud.js
+++ b/server/routes/calendar/crud.js
@@ -16,7 +16,7 @@ import {
   stageDocumentUpload,
 } from '../../services/document-storage.js';
 import { queueEventDeletion, markEventOutbound, flushOutbound } from '../../services/calendar-outbound.js';
-import { SOURCE_CALENDAR_REF_SQL } from '../../services/calendar-events.js';
+import { SOURCE_CALENDAR_COLUMNS, SOURCE_CALENDAR_JOIN } from '../../services/calendar-events.js';
 import {
   ASSIGNED_USERS_SQL,
   getUserId,
@@ -57,7 +57,7 @@ router.get('/:id', (req, res) => {
              -- angelegter oder geaenderter Termin kam ohne ihn zurueck.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
-             ${SOURCE_CALENDAR_REF_SQL},
+             ${SOURCE_CALENDAR_COLUMNS},
              COALESCE(bd.name, nd.name) AS birthday_name,
              bd.birth_date AS birthday_date,
              nd.name_day   AS name_day,
@@ -69,6 +69,7 @@ router.get('/:id', (req, res) => {
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
       LEFT JOIN users u_created  ON u_created.id  = e.created_by
       LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+      ${SOURCE_CALENDAR_JOIN}
       LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
       LEFT JOIN birthdays bd ON bd.calendar_event_id = e.id
       LEFT JOIN birthdays nd ON nd.name_day_calendar_event_id = e.id
@@ -212,12 +213,13 @@ router.post('/', async (req, res) => {
              -- angelegter oder geaenderter Termin kam ohne ihn zurueck.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
-             ${SOURCE_CALENDAR_REF_SQL},
+             ${SOURCE_CALENDAR_COLUMNS},
              ${ASSIGNED_USERS_SQL}
       FROM calendar_events e
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
       LEFT JOIN users u_created  ON u_created.id  = e.created_by
       LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+      ${SOURCE_CALENDAR_JOIN}
       LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
       WHERE e.id = ?
     `).get(eventId);
@@ -574,12 +576,13 @@ router.put('/:id', async (req, res) => {
              -- angelegter oder geaenderter Termin kam ohne ihn zurueck.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
-             ${SOURCE_CALENDAR_REF_SQL},
+             ${SOURCE_CALENDAR_COLUMNS},
              ${ASSIGNED_USERS_SQL}
       FROM calendar_events e
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
       LEFT JOIN users u_created  ON u_created.id  = e.created_by
       LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+      ${SOURCE_CALENDAR_JOIN}
       LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
       WHERE e.id = ?
     `).get(id);

--- a/server/routes/calendar/crud.js
+++ b/server/routes/calendar/crud.js
@@ -563,6 +563,17 @@ router.put('/:id', async (req, res) => {
       setEventAssignments(db.get(), id, userIds);
     })();
 
+    // Änderung an einem synchronisierten Termin beim Provider nachziehen (#593):
+    // geänderte Felder als Patch, ein gewechselter Zielkalender als Umzug.
+    // Wie beim Löschen: vormerken, antworten, danach best effort ausführen.
+    // Vorgemerkt wird VOR dem Lesen der Antwort: deren Quelle folgt einem
+    // anstehenden Umzug, und ohne ihn filterte die Seite den Termin bis zum
+    // nächsten Laden weiter als Teil des alten Kalenders (#1064).
+    const pending = markEventOutbound(
+      event,
+      db.get().prepare('SELECT * FROM calendar_events WHERE id = ?').get(id),
+    );
+
     const updated = db.get().prepare(`
       SELECT e.*,
              u_assigned.display_name AS assigned_name,
@@ -586,11 +597,6 @@ router.put('/:id', async (req, res) => {
       LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
       WHERE e.id = ?
     `).get(id);
-
-    // Änderung an einem synchronisierten Termin beim Provider nachziehen (#593):
-    // geänderte Felder als Patch, ein gewechselter Zielkalender als Umzug.
-    // Wie beim Löschen: vormerken, antworten, danach best effort ausführen.
-    const pending = markEventOutbound(event, updated);
 
     res.json({ data: serializeEvent(updated) });
 

--- a/server/routes/calendar/crud.js
+++ b/server/routes/calendar/crud.js
@@ -16,6 +16,7 @@ import {
   stageDocumentUpload,
 } from '../../services/document-storage.js';
 import { queueEventDeletion, markEventOutbound, flushOutbound } from '../../services/calendar-outbound.js';
+import { SOURCE_CALENDAR_REF_SQL } from '../../services/calendar-events.js';
 import {
   ASSIGNED_USERS_SQL,
   getUserId,
@@ -56,6 +57,7 @@ router.get('/:id', (req, res) => {
              -- angelegter oder geaenderter Termin kam ohne ihn zurueck.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
+             ${SOURCE_CALENDAR_REF_SQL},
              COALESCE(bd.name, nd.name) AS birthday_name,
              bd.birth_date AS birthday_date,
              nd.name_day   AS name_day,
@@ -210,6 +212,7 @@ router.post('/', async (req, res) => {
              -- angelegter oder geaenderter Termin kam ohne ihn zurueck.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
+             ${SOURCE_CALENDAR_REF_SQL},
              ${ASSIGNED_USERS_SQL}
       FROM calendar_events e
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
@@ -571,6 +574,7 @@ router.put('/:id', async (req, res) => {
              -- angelegter oder geaenderter Termin kam ohne ihn zurueck.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
+             ${SOURCE_CALENDAR_REF_SQL},
              ${ASSIGNED_USERS_SQL}
       FROM calendar_events e
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to

--- a/server/routes/calendar/read.js
+++ b/server/routes/calendar/read.js
@@ -7,7 +7,7 @@ import { createLogger } from '../../logger.js';
 import express from 'express';
 import * as db from '../../db.js';
 import { DATE_RE } from '../../middleware/validate.js';
-import { expandRecurringEvents, getUpcomingEvents, loadEventExceptions } from '../../services/calendar-events.js';
+import { expandRecurringEvents, getUpcomingEvents, loadEventExceptions, SOURCE_CALENDAR_REF_SQL } from '../../services/calendar-events.js';
 import { buildMatchQuery } from '../../services/search.js';
 import { visibilityWhere } from '../../services/visibility.js';
 import { VALID_SOURCES, ASSIGNED_USERS_SQL, getUserId, serializeEvent } from './helpers.js';
@@ -52,6 +52,7 @@ router.get('/', (req, res) => {
              -- sichtbar die Farbe seiner Quelle und konnte sie nirgends nennen.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
+             ${SOURCE_CALENDAR_REF_SQL},
              COALESCE(bd.name, nd.name) AS birthday_name,
              bd.birth_date AS birthday_date,
              nd.name_day   AS name_day,
@@ -178,6 +179,7 @@ router.get('/search', (req, res) => {
              -- sichtbar die Farbe seiner Quelle und konnte sie nirgends nennen.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
+             ${SOURCE_CALENDAR_REF_SQL},
              COALESCE(bd.name, nd.name) AS birthday_name,
              bd.birth_date AS birthday_date,
              nd.name_day   AS name_day,

--- a/server/routes/calendar/read.js
+++ b/server/routes/calendar/read.js
@@ -7,7 +7,7 @@ import { createLogger } from '../../logger.js';
 import express from 'express';
 import * as db from '../../db.js';
 import { DATE_RE } from '../../middleware/validate.js';
-import { expandRecurringEvents, getUpcomingEvents, loadEventExceptions, SOURCE_CALENDAR_REF_SQL } from '../../services/calendar-events.js';
+import { expandRecurringEvents, getUpcomingEvents, loadEventExceptions, SOURCE_CALENDAR_COLUMNS, SOURCE_CALENDAR_JOIN } from '../../services/calendar-events.js';
 import { buildMatchQuery } from '../../services/search.js';
 import { visibilityWhere } from '../../services/visibility.js';
 import { VALID_SOURCES, ASSIGNED_USERS_SQL, getUserId, serializeEvent } from './helpers.js';
@@ -52,7 +52,7 @@ router.get('/', (req, res) => {
              -- sichtbar die Farbe seiner Quelle und konnte sie nirgends nennen.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
-             ${SOURCE_CALENDAR_REF_SQL},
+             ${SOURCE_CALENDAR_COLUMNS},
              COALESCE(bd.name, nd.name) AS birthday_name,
              bd.birth_date AS birthday_date,
              nd.name_day   AS name_day,
@@ -63,6 +63,7 @@ router.get('/', (req, res) => {
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
       LEFT JOIN users u_created  ON u_created.id  = e.created_by
       LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+      ${SOURCE_CALENDAR_JOIN}
       LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
       LEFT JOIN birthdays bd ON bd.calendar_event_id = e.id
       LEFT JOIN birthdays nd ON nd.name_day_calendar_event_id = e.id
@@ -179,7 +180,7 @@ router.get('/search', (req, res) => {
              -- sichtbar die Farbe seiner Quelle und konnte sie nirgends nennen.
              COALESCE(ec.name, isub.name)   AS cal_name,
              COALESCE(ec.color, isub.color) AS cal_color,
-             ${SOURCE_CALENDAR_REF_SQL},
+             ${SOURCE_CALENDAR_COLUMNS},
              COALESCE(bd.name, nd.name) AS birthday_name,
              bd.birth_date AS birthday_date,
              nd.name_day   AS name_day,
@@ -191,6 +192,7 @@ router.get('/search', (req, res) => {
       LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
       LEFT JOIN users u_created  ON u_created.id  = e.created_by
       LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+      ${SOURCE_CALENDAR_JOIN}
       LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
       LEFT JOIN birthdays bd ON bd.calendar_event_id = e.id
       LEFT JOIN birthdays nd ON nd.name_day_calendar_event_id = e.id

--- a/server/services/calendar-events.js
+++ b/server/services/calendar-events.js
@@ -31,16 +31,25 @@ const ASSIGNED_USERS_SQL = `(
  * Ohne diesen Rueckfall bliebe er stehen, obwohl sein Kalender ausgeblendet ist.
  *
  * Bewusst nicht im Join fuer `cal_name`/`cal_color`: die geerbte Farbe folgt
- * weiter dem, was der Sync bestaetigt hat. Jeder Lesepfad, der Termine an die
- * Kalenderseite liefert, waehlt dieses Feld mit aus.
+ * weiter dem, was der Sync bestaetigt hat. Name und Farbe der QUELLE kommen
+ * trotzdem mit (`source_calendar_name`/`_color`): ohne sie stand ein Kalender,
+ * von dem nur ein neuer Termin im Zeitraum liegt, im Filterblatt als
+ * namenloses „Kalender" - zwei davon waren nicht zu unterscheiden (Codex-Review
+ * zu #1124). Jeder Lesepfad, der Termine an die Kalenderseite liefert, nimmt
+ * den Join und die Spalten mit.
  */
-export const SOURCE_CALENDAR_REF_SQL = `COALESCE(
+export const SOURCE_CALENDAR_JOIN = `LEFT JOIN external_calendars src ON src.id = COALESCE(
   e.calendar_ref_id,
   (SELECT tg.id FROM external_calendars tg
     WHERE tg.source = 'google' AND tg.external_id = e.target_google_calendar_id),
   (SELECT tc.id FROM external_calendars tc
     WHERE tc.source = 'caldav' AND tc.external_id = e.target_caldav_calendar_url)
-) AS source_calendar_ref_id`;
+)`;
+
+/** Die Spalten zu SOURCE_CALENDAR_JOIN: ID, Name und Farbe der aufgeloesten Quelle. */
+export const SOURCE_CALENDAR_COLUMNS = `src.id    AS source_calendar_ref_id,
+  src.name  AS source_calendar_name,
+  src.color AS source_calendar_color`;
 
 /**
  * Lädt die Instanz-Ausnahmen (EXDATE, #489) für die gegebenen Event-IDs als Map.
@@ -323,7 +332,7 @@ export function getUpcomingEvents(d, {
            -- am Abo-Termin NULL, obwohl dessen Farbe schon herauskam (#1064).
            COALESCE(ec.name, isub.name)   AS cal_name,
            COALESCE(ec.color, isub.color) AS cal_color,
-           ${SOURCE_CALENDAR_REF_SQL},
+           ${SOURCE_CALENDAR_COLUMNS},
            COALESCE(bd.name, nd.name) AS birthday_name,
            bd.birth_date AS birthday_date,
            nd.name_day   AS name_day,
@@ -333,6 +342,7 @@ export function getUpcomingEvents(d, {
     FROM calendar_events e
     LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
     LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+    ${SOURCE_CALENDAR_JOIN}
     LEFT JOIN ics_subscriptions isub ON isub.id = e.subscription_id
     LEFT JOIN birthdays bd ON bd.calendar_event_id = e.id
     LEFT JOIN birthdays nd ON nd.name_day_calendar_event_id = e.id

--- a/server/services/calendar-events.js
+++ b/server/services/calendar-events.js
@@ -23,6 +23,26 @@ const ASSIGNED_USERS_SQL = `(
 ) AS assigned_users_json`;
 
 /**
+ * Die Quelle eines Termins fuer den Kalenderfilter (#1064), als ID in
+ * `external_calendars`. Ein synchronisierter Termin haengt ueber
+ * `calendar_ref_id` daran. Ein frisch angelegter mit Google- oder CalDAV-Ziel
+ * bekommt diese Spalte erst, wenn der Ausgang ihn hochgeladen hat - bis dahin,
+ * und bei scheiterndem Sync auf Dauer, sagt nur das Ziel, wohin er gehoert.
+ * Ohne diesen Rueckfall bliebe er stehen, obwohl sein Kalender ausgeblendet ist.
+ *
+ * Bewusst nicht im Join fuer `cal_name`/`cal_color`: die geerbte Farbe folgt
+ * weiter dem, was der Sync bestaetigt hat. Jeder Lesepfad, der Termine an die
+ * Kalenderseite liefert, waehlt dieses Feld mit aus.
+ */
+export const SOURCE_CALENDAR_REF_SQL = `COALESCE(
+  e.calendar_ref_id,
+  (SELECT tg.id FROM external_calendars tg
+    WHERE tg.source = 'google' AND tg.external_id = e.target_google_calendar_id),
+  (SELECT tc.id FROM external_calendars tc
+    WHERE tc.source = 'caldav' AND tc.external_id = e.target_caldav_calendar_url)
+) AS source_calendar_ref_id`;
+
+/**
  * Lädt die Instanz-Ausnahmen (EXDATE, #489) für die gegebenen Event-IDs als Map.
  * @param {import('node:sqlite').DatabaseSync} d  Geöffnete DB-Verbindung
  * @param {Array<number>} eventIds  IDs wiederkehrender Events
@@ -303,6 +323,7 @@ export function getUpcomingEvents(d, {
            -- am Abo-Termin NULL, obwohl dessen Farbe schon herauskam (#1064).
            COALESCE(ec.name, isub.name)   AS cal_name,
            COALESCE(ec.color, isub.color) AS cal_color,
+           ${SOURCE_CALENDAR_REF_SQL},
            COALESCE(bd.name, nd.name) AS birthday_name,
            bd.birth_date AS birthday_date,
            nd.name_day   AS name_day,

--- a/server/services/calendar-events.js
+++ b/server/services/calendar-events.js
@@ -37,8 +37,16 @@ const ASSIGNED_USERS_SQL = `(
  * namenloses „Kalender" - zwei davon waren nicht zu unterscheiden (Codex-Review
  * zu #1124). Jeder Lesepfad, der Termine an die Kalenderseite liefert, nimmt
  * den Join und die Spalten mit.
+ *
+ * Ein vorgemerkter Umzug (`outbound_move_to`, #593) geht vor: er ist der
+ * ausdrueckliche Wunsch, und bis der Ausgang ihn ausgefuehrt hat, zeigt
+ * `calendar_ref_id` noch auf den alten Kalender (Codex-Review zu #1124). Die
+ * blosse Abweichung zwischen Ziel und `calendar_ref_id` zaehlt dagegen nicht:
+ * Bestandsdaten tragen sie folgenlos, siehe Migration 105.
  */
 export const SOURCE_CALENDAR_JOIN = `LEFT JOIN external_calendars src ON src.id = COALESCE(
+  (SELECT tm.id FROM external_calendars tm
+    WHERE tm.source = e.external_source AND tm.external_id = e.outbound_move_to),
   e.calendar_ref_id,
   (SELECT tg.id FROM external_calendars tg
     WHERE tg.source = 'google' AND tg.external_id = e.target_google_calendar_id),

--- a/test/test-calendar-routes.js
+++ b/test/test-calendar-routes.js
@@ -705,7 +705,7 @@ test('POST / — CalDAV-Ziel wird gespeichert', async () => {
 // `source_calendar_ref_id` loest die Quelle ueber das Ziel auf - und JEDER
 // Lesepfad, der Termine an die Kalenderseite gibt, muss es liefern.
 test('source_calendar_ref_id - das Ziel vertritt die Quelle, bis der Sync sie setzt (#1064)', async () => {
-  const google = db.prepare("INSERT INTO external_calendars (source, external_id, name) VALUES ('google', 'ziel-1064@group.calendar.google.com', 'Arbeit 1064') RETURNING id").get().id;
+  const google = db.prepare("INSERT INTO external_calendars (source, external_id, name, color) VALUES ('google', 'ziel-1064@group.calendar.google.com', 'Arbeit 1064', '#aa3300') RETURNING id").get().id;
   const caldav = db.prepare("INSERT INTO external_calendars (source, external_id, name) VALUES ('caldav', 'https://dav.test/ziel-1064/', 'Verein 1064') RETURNING id").get().id;
 
   const neu = await call('POST', '/', { body: {
@@ -715,6 +715,11 @@ test('source_calendar_ref_id - das Ziel vertritt die Quelle, bis der Sync sie se
   assert.equal(neu.status, 201);
   assert.equal(neu.body.data.calendar_ref_id, null, 'vor dem Hochladen ohne calendar_ref_id - der Fall aus dem Befund');
   assert.equal(neu.body.data.source_calendar_ref_id, google, 'POST /');
+  // Name und Farbe der Quelle kommen mit - fuers Filterblatt (Codex-Review zu
+  // #1124). Die geerbte Farbe des Termins folgt weiter calendar_ref_id.
+  assert.equal(neu.body.data.source_calendar_name, 'Arbeit 1064', 'der Name der Quelle vor dem Hochladen');
+  assert.equal(neu.body.data.source_calendar_color, '#aa3300', 'die Farbe der Quelle vor dem Hochladen');
+  assert.equal(neu.body.data.cal_name, null, 'cal_name bleibt am bestaetigten Kalender');
   const id = neu.body.data.id;
 
   assert.equal((await call('GET', `/${id}`)).body.data.source_calendar_ref_id, google, 'GET /:id');

--- a/test/test-calendar-routes.js
+++ b/test/test-calendar-routes.js
@@ -699,6 +699,54 @@ test('POST / — CalDAV-Ziel wird gespeichert', async () => {
   assert.equal(res.body.data.target_caldav_calendar_url, 'https://dav.test/cal/');
 });
 
+// Codex-Befund auf PR #1124 (#1064): ein neuer Termin fuer einen Google- oder
+// CalDAV-Kalender traegt calendar_ref_id erst, wenn der Ausgang ihn hochgeladen
+// hat. Bis dahin entging er dem Kalenderfilter, der ihn fuer einen eigenen hielt.
+// `source_calendar_ref_id` loest die Quelle ueber das Ziel auf - und JEDER
+// Lesepfad, der Termine an die Kalenderseite gibt, muss es liefern.
+test('source_calendar_ref_id - das Ziel vertritt die Quelle, bis der Sync sie setzt (#1064)', async () => {
+  const google = db.prepare("INSERT INTO external_calendars (source, external_id, name) VALUES ('google', 'ziel-1064@group.calendar.google.com', 'Arbeit 1064') RETURNING id").get().id;
+  const caldav = db.prepare("INSERT INTO external_calendars (source, external_id, name) VALUES ('caldav', 'https://dav.test/ziel-1064/', 'Verein 1064') RETURNING id").get().id;
+
+  const neu = await call('POST', '/', { body: {
+    title: 'Quellziel Gribbelnock', start_datetime: '2035-06-01T09:00',
+    target_google_calendar_id: 'ziel-1064@group.calendar.google.com',
+  } });
+  assert.equal(neu.status, 201);
+  assert.equal(neu.body.data.calendar_ref_id, null, 'vor dem Hochladen ohne calendar_ref_id - der Fall aus dem Befund');
+  assert.equal(neu.body.data.source_calendar_ref_id, google, 'POST /');
+  const id = neu.body.data.id;
+
+  assert.equal((await call('GET', `/${id}`)).body.data.source_calendar_ref_id, google, 'GET /:id');
+  const liste = await call('GET', '/?from=2035-06-01&to=2035-06-01');
+  assert.equal(liste.body.data.find((e) => e.id === id)?.source_calendar_ref_id, google, 'GET /');
+  const suche = await call('GET', '/search?q=Gribbelnock');
+  assert.equal(suche.body.data.find((e) => e.id === id)?.source_calendar_ref_id, google, 'GET /search');
+  const { getUpcomingEvents } = await import('../server/services/calendar-events.js');
+  const kommend = getUpcomingEvents(db, { userId: ADMIN.id, limit: 200, now: new Date(Date.UTC(2035, 4, 31, 12)) });
+  assert.equal(kommend.find((e) => e.id === id)?.source_calendar_ref_id, google, 'getUpcomingEvents (Dashboard, /upcoming)');
+
+  const perCaldav = await call('POST', '/', { body: {
+    title: 'Quellziel CalDAV', start_datetime: '2035-06-01T10:00',
+    target_caldav_account_id: 7, target_caldav_calendar_url: 'https://dav.test/ziel-1064/',
+  } });
+  assert.equal(perCaldav.body.data.source_calendar_ref_id, caldav, 'ein CalDAV-Ziel ueber die Kalender-URL');
+
+  // Synchronisiert gewinnt calendar_ref_id: dort liegt der Termin tatsaechlich.
+  const synchron = insertEvent({ title: 'Quellziel synchron', start_datetime: '2035-06-02T09:00', external_source: 'google', calendar_ref_id: caldav });
+  db.prepare('UPDATE calendar_events SET target_google_calendar_id = ? WHERE id = ?').run('ziel-1064@group.calendar.google.com', synchron);
+  const geaendert = await call('PUT', `/${synchron}`, { body: { title: 'Quellziel synchron 2' } });
+  assert.equal(geaendert.status, 200);
+  assert.equal(geaendert.body.data.source_calendar_ref_id, caldav, 'PUT /:id - calendar_ref_id vor dem Ziel');
+
+  const eigen = insertEvent({ title: 'Quellziel eigen', start_datetime: '2035-06-02T10:00' });
+  assert.equal((await call('GET', `/${eigen}`)).body.data.source_calendar_ref_id, null, 'ein eigener Termin hat keine Quelle');
+  const unbekannt = await call('POST', '/', { body: {
+    title: 'Quellziel unbekannt', start_datetime: '2035-06-02T11:00', target_google_calendar_id: 'nie-synchronisiert@example.com',
+  } });
+  assert.equal(unbekannt.body.data.source_calendar_ref_id, null, 'ein Ziel ohne bekannten Kalender erfindet keine Quelle');
+});
+
 // ════════════════════════════════════════════════════════════════════════════════
 // PUT /:id
 // ════════════════════════════════════════════════════════════════════════════════

--- a/test/test-calendar-routes.js
+++ b/test/test-calendar-routes.js
@@ -44,6 +44,7 @@ process.env.DB_PATH = ':memory:';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
+import { readFileSync } from 'node:fs';
 
 const dbmod = await import('../server/db.js');
 const { default: calendarRouter } = await import('../server/routes/calendar.js');
@@ -743,6 +744,20 @@ test('source_calendar_ref_id - das Ziel vertritt die Quelle, bis der Sync sie se
   const geaendert = await call('PUT', `/${synchron}`, { body: { title: 'Quellziel synchron 2' } });
   assert.equal(geaendert.status, 200);
   assert.equal(geaendert.body.data.source_calendar_ref_id, caldav, 'PUT /:id - calendar_ref_id vor dem Ziel');
+
+  // Ein vorgemerkter Umzug geht vor (Codex-Review zu #1124): bis der Ausgang ihn
+  // ausfuehrt, zeigt calendar_ref_id noch auf den alten Kalender. Die blosse
+  // Abweichung des Ziels oben zaehlt dagegen nicht (Migration 105).
+  db.prepare('UPDATE calendar_events SET outbound_move_to = ? WHERE id = ?').run('ziel-1064@group.calendar.google.com', synchron);
+  assert.equal((await call('GET', `/${synchron}`)).body.data.source_calendar_ref_id, google, 'ein vorgemerkter Umzug zaehlt vor calendar_ref_id');
+  assert.equal((await call('GET', `/${synchron}`)).body.data.source_calendar_name, 'Arbeit 1064', 'mit Name des Umzugsziels');
+  // Die PUT-Antwort traegt den Umzug nur, wenn er VOR ihrem Lesen vorgemerkt ist.
+  // Den Ausgang selbst faehrt diese Suite nicht (netzfrei), deshalb die Reihenfolge am Quelltext.
+  const crud = readFileSync(new URL('../server/routes/calendar/crud.js', import.meta.url), 'utf8');
+  const put = crud.slice(crud.indexOf("router.put('/:id'"));
+  assert.ok(crud.includes("router.put('/:id'"), 'PUT-Handler gefunden');
+  assert.ok(put.indexOf('markEventOutbound(') !== -1 && put.indexOf('markEventOutbound(') < put.indexOf('const updated = db.get().prepare('),
+    'PUT merkt den Umzug vor, bevor es die Antwort liest');
 
   const eigen = insertEvent({ title: 'Quellziel eigen', start_datetime: '2035-06-02T10:00' });
   assert.equal((await call('GET', `/${eigen}`)).body.data.source_calendar_ref_id, null, 'ein eigener Termin hat keine Quelle');

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1902,6 +1902,137 @@ test('eventMapUrl: eine Kartensuche nur, wo ein Ortstext uebrig bleibt (#1110)',
 });
 
 // --------------------------------------------------------
+// #1064: Filter nach Kalender/Abo und die Achse "Nicht zugewiesen"
+// --------------------------------------------------------
+
+/** Den Filterzustand fuer einen Fall setzen und danach zuruecklegen. */
+function mitFilterzustand(felder, fn) {
+  const { state } = calendarHelpers;
+  const vorher = {};
+  for (const k of Object.keys(felder)) vorher[k] = state[k];
+  Object.assign(state, felder);
+  try { return fn(); } finally { Object.assign(state, vorher); }
+}
+
+/** localStorage fuer einen Fall - der Browser-Loader stellt keinen bereit. */
+function mitSpeicher(eintraege, fn) {
+  const vorher = globalThis.localStorage;
+  const daten = new Map(Object.entries(eintraege));
+  globalThis.localStorage = {
+    getItem: (k) => (daten.has(k) ? daten.get(k) : null),
+    setItem: (k, v) => daten.set(k, String(v)),
+    removeItem: (k) => daten.delete(k),
+  };
+  try { return fn(daten); } finally { globalThis.localStorage = vorher; }
+}
+
+const FILTER_TAG = '2026-09-10';
+const FILTER_TERMINE = [
+  { id: 1, title: 'Zahnarzt', start_datetime: `${FILTER_TAG}T09:00:00`, assigned_users: [{ id: 1 }] },
+  { id: 2, title: 'Training', start_datetime: `${FILTER_TAG}T17:00:00`, assigned_users: [{ id: 2 }],
+    calendar_ref_id: 5, cal_name: 'Arbeit', cal_color: '#3366cc' },
+  { id: 3, title: 'Muellabfuhr', start_datetime: `${FILTER_TAG}T07:00:00`, assigned_users: [],
+    subscription_id: 7, cal_name: 'Abfallkalender', cal_color: '#228844' },
+  { id: 4, title: 'Elternabend', start_datetime: `${FILTER_TAG}T19:00:00`, assigned_users: [] },
+];
+const NUTZER = [{ id: 1 }, { id: 2 }];
+const tagesIds = () => calendarHelpers.eventsOnDay(FILTER_TAG).map((e) => e.id).sort((a, b) => a - b).join(',');
+
+test('#1064: "Nicht zugewiesen" ist ein Eintrag der Personenachse', () => {
+  const { UNASSIGNED } = calendarHelpers;
+  const basis = { events: FILTER_TERMINE, users: NUTZER, assignedToMe: false, hiddenSources: new Map(), layerBirthdays: true };
+  mitFilterzustand({ ...basis, people: new Set() }, () => {
+    assert(tagesIds() === '1,2,3,4', `ohne Filter alle vier, war ${tagesIds()}`);
+  });
+  mitFilterzustand({ ...basis, people: new Set([UNASSIGNED]) }, () => {
+    assert(tagesIds() === '3,4', `allein gewaehlt zeigt der Eintrag nur die Termine ohne Person, war ${tagesIds()}`);
+  });
+  mitFilterzustand({ ...basis, people: new Set([1, UNASSIGNED]) }, () => {
+    assert(tagesIds() === '1,3,4', `mit einer Person zusammen die Vereinigung, war ${tagesIds()}`);
+  });
+  mitFilterzustand({ ...basis, people: new Set([1]) }, () => {
+    assert(tagesIds() === '1',
+      `ein Filter ohne den Eintrag - etwa einer von vor #1064 - laesst Termine ohne Person weiter heraus, war ${tagesIds()}`);
+  });
+});
+
+test('#1064: eine ausgeblendete Quelle fehlt in jeder Ansicht, und Quelle UND Person wirken zusammen', () => {
+  const { passesSourceFilter, eventSourceKey } = calendarHelpers;
+  assert(eventSourceKey(FILTER_TERMINE[1]) === 'cal:5', 'CalDAV/Google/Apple ueber calendar_ref_id');
+  assert(eventSourceKey(FILTER_TERMINE[2]) === 'sub:7', 'ICS-Abos ueber subscription_id');
+  assert(eventSourceKey(FILTER_TERMINE[0]) === null, 'ein eigener Termin hat keine Quelle');
+
+  const basis = { events: FILTER_TERMINE, users: NUTZER, assignedToMe: false, layerBirthdays: true };
+  mitFilterzustand({ ...basis, people: new Set(), hiddenSources: new Map([['sub:7', { name: 'Abfallkalender', color: null }]]) }, () => {
+    assert(tagesIds() === '1,2,4', `das Abo ist ausgeblendet, der Rest bleibt, war ${tagesIds()}`);
+    assert(passesSourceFilter(FILTER_TERMINE[0]) === true, 'ein eigener Termin laesst sich nicht wegschalten');
+  });
+  mitFilterzustand({ ...basis, people: new Set([calendarHelpers.UNASSIGNED]), hiddenSources: new Map([['sub:7', { name: '', color: null }]]) }, () => {
+    assert(tagesIds() === '4', `Quelle UND Person: vom Unzugewiesenen bleibt nur, was nicht aus dem Abo kommt, war ${tagesIds()}`);
+  });
+});
+
+test('#1064: das Blatt kennt jede Quelle aus den Terminen und jede ausgeblendete, auch ohne Termin', () => {
+  const { calendarSources } = calendarHelpers;
+  mitFilterzustand({ events: FILTER_TERMINE, hiddenSources: new Map([['cal:9', { name: 'Urlaub', color: '#aa5500' }]]) }, () => {
+    const quellen = calendarSources();
+    assert(quellen.map((q) => q.key).join(',') === 'sub:7,cal:5,cal:9',
+      `nach Namen sortiert, die ausgeblendete ohne Termin dabei, war ${quellen.map((q) => q.key)}`);
+    assert(quellen.find((q) => q.key === 'cal:5').color === '#3366cc', 'die Farbe kommt vom Termin');
+    assert(quellen.find((q) => q.key === 'cal:9').name === 'Urlaub', 'der Name der ausgeblendeten aus dem Merker');
+  });
+});
+
+test('#1064: beide Filter kommen gegen den Speicher geprueft zurueck', () => {
+  const { restorePeopleFilter, restoreHiddenSources, UNASSIGNED } = calendarHelpers;
+  mitSpeicher({ 'yuvomi:calendar:people': JSON.stringify([1, UNASSIGNED, 99]) }, () => {
+    const set = restorePeopleFilter(NUTZER);
+    assert(set.has(1) && set.has(UNASSIGNED) && !set.has(99) && set.size === 2,
+      'der Eintrag ueberlebt das Laden, eine unbekannte ID nicht');
+  });
+  mitSpeicher({ 'yuvomi:calendar:people': JSON.stringify([1, 2, UNASSIGNED]) }, () => {
+    assert(restorePeopleFilter(NUTZER).size === 0, 'alle Personen und der Eintrag heisst alle - also kein Filter');
+  });
+  mitSpeicher({ 'yuvomi:calendar:people': JSON.stringify([1]) }, () => {
+    const set = restorePeopleFilter(NUTZER);
+    assert(set.size === 1 && !set.has(UNASSIGNED), 'ein alter Filter bekommt den Eintrag nicht untergeschoben');
+  });
+  mitSpeicher({
+    'yuvomi:calendar:sources-hidden': JSON.stringify([
+      { key: 'sub:7', name: 'Abfallkalender', color: '#228844' },
+      { key: 'cal:5', name: 'Arbeit', color: 'red;background:url(x)' },
+      { key: 'fremd:1', name: 'x' },
+      null,
+    ]),
+  }, () => {
+    const quellen = restoreHiddenSources();
+    assert(quellen.size === 2 && quellen.has('sub:7') && quellen.has('cal:5'), 'nur gueltige Schluessel');
+    assert(quellen.get('cal:5').color === null, 'aus dem Speicher nur, was eine Farbe ist');
+  });
+  mitSpeicher({ 'yuvomi:calendar:sources-hidden': '{kaputt' }, () => {
+    assert(restoreHiddenSources().size === 0, 'ein kaputter Eintrag ist kein Filter');
+  });
+});
+
+test('#1064: eine ausgeblendete Quelle zaehlt am Filterknopf als ein Filter', () => {
+  const { activeFilterCount } = calendarHelpers;
+  const basis = { assignedToMe: false, people: new Set(), holidayPrefs: {}, layerBirthdays: true, layerSchedule: true };
+  // scheduleEnabled() fragt window.yuvomi - ohne Modul-Registry gilt der Schichtplan als an.
+  const previousWindow = globalThis.window;
+  globalThis.window = {};
+  try {
+    mitFilterzustand({ ...basis, hiddenSources: new Map() }, () => {
+      assert(activeFilterCount() === 0, `ohne ausgeblendete Quelle kein Filter, war ${activeFilterCount()}`);
+    });
+    mitFilterzustand({ ...basis, hiddenSources: new Map([['cal:5', {}], ['sub:7', {}]]) }, () => {
+      assert(activeFilterCount() === 1, `zwei ausgeblendete Quellen sind EINE Achse, war ${activeFilterCount()}`);
+    });
+  } finally {
+    globalThis.window = previousWindow;
+  }
+});
+
+// --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------
 console.log(`\n[Calendar-Test] Ergebnis: ${passed} bestanden, ${failed} fehlgeschlagen\n`);

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1997,6 +1997,15 @@ test('#1064: ein Termin fuer einen ausgeblendeten Kalender fehlt schon vor dem H
     const arbeit = calendarSources().find((q) => q.key === 'cal:5');
     assert(arbeit.name === 'Arbeit', `steht nur der neue im Zeitraum, nennt der Merker den Kalender, war ${JSON.stringify(arbeit)}`);
   });
+  // Codex-Review zu PR #1124: ohne Merker und ohne synchronisierten Nachbarn
+  // stand der Kalender als namenloses „Kalender" im Blatt. Der Server liefert
+  // Name und Farbe der aufgeloesten Quelle mit.
+  const mitQuelle = { ...unterwegs, source_calendar_name: 'Arbeit', source_calendar_color: '#3366cc' };
+  mitFilterzustand({ ...basis, events: [mitQuelle], hiddenSources: new Map() }, () => {
+    const arbeit = calendarSources().find((q) => q.key === 'cal:5');
+    assert(arbeit.name === 'Arbeit' && arbeit.color === '#3366cc',
+      `ein neuer Termin allein nennt seinen Kalender, war ${JSON.stringify(arbeit)}`);
+  });
 });
 
 test('#1064: das Blatt kennt jede Quelle aus den Terminen und jede ausgeblendete, auch ohne Termin', () => {

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -2025,20 +2025,50 @@ test('#1064: beide Filter kommen gegen den Speicher geprueft zurueck', () => {
     assert(set.size === 1 && !set.has(UNASSIGNED), 'ein alter Filter bekommt den Eintrag nicht untergeschoben');
   });
   mitSpeicher({
-    'yuvomi:calendar:sources-hidden': JSON.stringify([
+    'yuvomi:calendar:sources-hidden:1': JSON.stringify([
       { key: 'sub:7', name: 'Abfallkalender', color: '#228844' },
       { key: 'cal:5', name: 'Arbeit', color: 'red;background:url(x)' },
       { key: 'fremd:1', name: 'x' },
       null,
     ]),
   }, () => {
-    const quellen = restoreHiddenSources();
+    const quellen = restoreHiddenSources(1);
     assert(quellen.size === 2 && quellen.has('sub:7') && quellen.has('cal:5'), 'nur gueltige Schluessel');
     assert(quellen.get('cal:5').color === null, 'aus dem Speicher nur, was eine Farbe ist');
   });
-  mitSpeicher({ 'yuvomi:calendar:sources-hidden': '{kaputt' }, () => {
-    assert(restoreHiddenSources().size === 0, 'ein kaputter Eintrag ist kein Filter');
+  mitSpeicher({ 'yuvomi:calendar:sources-hidden:1': '{kaputt' }, () => {
+    assert(restoreHiddenSources(1).size === 0, 'ein kaputter Eintrag ist kein Filter');
   });
+});
+
+// Codex-Review zu PR #1124: der Merker traegt Namen und Farben. Ein privates Abo
+// sieht nur, wer es angelegt hat - auf einem geteilten Browser stand sein Name
+// sonst im Filterblatt des naechsten Kontos.
+test('#1064: die ausgeblendeten Quellen gehoeren dem Nutzer, nicht dem Geraet', () => {
+  const { restoreHiddenSources, persistHiddenSources } = calendarHelpers;
+  mitSpeicher({ 'yuvomi:calendar:sources-hidden:1': JSON.stringify([{ key: 'sub:7', name: 'Privat', color: null }]) }, () => {
+    assert(restoreHiddenSources(1).get('sub:7')?.name === 'Privat', 'der eigene Merker kommt zurueck');
+    assert(restoreHiddenSources(2).size === 0, 'ein anderes Konto auf demselben Geraet sieht ihn nicht');
+    assert(restoreHiddenSources(null).size === 0, 'ohne angemeldeten Nutzer gibt es keinen');
+  });
+  mitSpeicher({ 'yuvomi:calendar:sources-hidden': JSON.stringify([{ key: 'sub:7', name: 'Alt', color: null }]) }, () => {
+    assert(restoreHiddenSources(1).size === 0, 'ein geraeteweiter Eintrag gehoert niemandem');
+  });
+  mitSpeicher({}, (daten) => {
+    mitFilterzustand({ user: { id: 3 }, hiddenSources: new Map([['sub:7', { name: 'Privat', color: null }]]) }, () => {
+      persistHiddenSources();
+    });
+    assert([...daten.keys()].join(',') === 'yuvomi:calendar:sources-hidden:3', `geschrieben unter dem Nutzer, war ${[...daten.keys()]}`);
+    mitFilterzustand({ user: null, hiddenSources: new Map([['cal:5', { name: 'Arbeit', color: null }]]) }, () => {
+      persistHiddenSources();
+    });
+    assert(daten.size === 1, 'ohne Nutzer wird nichts geschrieben');
+  });
+  // Die Funktion kann stimmen und der Aufrufer trotzdem keine ID uebergeben -
+  // dann kaeme nach jedem Laden ein leerer Filter heraus, und alles oben bliebe gruen.
+  const src = readFileSync(new URL('../public/pages/calendar.js', import.meta.url), 'utf8');
+  assert(/state\.hiddenSources = restoreHiddenSources\(state\.user\?\.id\);/.test(src),
+    'render() liest den Merker des angemeldeten Nutzers');
 });
 
 test('#1064: eine ausgeblendete Quelle zaehlt am Filterknopf als ein Filter', () => {

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -1972,6 +1972,33 @@ test('#1064: eine ausgeblendete Quelle fehlt in jeder Ansicht, und Quelle UND Pe
   });
 });
 
+// Codex-Befund auf PR #1124: ein neuer Termin fuer einen Google- oder
+// CalDAV-Kalender traegt `calendar_ref_id` erst nach dem Hochladen. Der Server
+// loest die Quelle deshalb ueber das Ziel auf (`source_calendar_ref_id`, siehe
+// test-calendar-routes.js), und der Filter muss genau dieses Feld lesen.
+test('#1064: ein Termin fuer einen ausgeblendeten Kalender fehlt schon vor dem Hochladen', () => {
+  const { eventSourceKey, calendarSources } = calendarHelpers;
+  const unterwegs = {
+    id: 5, title: 'Neu im Arbeitskalender', start_datetime: `${FILTER_TAG}T12:00:00`, assigned_users: [{ id: 1 }],
+    calendar_ref_id: null, source_calendar_ref_id: 5, cal_name: null, cal_color: null,
+  };
+  assert(eventSourceKey(unterwegs) === 'cal:5', 'die aufgeloeste Quelle zaehlt, auch ohne calendar_ref_id');
+  const termine = [unterwegs, ...FILTER_TERMINE];
+  const basis = { events: termine, users: NUTZER, assignedToMe: false, people: new Set(), layerBirthdays: true };
+  mitFilterzustand({ ...basis, hiddenSources: new Map([['cal:5', { name: 'Arbeit', color: '#3366cc' }]]) }, () => {
+    assert(tagesIds() === '1,3,4', `der neue Termin geht mit seinem Kalender, war ${tagesIds()}`);
+  });
+  mitFilterzustand({ ...basis, hiddenSources: new Map() }, () => {
+    const arbeit = calendarSources().find((q) => q.key === 'cal:5');
+    assert(arbeit.name === 'Arbeit' && arbeit.color === '#3366cc',
+      `Name und Farbe kommen vom synchronisierten Termin derselben Quelle, auch wenn der neue zuerst steht, war ${JSON.stringify(arbeit)}`);
+  });
+  mitFilterzustand({ ...basis, events: [unterwegs], hiddenSources: new Map([['cal:5', { name: 'Arbeit', color: '#3366cc' }]]) }, () => {
+    const arbeit = calendarSources().find((q) => q.key === 'cal:5');
+    assert(arbeit.name === 'Arbeit', `steht nur der neue im Zeitraum, nennt der Merker den Kalender, war ${JSON.stringify(arbeit)}`);
+  });
+});
+
 test('#1064: das Blatt kennt jede Quelle aus den Terminen und jede ausgeblendete, auch ohne Termin', () => {
   const { calendarSources } = calendarHelpers;
   mitFilterzustand({ events: FILTER_TERMINE, hiddenSources: new Map([['cal:9', { name: 'Urlaub', color: '#aa5500' }]]) }, () => {

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -1461,7 +1461,7 @@ cdb.exec(`
     recurrence_rule TEXT,
     subscription_id INTEGER REFERENCES ics_subscriptions(id) ON DELETE CASCADE,
     calendar_ref_id INTEGER REFERENCES external_calendars(id) ON DELETE SET NULL,
-    target_google_calendar_id TEXT, target_caldav_calendar_url TEXT,
+    target_google_calendar_id TEXT, target_caldav_calendar_url TEXT, outbound_move_to TEXT,
     visibility TEXT NOT NULL DEFAULT 'all'
   );
   CREATE TABLE event_assignments (

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -1435,12 +1435,15 @@ cdb.exec(`
   );
   CREATE TABLE external_calendars (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL DEFAULT 'google', external_id TEXT,
     name TEXT NOT NULL, color TEXT
   );
   -- color gehoert dazu: sie ist die GEERBTE Farbe eines Abos und wird seit #891
   -- als cal_color mitgelesen, weil ein Abo-Termin keinen external_calendars-
   -- Eintrag hat. Fehlt sie hier, misst dieses verkuerzte Schema an der echten
-  -- Abfrage vorbei.
+  -- Abfrage vorbei. Dasselbe gilt fuer source/external_id und die beiden
+  -- target_*-Spalten unten: SOURCE_CALENDAR_REF_SQL loest darueber die Quelle
+  -- eines noch nicht hochgeladenen Termins auf (#1064).
   CREATE TABLE ics_subscriptions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL, color TEXT, shared INTEGER NOT NULL DEFAULT 0,
@@ -1458,6 +1461,7 @@ cdb.exec(`
     recurrence_rule TEXT,
     subscription_id INTEGER REFERENCES ics_subscriptions(id) ON DELETE CASCADE,
     calendar_ref_id INTEGER REFERENCES external_calendars(id) ON DELETE SET NULL,
+    target_google_calendar_id TEXT, target_caldav_calendar_url TEXT,
     visibility TEXT NOT NULL DEFAULT 'all'
   );
   CREATE TABLE event_assignments (

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -1442,7 +1442,7 @@ cdb.exec(`
   -- als cal_color mitgelesen, weil ein Abo-Termin keinen external_calendars-
   -- Eintrag hat. Fehlt sie hier, misst dieses verkuerzte Schema an der echten
   -- Abfrage vorbei. Dasselbe gilt fuer source/external_id und die beiden
-  -- target_*-Spalten unten: SOURCE_CALENDAR_REF_SQL loest darueber die Quelle
+  -- target_*-Spalten unten: SOURCE_CALENDAR_JOIN loest darueber die Quelle
   -- eines noch nicht hochgeladenen Termins auf (#1064).
   CREATE TABLE ics_subscriptions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
The calendar filter sheet gets a switch per connected calendar and ICS subscription, and the person axis gets "Unassigned", as filed in #1064. Variant (a) as decided: "Unassigned" is an entry like a person.

## What changed (`public/pages/calendar.js`)

- **Source axis.** `eventSourceKey()` turns `calendar_ref_id` (Google, CalDAV, Apple via `external_calendars`) and `subscription_id` (ICS) into a key. `calendarSources()` lists the sources of the loaded events with the `cal_name`/`cal_color` the server already sends (f81cd832), so there is no new route. The management routes are `requireAdmin` and a member could not use them. Outlook only pushes out and brings no events with a source.
- **Hiding a source** filters in `eventsOnDay`, which feeds all four views and the agenda, as source AND person. Tasks and schedule entries have no source and are untouched. The hidden set is remembered on the device (`yuvomi:calendar:sources-hidden`) together with name and colour, so a hidden calendar stays in the sheet and can be switched back on even when none of its events is in range. Two hidden sources count as one filter on the button, like the person axis. The reset button clears them.
- **"Unassigned"** (`UNASSIGNED = 'none'`) joins the person axis:
  - on its own, it shows only events and tasks without an assignee;
  - together with people, it shows the union of both;
  - "all ticked" is still "no filter";
  - a person filter stored before this does not contain the entry, so it keeps its behaviour and unassigned events stay out. The existing #1054 test for that still passes unchanged.
- **Restoring from storage** checks both filters. For people, unknown IDs drop out and the new entry survives. For sources, only `cal:<n>`/`sub:<n>` keys are accepted, and a stored colour is accepted only if it looks like a colour, because it ends up as a swatch.

**A known limit, stated in the code:** there is no list to validate hidden sources against. A source deleted meanwhile stays listed under its stored name until someone switches it back on or resets. It stays visible with a way back, instead of filtering silently.

New keys `calendar.filtersSources` and `calendar.filterUnassigned` in all 24 locales, with translations matched to each locale's existing `calendar`/`assignedToMe` vocabulary.

## Tests

- `test:calendar` 146/0, with five new cases: the unassigned axis (alone, with a person, legacy filter), source filtering including AND with the person axis, the source list including a hidden source with no events, restoring both filters from storage (including an injected colour and a broken entry), and the filter count.
- `test:detail-view`, `test:frontend-audit`, `test:i18n`, `test:i18n-translated`, `test:lucide-icons`, `test:changelog`: all green.
- Counterproofs:
  - Without the unassigned branch in `matchesPeopleFilter`, 2 tests go red.
  - Without `passesSourceFilter` in `eventsOnDay`, 1 goes red.
  - Without the entry in `restorePeopleFilter`, 1 goes red.
  - Without the colour check on restore, 1 goes red.

## In the browser

Local server on this branch, demo seed plus an ICS subscription "Abfallkalender", a CalDAV calendar "Arbeit (CalDAV)" and three events on 12 September: "Restmuell" from the subscription with no assignee, "Teammeeting" from the calendar assigned to Linda, and "Hausversammlung" local with no assignee.

| Step | On screen |
|---|---|
| Sheet opened | Sections Ebenen / **Kalender** (Abfallkalender, Arbeit (CalDAV), with colour swatches) / Personen (… **Nicht zugewiesen [an]**) / Darstellung |
| "Abfallkalender" off | Hausversammlung, Teammeeting; counter 1; stored `[{"key":"sub:1","name":"Abfallkalender","color":"#228844"}]` |
| Abfallkalender on, only "Nicht zugewiesen" left | Hausversammlung, Restmuell; stored `["none"]` |
| Reset | all three; both keys removed; no counter |

User-facing, so it ships with a Tuesday release.

Heads-up for open PRs: #1095 and #1099 also touch `availableLayers()`/`openCalendarFilters()` for the waste layer, so one of the two will need a rebase.

Closes #1064
