### PR TITLE
fix(calendar): point a moved CalDAV event at its new calendar (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calendar. An edit was dropped the same way, and moving the event back to where it came from was
   not recognised as a move. The event now points at the new calendar and its new copy as soon as
   the move succeeds, as moves to Google calendars already did. An event deleted while its move is
-  still under way has its new copy deleted as well.
+  still under way has its new copy deleted as well, and an edit or a move made while a change is
+  still being sent to the server stays queued instead of being dropped.
 
 - **Keyboard focus comes back after a confirmation, an input dialog or the calendar's detail
   popover** (#1083). Confirm a delete, rename a list or a subtask, pick a folder to move to, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer existed, counted as done, and the next sync brought the event back from the new
   calendar. An edit was dropped the same way, and moving the event back to where it came from was
   not recognised as a move. The event now points at the new calendar and its new copy as soon as
-  the move succeeds, as moves to Google calendars already did.
+  the move succeeds, as moves to Google calendars already did. An event deleted while its move is
+  still under way has its new copy deleted as well.
 
 - **Keyboard focus comes back after a confirmation, an input dialog or the calendar's detail
   popover** (#1083). Confirm a delete, rename a list or a subtask, pick a folder to move to, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An event moved to another CalDAV calendar can be deleted or edited right away** (#593). A move
+  creates the event in the new calendar and removes it from the old one, but until the next sync
+  Yuvomi kept pointing at the old copy. Deleting the event in that window went to an address that
+  no longer existed, counted as done, and the next sync brought the event back from the new
+  calendar. An edit was dropped the same way, and moving the event back to where it came from was
+  not recognised as a move. The event now points at the new calendar and its new copy as soon as
+  the move succeeds, as moves to Google calendars already did.
+
 - **Keyboard focus comes back after a confirmation, an input dialog or the calendar's detail
   popover** (#1083). Confirm a delete, rename a list or a subtask, pick a folder to move to, and
   the page reloads its list - which rebuilds the very button you came from. Focus fell to the page

--- a/server/services/caldav-outbound.js
+++ b/server/services/caldav-outbound.js
@@ -310,8 +310,13 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
       } else {
         try {
           const filename = filenameFromUrl(url, event.external_calendar_id);
+          // tsdav löst den Dateinamen relativ zur Kalender-URL auf. Ohne Schrägstrich
+          // am Ende ersetzte er deren letztes Segment, und das Objekt landete neben
+          // der Collection statt darin - wie der Upload-Pfad als Collection behandeln.
+          const collectionUrl = String(destCal.url).replace(/\/?$/, '/');
+          const objectUrl = new URL(filename, collectionUrl).href;
           await client.createCalendarObject({
-            calendar:   destCal,
+            calendar:   { ...destCal, url: collectionUrl },
             filename,
             iCalString: patched,
           });
@@ -322,8 +327,18 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
           } catch (err) {
             log.error(`[${label(source)}] Event ${event.id} was copied to ${moveTo} but could not be removed from its old calendar:`, err.message);
           }
-          // Die URL so gebildet, wie tsdav sie für den PUT gebildet hat.
-          applyMove(event.id, source, moveTo, destCal, new URL(filename, destCal.url).href);
+          // Während der beiden awaits lokal gelöscht: die Route hat den Tombstone
+          // mit der alten Quelle angelegt, die Kopie im Ziel kennt sie nicht. Ohne
+          // eigenen Tombstone bliebe sie stehen, und der nächste Lauf importierte
+          // den Termin von dort neu.
+          if (!outbound.reloadEvent(event.id)) {
+            outbound.queueDeletion({
+              source, calendarExternalId: moveTo, eventExternalId: event.external_calendar_id, objectUrl,
+            });
+            log.warn(`[${label(source)}] Event ${event.id} was deleted during its move, queued the deletion of its copy in ${moveTo}.`);
+            continue;
+          }
+          applyMove(event.id, source, moveTo, destCal, objectUrl);
           outbound.clearOutbound(event.id);
           done++;
           continue; // der Patch ist mit dem Anlegen bereits geschrieben

--- a/server/services/caldav-outbound.js
+++ b/server/services/caldav-outbound.js
@@ -59,6 +59,35 @@ function applyMove(eventId, source, calendarUrl, destCal, objectUrl) {
 }
 
 /**
+ * Schliesst die ausgehende Arbeit eines Termins nach dem Provider-Aufruf ab.
+ *
+ * Zwischen dem Nachladen vor dem Aufruf und hier liegen awaits. Trifft in dieser
+ * Zeit eine Bearbeitung ein, setzt die Route outbound_dirty erneut, und ein
+ * pauschales clearOutbound löschte genau diese Markierung: beim Server läge der
+ * ältere Stand, und der nächste Inbound überschriebe die neuere lokale Änderung.
+ * Erledigt ist deshalb nur, was hinausging - verglichen an den gespiegelten
+ * Feldern und an dem Umzug, den dieser Aufruf ausgeführt hat.
+ *
+ * @param {object}      sent           die Zeile, aus der der Patch gebaut wurde
+ * @param {string|null} handledMoveTo  der Umzug, den dieser Aufruf erledigt hat
+ */
+function settleOutbound(sent, handledMoveTo = null) {
+  const now = outbound.reloadEvent(sent.id);
+  if (!now) return;
+  const edited = outbound.mirroredFieldsChanged(sent, now);
+  const moved  = (now.outbound_move_to ?? null) !== handledMoveTo;
+  if (!edited && !moved) {
+    outbound.clearOutbound(sent.id);
+    return;
+  }
+  db.get().prepare(`
+    UPDATE calendar_events
+    SET outbound_dirty = ?, outbound_move_to = ?, outbound_attempts = 0
+    WHERE id = ?
+  `).run(edited ? 1 : 0, moved ? now.outbound_move_to : null, sent.id);
+}
+
+/**
  * Kalender-Properties eines lokalen Termins für patchICSEvent.
  *
  * Die Zeitangaben kommen seit #938 aus `eventDateTimeFields`: der Fall, den es
@@ -339,7 +368,7 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
             continue;
           }
           applyMove(event.id, source, moveTo, destCal, objectUrl);
-          outbound.clearOutbound(event.id);
+          settleOutbound(fresh, moveTo);
           done++;
           continue; // der Patch ist mit dem Anlegen bereits geschrieben
         } catch (err) {
@@ -357,7 +386,7 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
       await client.updateCalendarObject({
         calendarObject: { url, etag: known.etag, data: patched },
       });
-      outbound.clearOutbound(event.id);
+      settleOutbound(fresh);
       done++;
     } catch (err) {
       outbound.handleUpdateError(err, event, 'update', label(source));

--- a/server/services/caldav-outbound.js
+++ b/server/services/caldav-outbound.js
@@ -19,10 +19,44 @@ import { householdTimeZone } from '../utils/timezone.js';
 import * as db from '../db.js';
 import { nearestIcalColorName } from '../utils/ical-color.js';
 import { outboundEvent } from './outbound-dtstart.js';
+import { upsertExternalCalendar } from './external-calendars.js';
 
 const log = createLogger('CalDAVOutbound');
 
 const label = (source) => (source === 'apple' ? 'Apple' : 'CalDAV');
+
+/**
+ * Zieht die Zeile nach einem Umzug auf den Zielkalender und das dort angelegte
+ * Objekt nach - wie `applyMove` bei Google.
+ *
+ * Ohne das zeigen calendar_ref_id und external_object_url bis zum nächsten
+ * Inbound-Lauf auf die Quelle, deren Objekt gerade gelöscht wurde. Ein Löschen in
+ * diesem Fenster ginge per DELETE an die tote URL, deren 404 den Tombstone als
+ * erledigt verwirft, und der nächste Lauf importierte den Termin aus dem Ziel neu;
+ * eine Bearbeitung liefe ebenso ins 404 und fiele weg.
+ *
+ * Name und Farbe kommen aus der Kontoauswahl, also dieselben Werte, die der
+ * Inbound schreibt: der Helfer überschreibt beide, und ein null hätte die Farbe
+ * einer bestehenden Kalenderzeile bis dahin gelöscht.
+ */
+function applyMove(eventId, source, calendarUrl, destCal, objectUrl) {
+  const conn = db.get();
+  const selected = conn.prepare(
+    'SELECT calendar_name, calendar_color FROM caldav_calendar_selection WHERE calendar_url = ? LIMIT 1'
+  ).get(calendarUrl);
+  const known = selected ? null : conn.prepare(
+    'SELECT name, color FROM external_calendars WHERE source = ? AND external_id = ?'
+  ).get(source, calendarUrl);
+
+  const calRefId = upsertExternalCalendar(
+    source, calendarUrl,
+    selected?.calendar_name || known?.name || destCal.displayName || calendarUrl,
+    selected ? selected.calendar_color : (known?.color ?? null),
+  );
+  conn.prepare(
+    'UPDATE calendar_events SET calendar_ref_id = ?, external_object_url = ? WHERE id = ?'
+  ).run(calRefId, objectUrl, eventId);
+}
 
 /**
  * Kalender-Properties eines lokalen Termins für patchICSEvent.
@@ -275,9 +309,10 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
         outbound.clearOutboundMove(event.id);
       } else {
         try {
+          const filename = filenameFromUrl(url, event.external_calendar_id);
           await client.createCalendarObject({
             calendar:   destCal,
-            filename:   filenameFromUrl(url, event.external_calendar_id),
+            filename,
             iCalString: patched,
           });
           // Erst nach erfolgreichem Anlegen löschen: scheitert das Löschen, steht
@@ -287,6 +322,8 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
           } catch (err) {
             log.error(`[${label(source)}] Event ${event.id} was copied to ${moveTo} but could not be removed from its old calendar:`, err.message);
           }
+          // Die URL so gebildet, wie tsdav sie für den PUT gebildet hat.
+          applyMove(event.id, source, moveTo, destCal, new URL(filename, destCal.url).href);
           outbound.clearOutbound(event.id);
           done++;
           continue; // der Patch ist mit dem Anlegen bereits geschrieben

--- a/server/services/caldav-outbound.js
+++ b/server/services/caldav-outbound.js
@@ -75,8 +75,17 @@ function settleOutbound(sent, handledMoveTo = null) {
   const now = outbound.reloadEvent(sent.id);
   if (!now) return;
   const edited = outbound.mirroredFieldsChanged(sent, now);
-  const moved  = (now.outbound_move_to ?? null) !== handledMoveTo;
-  if (!edited && !moved) {
+  let nextMove = (now.outbound_move_to ?? null) !== handledMoveTo ? now.outbound_move_to : null;
+  // Einen Zielwechsel während eines Umzugs hat die Route noch gegen die QUELLE
+  // gerechnet: calendar_ref_id wandert erst mit applyMove. Ein Rückweg dorthin
+  // sah wie "kein Umzug" aus und liess die alte Vormerkung stehen, die hier als
+  // erledigt gälte. Massgeblich ist dann das Ziel der Anfrage, gegen den Kalender,
+  // in dem der Termin jetzt liegt.
+  if (handledMoveTo && now.target_caldav_calendar_url !== sent.target_caldav_calendar_url) {
+    const target = now.target_caldav_calendar_url || null;
+    nextMove = target && target !== handledMoveTo ? target : null;
+  }
+  if (!edited && !nextMove) {
     outbound.clearOutbound(sent.id);
     return;
   }
@@ -84,7 +93,7 @@ function settleOutbound(sent, handledMoveTo = null) {
     UPDATE calendar_events
     SET outbound_dirty = ?, outbound_move_to = ?, outbound_attempts = 0
     WHERE id = ?
-  `).run(edited ? 1 : 0, moved ? now.outbound_move_to : null, sent.id);
+  `).run(edited ? 1 : 0, nextMove, sent.id);
 }
 
 /**

--- a/server/services/caldav-outbound.js
+++ b/server/services/caldav-outbound.js
@@ -59,6 +59,29 @@ function applyMove(eventId, source, calendarUrl, destCal, objectUrl) {
 }
 
 /**
+ * Hat der Nutzer den Termin gelöscht, während sein Umzug lief? Dann steht der
+ * Tombstone der Löschroute für genau das Objekt in der Quelle - über dessen URL,
+ * bei Altbestand ohne gespeicherte URL über den Quellkalender.
+ *
+ * Eine fehlende Zeile allein sagt das nicht. Das Aufräumen eines abgewählten
+ * Kalenders, das Trennen eines Kontos und der Prune löschen ebenfalls lokal, und
+ * zwar ausdrücklich, ohne den Anbieter anzufassen (calendar-prune.js). Ein
+ * Tombstone für die Kopie im Ziel löschte dort einen Termin, den andere Clients
+ * derselben Familie weiter sehen sollen.
+ *
+ * Offen bleibt: räumt ein paralleler Durchgang den Tombstone der Quelle ab, bevor
+ * der Umzug hier ankommt, fehlt das Signal, und die Kopie im Ziel bleibt stehen.
+ * Das schliesst erst eine Serialisierung der ausgehenden Arbeit.
+ */
+function deletedByUser(source, uid, sourceObjectUrl, sourceCalendarUrl) {
+  return !!db.get().prepare(`
+    SELECT 1 FROM calendar_pending_deletions
+    WHERE source = ? AND event_external_id = ?
+      AND (object_url = ? OR (object_url IS NULL AND calendar_external_id = ?))
+  `).get(source, uid, sourceObjectUrl, sourceCalendarUrl);
+}
+
+/**
  * Schliesst die ausgehende Arbeit eines Termins nach dem Provider-Aufruf ab.
  *
  * Zwischen dem Nachladen vor dem Aufruf und hier liegen awaits. Trifft in dieser
@@ -365,15 +388,17 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
           } catch (err) {
             log.error(`[${label(source)}] Event ${event.id} was copied to ${moveTo} but could not be removed from its old calendar:`, err.message);
           }
-          // Während der beiden awaits lokal gelöscht: die Route hat den Tombstone
-          // mit der alten Quelle angelegt, die Kopie im Ziel kennt sie nicht. Ohne
-          // eigenen Tombstone bliebe sie stehen, und der nächste Lauf importierte
-          // den Termin von dort neu.
+          // Während der beiden awaits lokal entfernt. Hat der Nutzer gelöscht, gilt
+          // der Tombstone der Route nur der Quelle; die Kopie im Ziel bliebe stehen,
+          // und der nächste Lauf importierte den Termin von dort neu. Ein Aufräumen
+          // dagegen soll den Anbieter nicht anfassen - siehe deletedByUser.
           if (!outbound.reloadEvent(event.id)) {
-            outbound.queueDeletion({
-              source, calendarExternalId: moveTo, eventExternalId: event.external_calendar_id, objectUrl,
-            });
-            log.warn(`[${label(source)}] Event ${event.id} was deleted during its move, queued the deletion of its copy in ${moveTo}.`);
+            if (deletedByUser(source, event.external_calendar_id, url, known.calendarUrl)) {
+              outbound.queueDeletion({
+                source, calendarExternalId: moveTo, eventExternalId: event.external_calendar_id, objectUrl,
+              });
+              log.warn(`[${label(source)}] Event ${event.id} was deleted during its move, queued the deletion of its copy in ${moveTo}.`);
+            }
             continue;
           }
           applyMove(event.id, source, moveTo, destCal, objectUrl);

--- a/server/services/caldav-sync.js
+++ b/server/services/caldav-sync.js
@@ -8,7 +8,7 @@ import { createLogger } from '../logger.js';
 const log = createLogger('CalDAV');
 
 import * as db from '../db.js';
-import { decodeHtmlEntities } from '../utils/html-entities.js';
+import { upsertExternalCalendar } from './external-calendars.js';
 import { assignDefaultToEvent } from './sync-assignment.js';
 import { pruneDeletedEvents, countMirroredEvents, deleteMirroredEvents } from './calendar-prune.js';
 import * as outbound from './calendar-outbound.js';
@@ -86,20 +86,6 @@ function normalizeCalColor(c) {
   if (/^#[0-9a-fA-F]{8}$/.test(c)) return c.slice(0, 7); // strip alpha
   if (/^#[0-9a-fA-F]{6}$/.test(c)) return c;
   return null;
-}
-
-function upsertExternalCalendar(source, externalId, name, color) {
-  // Provider-Namen können HTML-entity-encoded sein — zu Klartext normalisieren,
-  // sonst escaped die UI doppelt (z. B. literales "&amp;").
-  const row = db.get().prepare(`
-    INSERT INTO external_calendars (source, external_id, name, color)
-    VALUES (?, ?, ?, ?)
-    ON CONFLICT(source, external_id) DO UPDATE SET
-      name  = excluded.name,
-      color = excluded.color
-    RETURNING id
-  `).get(source, externalId, decodeHtmlEntities(name), color);
-  return row.id;
 }
 
 // --------------------------------------------------------

--- a/server/services/external-calendars.js
+++ b/server/services/external-calendars.js
@@ -1,0 +1,30 @@
+// --------------------------------------------------------
+// Kalender-Metadaten eines Providers in external_calendars.
+//
+// Geteilt vom CalDAV-Sync (Inbound und Upload) und vom CalDAV-Outbound: der
+// Umzug eines Termins muss dieselbe Zeile finden bzw. anlegen, die der Inbound
+// für den Zielkalender schreibt, sonst zeigt calendar_ref_id bis zum nächsten
+// Lauf auf eine andere Zeile als die, zu der der Termin danach gehört.
+// Der Outbound darf dafür caldav-sync.js nicht importieren - das wäre ein Zyklus.
+// --------------------------------------------------------
+
+import * as db from '../db.js';
+import { decodeHtmlEntities } from '../utils/html-entities.js';
+
+/**
+ * Legt die Kalenderzeile an oder aktualisiert Name und Farbe.
+ * @returns {number} external_calendars.id
+ */
+export function upsertExternalCalendar(source, externalId, name, color) {
+  // Provider-Namen können HTML-entity-encoded sein - zu Klartext normalisieren,
+  // sonst escaped die UI doppelt (z. B. literales "&amp;").
+  const row = db.get().prepare(`
+    INSERT INTO external_calendars (source, external_id, name, color)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(source, external_id) DO UPDATE SET
+      name  = excluded.name,
+      color = excluded.color
+    RETURNING id
+  `).get(source, externalId, decodeHtmlEntities(name), color);
+  return row.id;
+}

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1242,6 +1242,63 @@ test('ein während des PUT vorgemerkter Umzug bleibt stehen', async () => {
   assert.equal(row.outbound_dirty, 0, 'die Feldänderung selbst ist angekommen');
 });
 
+test('wird der Quellkalender während des Umzugs aufgeräumt, bleibt die Kopie im Ziel stehen', async () => {
+  // Abwählen mit "Termine löschen" entfernt die Zeilen lokal und fasst den Anbieter
+  // ausdrücklich nicht an (calendar-prune.js). Eine fehlende Zeile ist deshalb kein
+  // Löschwunsch: ein Tombstone hier löschte den Termin bei allen anderen Clients.
+  reset();
+  const { deleteMirroredEvents } = await import('../server/services/calendar-prune.js');
+  const event = seedMoved('mv15@t');
+
+  const client = fakeClient({ onCreate: () => { deleteMirroredEvents(db, [CAL_URL]); } });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(client, 'caldav', indexFor('mv15@t'), calendars);
+
+  assert.equal(reload(event.id), undefined, 'Vorbedingung: das Aufräumen hat die Zeile entfernt');
+  assert.deepEqual(tombstones(), [], 'kein Tombstone - weder für die Quelle noch für das Ziel');
+});
+
+test('ein Tombstone derselben UID in einem fremden Kalender gilt nicht als Löschen dieses Termins', async () => {
+  reset();
+  const { deleteMirroredEvents } = await import('../server/services/calendar-prune.js');
+  const CAL3_URL = 'https://dav.example/cal/school/';
+  const event = seedMoved('mv16@t');
+  outbound.queueDeletion({
+    source: 'caldav', calendarExternalId: CAL3_URL, eventExternalId: 'mv16@t', objectUrl: `${CAL3_URL}mv16@t.ics`,
+  });
+
+  const client = fakeClient({ onCreate: () => { deleteMirroredEvents(db, [CAL_URL]); } });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(client, 'caldav', indexFor('mv16@t'), calendars);
+
+  assert.equal(reload(event.id), undefined);
+  assert.equal(tombstones().filter((t) => t.calendar_external_id === CAL2_URL).length, 0);
+});
+
+test('auch Altbestand ohne gespeicherte URL erkennt das Löschen während des Umzugs', async () => {
+  // Ohne external_object_url trägt der Tombstone der Route keine URL, nur den
+  // Quellkalender. Daran muss das Löschen erkannt werden.
+  reset();
+  const calRefId = upsertCalendar(CAL_URL);
+  const before = insertSyncedEvent({ uid: 'mv17@t', calRefId, target: CAL_URL });
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL2_URL, before.id);
+  outbound.markEventOutbound(before, reload(before.id));
+
+  const client = fakeClient({
+    onCreate: () => {
+      outbound.queueEventDeletion(reload(before.id));
+      db.prepare('DELETE FROM calendar_events WHERE id = ?').run(before.id);
+    },
+  });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(client, 'caldav', indexFor('mv17@t'), calendars);
+
+  assert.equal(tombstones().find((t) => t.calendar_external_id === CAL_URL)?.object_url, null,
+    'Vorbedingung: der Tombstone der Route kennt keine URL');
+  const target = tombstones().find((t) => t.calendar_external_id === CAL2_URL);
+  assert.equal(target?.object_url, `${CAL2_URL}mv17@t.ics`);
+});
+
 test('ein Rückweg in die Quelle während des Umzugs wird als neuer Umzug vorgemerkt', async () => {
   // Während das Anlegen im Ziel läuft, steht calendar_ref_id noch auf der Quelle.
   // Die Route sieht im Rückweg dorthin deshalb keinen Umzug und lässt die alte

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1129,6 +1129,56 @@ test('der Umzug übernimmt Name und Farbe des Zielkalenders aus der Kontoauswahl
   assert.equal(cal.color, '#FF8800');
 });
 
+test('eine Ziel-URL ohne Schrägstrich am Ende wird als Collection behandelt', async () => {
+  // tsdav bildet die Objekt-URL mit new URL(filename, calendar.url). Ohne den
+  // Schrägstrich ersetzt das das letzte Segment: das Objekt käme nach /cal/ statt
+  // nach /cal/work/, und die gespeicherte URL zeigte auf dieselbe falsche Stelle.
+  reset();
+  const bare = 'https://dav.example/cal/work';
+  const calRefId = upsertCalendar(CAL_URL);
+  const before = insertSyncedEvent({ uid: 'mv10@t', calRefId, objectUrl: `${CAL_URL}mv10@t.ics`, target: CAL_URL });
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(bare, before.id);
+  outbound.markEventOutbound(before, reload(before.id));
+
+  const client = fakeClient();
+  const calendars = new Map([[bare, { url: bare, displayName: 'Arbeit' }]]);
+  assert.equal(await processPendingUpdates(client, 'caldav', indexFor('mv10@t'), calendars), 1);
+
+  assert.equal(client.creates[0].calendar.url, `${bare}/`, 'der PUT geht in die Collection');
+  const row = reload(before.id);
+  assert.equal(row.external_object_url, `${bare}/mv10@t.ics`);
+  assert.equal(row.calendar_ref_id, calRefFor(bare), 'die Kalenderzeile behält die URL der Auswahl');
+});
+
+test('wird der Termin während des Umzugs gelöscht, wird auch die Kopie im Ziel gelöscht', async () => {
+  // Der Sofortversuch läuft ohne await hinter der Antwort. Löscht jemand den
+  // Termin, während das Anlegen im Ziel noch unterwegs ist, legt die Route den
+  // Tombstone mit der alten Quelle an - die neue Kopie bliebe sonst stehen und
+  // käme mit dem nächsten Lauf zurück.
+  reset();
+  const event = seedMoved('mv11@t');
+
+  const client = fakeClient({
+    onCreate: () => {
+      outbound.queueEventDeletion(reload(event.id));
+      db.prepare('DELETE FROM calendar_events WHERE id = ?').run(event.id);
+    },
+  });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(client, 'caldav', indexFor('mv11@t'), calendars);
+
+  const target = tombstones().find((t) => t.calendar_external_id === CAL2_URL);
+  assert.ok(target, 'für die Kopie im Ziel steht ein Tombstone');
+  assert.equal(target.event_external_id, 'mv11@t');
+  assert.equal(target.object_url, `${CAL2_URL}mv11@t.ics`);
+  assert.ok(outbound.hasPendingDeletion('caldav', 'mv11@t'), 'der Inbound importiert die UID nicht neu');
+
+  const cleanup = fakeClient();
+  await processPendingDeletions(cleanup, 'caldav', new Map(), new Set([CAL_URL, CAL2_URL]));
+  assert.ok(cleanup.deletes.some((d) => d.calendarObject.url === `${CAL2_URL}mv11@t.ics`),
+    'der nächste Lauf räumt die Kopie im Ziel ab');
+});
+
 test('ohne Eintrag in der Kontoauswahl behält eine bestehende Kalenderzeile Name und Farbe', async () => {
   reset();
   db.prepare('DELETE FROM caldav_calendar_selection').run();

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1026,6 +1026,124 @@ test('scheitert das Anlegen im Ziel, wird in der Quelle nichts gelöscht', async
   assert.equal(reload(before.id).outbound_move_to, CAL2_URL, 'der nächste Lauf versucht es erneut');
 });
 
+// ── Nach dem Kalenderwechsel: die Zeile zeigt auf das Ziel ─────────────────────
+//
+// Bis zum nächsten Inbound-Lauf zeigten calendar_ref_id und external_object_url
+// weiter auf die Quelle, deren Objekt der Umzug gerade gelöscht hatte. Alles, was
+// in diesem Fenster am Termin geschieht, adressiert diese beiden Spalten: ein
+// Löschen lief per DELETE auf die tote URL, das 404 galt als erledigt, der
+// Tombstone fiel weg - und der nächste Lauf importierte den Termin aus dem Ziel
+// neu. Google zieht calendar_ref_id im Umzug sofort nach (`applyMove`).
+
+function seedMoved(uid) {
+  const calRefId = upsertCalendar(CAL_URL);
+  const before = insertSyncedEvent({ uid, calRefId, objectUrl: `${CAL_URL}${uid}.ics`, target: CAL_URL });
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL2_URL, before.id);
+  outbound.markEventOutbound(before, reload(before.id));
+  return reload(before.id);
+}
+
+async function runMove(uid) {
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  return processPendingUpdates(fakeClient(), 'caldav', indexFor(uid), calendars);
+}
+
+function calRefFor(url) {
+  return db.prepare(`SELECT id FROM external_calendars WHERE source = 'caldav' AND external_id = ?`).get(url)?.id;
+}
+
+test('nach dem Kalenderwechsel zeigt der Termin auf den Zielkalender und sein neues Objekt', async () => {
+  reset();
+  const event = seedMoved('mv4@t');
+  assert.equal(await runMove('mv4@t'), 1);
+
+  const row = reload(event.id);
+  assert.ok(calRefFor(CAL2_URL), 'der Zielkalender hat seine external_calendars-Zeile');
+  assert.equal(row.calendar_ref_id, calRefFor(CAL2_URL), 'calendar_ref_id folgt dem Umzug');
+  assert.equal(row.external_object_url, `${CAL2_URL}mv4@t.ics`,
+    'die Objekt-URL ist die, unter der der Umzug angelegt hat');
+});
+
+test('ein Löschen direkt nach dem Umzug trifft das Objekt im Zielkalender', async () => {
+  reset();
+  const event = seedMoved('mv5@t');
+  await runMove('mv5@t');
+
+  assert.equal(outbound.queueEventDeletion(reload(event.id)), true);
+  const [row] = tombstones();
+  assert.equal(row.calendar_external_id, CAL2_URL, 'der Tombstone gehört zum Zielkalender');
+  assert.equal(row.object_url, `${CAL2_URL}mv5@t.ics`);
+
+  const client = fakeClient();
+  await processPendingDeletions(client, 'caldav', new Map(), new Set([CAL_URL, CAL2_URL]));
+  assert.equal(client.deletes[0].calendarObject.url, `${CAL2_URL}mv5@t.ics`,
+    'die alte URL ist schon gelöscht - ihr 404 hätte den Tombstone als erledigt verworfen');
+});
+
+test('eine Bearbeitung nach dem Umzug geht an das Objekt im Zielkalender', async () => {
+  reset();
+  const event = seedMoved('mv6@t');
+  await runMove('mv6@t');
+
+  db.prepare("UPDATE calendar_events SET title = 'Nach dem Umzug' WHERE id = ?").run(event.id);
+  outbound.markOutbound(event.id, { dirty: true });
+
+  // Der volle Lauf findet das Objekt nur noch im Ziel. Der Inbound überspringt
+  // einen Termin mit ausstehendem Push, korrigiert die Spalten also nicht vorher.
+  const client = fakeClient();
+  const index = indexFor('mv6@t', { url: `${CAL2_URL}mv6@t.ics`, calendarUrl: CAL2_URL });
+  assert.equal(await processPendingUpdates(client, 'caldav', index), 1);
+  assert.equal(client.updates[0].calendarObject.url, `${CAL2_URL}mv6@t.ics`,
+    'ein PUT auf die gelöschte URL endet im 404, und das verwirft die Bearbeitung');
+});
+
+test('ein Wechsel zurück in den Ausgangskalender wird als Umzug erkannt', async () => {
+  reset();
+  const event = seedMoved('mv7@t');
+  await runMove('mv7@t');
+
+  const before = reload(event.id);
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL_URL, event.id);
+  assert.equal(outbound.markEventOutbound(before, reload(event.id)), true,
+    'zeigte calendar_ref_id noch auf die Quelle, sähe das Ziel wie der aktuelle Kalender aus');
+  assert.equal(reload(event.id).outbound_move_to, CAL_URL);
+});
+
+test('der Umzug übernimmt Name und Farbe des Zielkalenders aus der Kontoauswahl', async () => {
+  // Dieselben Werte, die der nächste Inbound-Lauf schreibt: sonst setzte der Umzug
+  // eine vorhandene Kalenderfarbe bis dahin auf null.
+  reset();
+  db.prepare('DELETE FROM caldav_calendar_selection').run();
+  const accountId = db.prepare('SELECT id FROM caldav_accounts LIMIT 1').get().id;
+  db.prepare(`INSERT INTO caldav_calendar_selection (account_id, calendar_url, calendar_name, calendar_color, enabled)
+              VALUES (?, ?, 'Arbeit (Auswahl)', '#FF8800', 1)`).run(accountId, CAL2_URL);
+  // Eine ältere Kalenderzeile mit anderem Stand: die Auswahl gewinnt, wie im Inbound.
+  upsertCalendar(CAL2_URL, 'Arbeit (alt)');
+
+  const event = seedMoved('mv8@t');
+  await runMove('mv8@t');
+
+  const cal = db.prepare('SELECT id, name, color FROM external_calendars WHERE external_id = ?').get(CAL2_URL);
+  assert.equal(reload(event.id).calendar_ref_id, cal.id);
+  assert.equal(cal.name, 'Arbeit (Auswahl)');
+  assert.equal(cal.color, '#FF8800');
+});
+
+test('ohne Eintrag in der Kontoauswahl behält eine bestehende Kalenderzeile Name und Farbe', async () => {
+  reset();
+  db.prepare('DELETE FROM caldav_calendar_selection').run();
+  const calRefId = upsertCalendar(CAL2_URL, 'Arbeit (bekannt)');
+
+  const event = seedMoved('mv9@t');
+  await runMove('mv9@t');
+
+  const cal = db.prepare('SELECT id, name, color FROM external_calendars WHERE external_id = ?').get(CAL2_URL);
+  assert.equal(cal.id, calRefId, 'keine zweite Zeile für denselben Kalender');
+  assert.equal(reload(event.id).calendar_ref_id, calRefId);
+  assert.equal(cal.name, 'Arbeit (bekannt)', 'nicht der displayName des Abrufs');
+  assert.equal(cal.color, '#4A90E2', 'die Farbe wird nicht auf null gesetzt');
+});
+
 // ── Sofortversuch ───────────────────────────────────────────────────────────────
 
 /** Attrappe mit gezieltem Objektabruf, wie ihn der Sofortversuch nutzt. */

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1242,6 +1242,47 @@ test('ein während des PUT vorgemerkter Umzug bleibt stehen', async () => {
   assert.equal(row.outbound_dirty, 0, 'die Feldänderung selbst ist angekommen');
 });
 
+test('ein Rückweg in die Quelle während des Umzugs wird als neuer Umzug vorgemerkt', async () => {
+  // Während das Anlegen im Ziel läuft, steht calendar_ref_id noch auf der Quelle.
+  // Die Route sieht im Rückweg dorthin deshalb keinen Umzug und lässt die alte
+  // Vormerkung stehen - nach dem Umzug läge der Termin im Ziel, gewählt ist die Quelle.
+  reset();
+  const event = seedMoved('mv13@t');
+
+  const client = fakeClient({
+    onCreate: () => {
+      const before = reload(event.id);
+      db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL_URL, event.id);
+      outbound.markEventOutbound(before, reload(event.id));
+    },
+  });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(client, 'caldav', indexFor('mv13@t'), calendars);
+
+  const row = reload(event.id);
+  assert.equal(row.calendar_ref_id, calRefFor(CAL2_URL), 'Vorbedingung: der Umzug ins Ziel ist ausgeführt');
+  assert.equal(row.outbound_move_to, CAL_URL, 'der Rückweg läuft im nächsten Durchgang');
+});
+
+test('ein Zielwechsel während des Umzugs zurück auf das Umzugsziel merkt nichts vor', async () => {
+  // Das Gegenstück: liegt das Ziel der Anfrage am Ende dort, wohin der Umzug
+  // gerade ging, gibt es nichts mehr zu tun - kein zweiter Umzug an denselben Ort.
+  reset();
+  const CAL3_URL = 'https://dav.example/cal/school/';
+  const event = seedMoved('mv14@t');
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL3_URL, event.id);
+
+  const client = fakeClient({
+    onCreate: () => {
+      db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL2_URL, event.id);
+    },
+  });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(client, 'caldav', indexFor('mv14@t'), calendars);
+
+  assert.equal(reload(event.id).outbound_move_to, null);
+});
+
 test('ohne Eintrag in der Kontoauswahl behält eine bestehende Kalenderzeile Name und Farbe', async () => {
   reset();
   db.prepare('DELETE FROM caldav_calendar_selection').run();

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1179,6 +1179,69 @@ test('wird der Termin während des Umzugs gelöscht, wird auch die Kopie im Ziel
     'der nächste Lauf räumt die Kopie im Ziel ab');
 });
 
+// ── Was während des Provider-Aufrufs eintrifft ──────────────────────────────────
+//
+// Der Patch wird vor den awaits aus der Zeile gebaut. Eine Bearbeitung, die in
+// dieser Zeit ankommt, setzt outbound_dirty erneut - ein pauschales Abräumen
+// danach löschte ihre Markierung, und der nächste Inbound überschriebe sie.
+
+test('eine Bearbeitung während des Umzugs bleibt für den nächsten Push vorgemerkt', async () => {
+  reset();
+  const event = seedMoved('mv12@t');
+
+  const client = fakeClient({
+    onCreate: () => {
+      const before = reload(event.id);
+      db.prepare("UPDATE calendar_events SET title = 'Während des Umzugs' WHERE id = ?").run(event.id);
+      outbound.markEventOutbound(before, reload(event.id));
+    },
+  });
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  assert.equal(await processPendingUpdates(client, 'caldav', indexFor('mv12@t'), calendars), 1);
+
+  assert.doesNotMatch(client.creates[0].iCalString, /Während des Umzugs/,
+    'Vorbedingung: das angelegte Objekt trägt noch den alten Stand');
+  const row = reload(event.id);
+  assert.equal(row.outbound_dirty, 1, 'die neuere Bearbeitung wartet auf ihren Push');
+  assert.equal(row.outbound_move_to, null, 'der Umzug selbst ist erledigt');
+  assert.equal(row.calendar_ref_id, calRefFor(CAL2_URL));
+});
+
+test('eine Bearbeitung während des PUT bleibt für den nächsten Push vorgemerkt', async () => {
+  reset();
+  const event = seedDirty('u7@t', { title: 'Erste Fassung' });
+
+  const client = fakeClient({
+    onUpdate: () => {
+      const before = reload(event.id);
+      db.prepare("UPDATE calendar_events SET title = 'Zweite Fassung' WHERE id = ?").run(event.id);
+      outbound.markEventOutbound(before, reload(event.id));
+    },
+  });
+  assert.equal(await processPendingUpdates(client, 'caldav', indexFor('u7@t')), 1);
+
+  assert.match(client.updates[0].calendarObject.data, /SUMMARY:Erste Fassung/);
+  assert.equal(reload(event.id).outbound_dirty, 1, 'die zweite Fassung ist noch nicht beim Server');
+});
+
+test('ein während des PUT vorgemerkter Umzug bleibt stehen', async () => {
+  reset();
+  const event = seedDirty('u8@t', { title: 'Neu' });
+
+  const client = fakeClient({
+    onUpdate: () => {
+      const before = reload(event.id);
+      db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL2_URL, event.id);
+      outbound.markEventOutbound(before, reload(event.id));
+    },
+  });
+  await processPendingUpdates(client, 'caldav', indexFor('u8@t'));
+
+  const row = reload(event.id);
+  assert.equal(row.outbound_move_to, CAL2_URL, 'der Umzug läuft im nächsten Durchgang');
+  assert.equal(row.outbound_dirty, 0, 'die Feldänderung selbst ist angekommen');
+});
+
 test('ohne Eintrag in der Kontoauswahl behält eine bestehende Kalenderzeile Name und Farbe', async () => {
   reset();
   db.prepare('DELETE FROM caldav_calendar_selection').run();


### PR DESCRIPTION
Refs #593

Found in the review of #1124 (Codex thread on `server/services/calendar-events.js`: "CalDAV does not update `calendar_ref_id` during its move path at all").

## What went wrong

Moving a synced CalDAV event to another calendar runs as create-in-destination plus delete-in-source (`processPendingUpdates` in `server/services/caldav-outbound.js`). Afterwards only `clearOutbound()` ran. `calendar_ref_id` and `external_object_url` stayed on the old calendar until the next inbound run corrected them (`updEvent` in `caldav-sync.js`). The immediate flush makes that window as long as the sync interval, and three things in it address those two columns:

1. **Delete.** `queueEventDeletion()` writes the tombstone with the old calendar and the old object URL. The immediate flush (and the full sync, where `row.object_url` wins over the object found in this run) sends `DELETE` to that URL. The object is already gone, the 404 counts as `settled`, the tombstone is dropped. The event stays in the destination calendar, and the next sync imports it again.
2. **Edit.** The full sync finds the object only in the destination, but the PUT goes to `event.external_object_url`, the dead URL. 404, `settled`, the edit is dropped. The inbound does not correct the columns first, because it skips rows with `outbound_dirty`.
3. **Moving back.** `markEventOutbound()` reads the current calendar through `calendar_ref_id`. It still says "source", so a move back to the source looks like "target == current" and is not queued.

Google's move path (`applyMove` in `google-calendar.js`) updates `calendar_ref_id` right away for exactly this reason.

## Fix

After a successful create, the row takes:
- `calendar_ref_id` = the destination's `external_calendars` row (`source`, `external_id` = destination URL) via `upsertExternalCalendar`, the helper the upload path already uses;
- `external_object_url` = `new URL(filename, <destination as collection URL>).href`, the URL tsdav builds for the PUT (`createCalendarObject`), see round 1.

The helper overwrites name and colour, so they come from `caldav_calendar_selection` (the values the inbound writes), otherwise from an existing `external_calendars` row. Otherwise the move would null a calendar's colour until the next run. `upsertExternalCalendar` moves to `server/services/external-calendars.js`: `caldav-outbound.js` cannot import `caldav-sync.js` without a cycle. The identical copies in `apple-calendar.js` and `google-calendar.js` are left alone.

### Review round 1 (Codex, `13c5b80e`)

- **Slash-less destination URL.** tsdav resolves the filename with `new URL(filename, calendar.url)`. Without a trailing slash, the object and the recorded URL both landed next to the collection. The move now normalises the destination to a collection URL for the PUT and for the recorded URL, as the upload path does. The `external_calendars` row keeps the selection's URL.
- **Delete while the move is in flight.** The immediate flush runs behind the response. A delete in that window queues its tombstone for the source, and `applyMove` found no row. If the row is gone after the awaits, the move now queues a tombstone for the destination copy.

### Review round 2 (Codex, `3e9d5ddf`)

- **Edit while the provider call is in flight.** The patch is built from the row before the awaits, and both completion paths (move and plain PUT) cleared the outbound flags unconditionally afterwards, erasing an edit or a move queued in between. Both now go through `settleOutbound()`: `outbound_dirty` stays when a mirrored field changed since the patch was built, `outbound_move_to` stays when it differs from the move this run executed. Google's `processPendingUpdates` has the same race, which predates this PR; I left it for a separate change.

### Review round 3 (Codex, `7badde57`)

- **Move reversed while it is in flight.** Until `applyMove`, `calendar_ref_id` still names the source, so a request that picks the source again looks like "no move" and leaves the old marker, which `settleOutbound()` then cleared as done. When the target changed during a move, the settle now decides from the target the request set, against the calendar the event now lives in. A move reverted before any flush runs is an older gap in `markEventOutbound` (`COALESCE` cannot cancel a marker) and is left for its own change.

### Review round 4 (Codex, `5da579dd`)

- **Local cleanup is not a delete.** The round-1 tombstone for the destination copy was queued for any missing row. Deselecting a calendar with its events, disconnecting an account and the prune also remove rows, and by design leave the provider alone; a tombstone there deleted the event for every other client. It now requires the delete route's own tombstone for exactly this object (by URL, or by source calendar for rows without a stored URL).
- **Not addressed: a parallel flush dropping the source tombstone first** (summary comment). Then the signal is gone and the destination copy stays, as before this PR. Another check would not close this; it needs the CalDAV outbound work (immediate flush, scheduled sync) to be serialised. Four review rounds on this PR were all this kind of race, so I would take that as its own issue instead of adding further guards here.

Not changed: if deleting the old object fails, the event is on the server twice (as before). The row now points at the destination copy, which is the one that carries the change.

## Tests

`test/test-caldav-outbound.js`, network-free with the existing tsdav stub, sixteen new tests. On the old code, the first five were red (the sixth came later for the fallback rule, the rest with the review rounds):

| Test | Rule |
|---|---|
| after the move, the event points at the destination calendar and its new object | ref + URL |
| a delete right after the move hits the object in the destination | ref + URL (tombstone) |
| an edit after the move goes to the object in the destination | URL |
| moving back to the source is recognised as a move | ref |
| the move takes name and colour from the account selection, over an older row | selection wins |
| without a selection entry, an existing row keeps name and colour | fallback |
| a destination URL without a trailing slash is treated as a collection | round 1 |
| an event deleted during its move gets its destination copy deleted | round 1 |
| an edit during the move stays queued for the next push | round 2 |
| an edit during the PUT stays queued for the next push | round 2 |
| a move queued during the PUT stays queued | round 2 |
| a reversal to the source during the move is queued as a new move | round 3 |
| a target ending on the destination during the move queues nothing | round 3 |
| a calendar cleanup during the move leaves the destination copy alone | round 4 |
| a same-UID tombstone in another calendar does not count as this delete | round 4 |
| a legacy row without stored URL still recognises the delete | round 4 |

Counterproofs (file restored from a `cp` backup each time):
- no `calendar_ref_id` in the UPDATE: tests 1, 2, 4, 5 red
- no `external_object_url` in the UPDATE: tests 1, 2, 3 red
- colour hard-coded to `null`: test 5 red; name taken from `displayName`: test 5 red
- existing row before selection: test 5 red
- no fallback to the existing row: test 6 red
- no slash normalisation: test 7 red; missing-row check disabled: test 8 red
- settle rule off: tests 9-11 red; edit check off: 9, 10; move check off: 11; move call site back on `clearOutbound`: 9; PUT call site: 10, 11
- reconciliation off: test 12 red; "not where it already is" guard off: test 13 red
- delete gate off: tests 14, 15 red; calendar/URL match off: 15; null-URL branch off: 16

`test:caldav-outbound` 87/87. `caldav`, `caldav-object-urls`, `caldav-event-target`, `caldav-recurrence`, `caldav-reminders`, `caldav-todo-outbound`, `calendar-outbound-migration`, `google-outbound`, `layer-boundary` and `changelog` are green. Full `npm test` on `ffd1ae03`: EXIT=0.

Pairwise with main after #1124 (`17b37837`, which reads `outbound_move_to` before `calendar_ref_id` for the source): the merge tree is conflict-free, and `caldav-outbound`, `calendar-routes`, `calendar`, `caldav-object-urls`, `google-outbound` and `changelog` are green on it.

Round 1 (`13c5b80e`): full `npm test` EXIT=0 on the merge with main at `a8067497` (after #1125 and #1126), conflict-free.

Round 2 (`3e9d5ddf`): full `npm test` EXIT=0 on the merge with main at `a8067497`, conflict-free.

Round 3 (`7badde57`): full `npm test` EXIT=0 on the merge with main at `a8067497`, conflict-free.

Round 4 (`5da579dd`): full `npm test` EXIT=0 on the merge with main at `a8067497`, conflict-free.

### Review round 5 (Codex, on `5da579dd`)

The round-4 residual came back as an inline P1 (a parallel flush settles the source tombstone before the move returns). Not changed here: keeping the signal alive means serialising CalDAV outbound work, which is a design decision for its own change. The thread stays open until then.
