### PR TITLE
fix(calendar): settle caldav outbound work through the shared helper

### DIFF
--- a/server/services/caldav-outbound.js
+++ b/server/services/caldav-outbound.js
@@ -82,44 +82,6 @@ function deletedByUser(source, uid, sourceObjectUrl, sourceCalendarUrl) {
 }
 
 /**
- * Schliesst die ausgehende Arbeit eines Termins nach dem Provider-Aufruf ab.
- *
- * Zwischen dem Nachladen vor dem Aufruf und hier liegen awaits. Trifft in dieser
- * Zeit eine Bearbeitung ein, setzt die Route outbound_dirty erneut, und ein
- * pauschales clearOutbound löschte genau diese Markierung: beim Server läge der
- * ältere Stand, und der nächste Inbound überschriebe die neuere lokale Änderung.
- * Erledigt ist deshalb nur, was hinausging - verglichen an den gespiegelten
- * Feldern und an dem Umzug, den dieser Aufruf ausgeführt hat.
- *
- * @param {object}      sent           die Zeile, aus der der Patch gebaut wurde
- * @param {string|null} handledMoveTo  der Umzug, den dieser Aufruf erledigt hat
- */
-function settleOutbound(sent, handledMoveTo = null) {
-  const now = outbound.reloadEvent(sent.id);
-  if (!now) return;
-  const edited = outbound.mirroredFieldsChanged(sent, now);
-  let nextMove = (now.outbound_move_to ?? null) !== handledMoveTo ? now.outbound_move_to : null;
-  // Einen Zielwechsel während eines Umzugs hat die Route noch gegen die QUELLE
-  // gerechnet: calendar_ref_id wandert erst mit applyMove. Ein Rückweg dorthin
-  // sah wie "kein Umzug" aus und liess die alte Vormerkung stehen, die hier als
-  // erledigt gälte. Massgeblich ist dann das Ziel der Anfrage, gegen den Kalender,
-  // in dem der Termin jetzt liegt.
-  if (handledMoveTo && now.target_caldav_calendar_url !== sent.target_caldav_calendar_url) {
-    const target = now.target_caldav_calendar_url || null;
-    nextMove = target && target !== handledMoveTo ? target : null;
-  }
-  if (!edited && !nextMove) {
-    outbound.clearOutbound(sent.id);
-    return;
-  }
-  db.get().prepare(`
-    UPDATE calendar_events
-    SET outbound_dirty = ?, outbound_move_to = ?, outbound_attempts = 0
-    WHERE id = ?
-  `).run(edited ? 1 : 0, nextMove, sent.id);
-}
-
-/**
  * Kalender-Properties eines lokalen Termins für patchICSEvent.
  *
  * Die Zeitangaben kommen seit #938 aus `eventDateTimeFields`: der Fall, den es
@@ -402,7 +364,7 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
             continue;
           }
           applyMove(event.id, source, moveTo, destCal, objectUrl);
-          settleOutbound(fresh, moveTo);
+          outbound.settleOutbound(fresh, moveTo);
           done++;
           continue; // der Patch ist mit dem Anlegen bereits geschrieben
         } catch (err) {
@@ -420,7 +382,7 @@ export async function processPendingUpdates(client, source, objectIndex, calenda
       await client.updateCalendarObject({
         calendarObject: { url, etag: known.etag, data: patched },
       });
-      settleOutbound(fresh);
+      outbound.settleOutbound(fresh);
       done++;
     } catch (err) {
       outbound.handleUpdateError(err, event, 'update', label(source));

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1340,6 +1340,32 @@ test('ein Zielwechsel während des Umzugs zurück auf das Umzugsziel merkt nicht
   assert.equal(reload(event.id).outbound_move_to, null);
 });
 
+test('ein während des PUT gewählter und wieder verworfener Umzug verfällt', async () => {
+  // Ohne Umzug in diesem Lauf: ein anderer Kalender wird vorgemerkt, dann wieder der
+  // gewählt, in dem der Termin liegt. Die Route kann die Vormerkung nicht zurücknehmen,
+  // der nächste Lauf verschöbe den Termin in den verworfenen Kalender.
+  reset();
+  const event = seedDirty('u9@t', { title: 'Neu' });
+
+  const retarget = (url) => {
+    const before = reload(event.id);
+    db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(url, event.id);
+    outbound.markEventOutbound(before, reload(event.id));
+  };
+  const client = fakeClient({
+    onUpdate: () => {
+      retarget(CAL2_URL);
+      assert.equal(reload(event.id).outbound_move_to, CAL2_URL, 'Vorbedingung: der Umweg ist vorgemerkt');
+      retarget(CAL_URL);
+    },
+  });
+  await processPendingUpdates(client, 'caldav', indexFor('u9@t'));
+
+  const row = reload(event.id);
+  assert.equal(row.outbound_move_to, null, 'gewählt ist der Kalender, in dem der Termin liegt');
+  assert.equal(row.outbound_dirty, 0);
+});
+
 test('ohne Eintrag in der Kontoauswahl behält eine bestehende Kalenderzeile Name und Farbe', async () => {
   reset();
   db.prepare('DELETE FROM caldav_calendar_selection').run();


### PR DESCRIPTION
Refs #593

Follow-up to #1127 and #1128, both merged.

## What changes

`server/services/caldav-outbound.js` kept a private `settleOutbound` from #1127. #1128 moved the helper into `server/services/calendar-outbound.js`, and its three review rounds made the shared version stricter than the copy. This PR deletes the copy; both call sites (move completion and plain PUT) now call `outbound.settleOutbound`, with the same arguments as before.

## Why it matters for CalDAV

The copy only reconciled the target after a move. The shared helper reconciles any move queued during the call against the calendar the event is in (`currentCalendarId`, read from `calendar_ref_id`). That closes one case for CalDAV:

- **A move picked and reverted during a PUT.** Picking another calendar while the PUT runs is queued, because the event is still in its calendar. Picking that calendar again cannot take the marker back in the route (`markEventOutbound` sees "target == current"). The copy kept the marker, and the next sync moved the event to the calendar the user had abandoned.

Before #1127 the unconditional `clearOutbound` happened to drop that marker, so this never reached a release and needs no CHANGELOG entry.

The other difference, a detour through a third calendar during a move and back to the destination during the follow-up patch, is Google-only: CalDAV's move and patch are a single `createCalendarObject`, so both retargets land in the same await, and the route's `COALESCE` already leaves the destination as the marker.

For everything the copy handled, the shared helper decides the same way: CalDAV passes no `requested` row, so the target comparison uses `sent` as before, and after a move `calendar_ref_id` already names the destination (`applyMove` runs before the settle), so the current calendar equals `handledMoveTo`.

## Tests

`test/test-caldav-outbound.js`: one new test, "a move picked and reverted during the PUT lapses" (retarget to the second calendar, then back, inside the fake `updateCalendarObject`).

Counterproofs, files restored from a `cp` backup each time:
- `caldav-outbound.js` back to main's version (private copy): only the new test red, the other 87 green. #1127's round 2 and 3 tests pass on the shared helper unchanged.
- shared helper reconciles only after a move (`handledMoveTo &&` in front of the condition): only the new test red.

`test:caldav-outbound` 88/88. `caldav`, `caldav-object-urls`, `caldav-event-target`, `caldav-recurrence`, `caldav-reminders`, `caldav-todo-outbound`, `google-outbound`, `calendar-outbound-migration`, `calendar-routes`, `layer-boundary` and `changelog` are green. Full `npm test` on `7fb7ffe6`: EXIT=0.

## Not changed

Still open from the #1127/#1128 threads, for a separate change: serialising outbound runs per provider (two runs can process the same row), a queued move reverted before any run starts (`COALESCE` in `markOutbound`), the remaining unconditional clears in the error and skip paths, and a delete during a Google move.
