### PR TITLE
test(frontend-audit): skip declaration heads as close anchors (#1083)

### DIFF
--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -16376,6 +16376,8 @@ function selbstNachziehend(lines) {
  * ohne den Fokus nachzuziehen. Eine eigene Funktion, damit die Sonden weiter
  * unten dieselbe Pruefung an kuenstlichen Quellen fahren wie der Guard am Repo.
  */
+const DEKLARATIONS_KOPF = /^\s*(?:export\s+)?(?:async\s+)?function\s*\*?\s*[A-Za-z_$][\w$]*\s*\(/;
+
 function fokusLuecken(datei, lines) {
   const fehlend = [];
   const wrapper = rendererIn(lines);
@@ -16387,7 +16389,15 @@ function fokusLuecken(datei, lines) {
   for (const n of schliesst) wrapper.delete(n);
   const nachziehend = selbstNachziehend(lines);
   lines.forEach((zeile, i) => {
-    if (!istSchliessen(zeile, schliesst)) return;
+    // EINE DEKLARATION SCHLIESST NICHTS. `export function confirmModal(` in
+    // modal.js traf den Namen aus ERGEBNIS_DIALOGE und wurde zum Anker - in
+    // Spalte 0, also ohne umschliessende Funktion, und das Fenster las damit
+    // bis weit in die Datei. Beim Merge von #1055 fand es dort das abgewartete
+    // `close` einer Hilfsfunktion und verlangte `refocusAfterRender()`, das die
+    // Wache darunter als tot gemeldet haette.
+    // Weg faellt nur der KOPF, nicht die Zeile: `async function save() {
+    // closeModal();` in einer Zeile bleibt ein Anker (Codex-Review zu #1131).
+    if (!istSchliessen(zeile.replace(DEKLARATIONS_KOPF, ''), schliesst)) return;
     // EIN VERZOEGERTES SCHLIESSEN IST HIER KEINES. `setTimeout(() =>
     // closeModal(...), 700)` in tasks.js laeuft erst, wenn der Block
     // laengst durch ist - der Merker, auf den `refocusAfterRender()`
@@ -17000,6 +17010,34 @@ test('Fokus-Guard: close-Parameter, Einzeiler, Signaturen, Dialog nach dem Neuau
   assert.deepEqual(stellen('danach.js', danach), ['danach.js:2'], 'confirmModal danach findet den Knopf nicht wieder');
   const offen = danach.map((l) => l.replace('if (await confirmModal(frage)) tuNochWas();', 'closeModal();'));
   assert.deepEqual(stellen('danach.js', offen), [], 'ein Dialog, der schon offen war, setzt den Fokus beim Schliessen selbst');
+
+  // Eine Deklaration ist kein Schliessen (Merge von #1055): `confirmModal(` in
+  // der eigenen Signatur liess das Fenster ohne umschliessende Funktion bis in
+  // die naechste lesen, und dort galt das abgewartete `close` als Neuaufbau.
+  const deklaration = [
+    'export function confirmModal(frage) {',
+    '  return new Promise((resolve) => {',
+    '    resolve(true);',
+    '  });',
+    '}',
+    'async function beenden(',
+    '  bestaetigt,',
+    '  { close = closeModal } = {},',
+    ') {',
+    '  if (bestaetigt) await close({ force: true });',
+    '  return bestaetigt;',
+    '}',
+  ];
+  assert.deepEqual(stellen('deklaration.js', deklaration), [],
+    'die Signatur von confirmModal ist kein Anker');
+  const gleichzeile = [
+    'async function speichern() { closeModal({ force: true });',
+    '  await api.put(url);',
+    '  renderListe();',
+    '}',
+  ];
+  assert.deepEqual(stellen('gleichzeile.js', gleichzeile), ['gleichzeile.js:1'],
+    'ein Schliessen hinter dem Kopf in derselben Zeile bleibt ein Anker');
 
   // Ein Wrapper, der auf seiner eigenen Ebene nachzieht, deckt seinen Neuaufbau.
   const wrapper = [

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -16376,7 +16376,7 @@ function selbstNachziehend(lines) {
  * ohne den Fokus nachzuziehen. Eine eigene Funktion, damit die Sonden weiter
  * unten dieselbe Pruefung an kuenstlichen Quellen fahren wie der Guard am Repo.
  */
-const DEKLARATIONS_KOPF = /^\s*(?:export\s+)?(?:async\s+)?function\s*\*?\s*[A-Za-z_$][\w$]*\s*\(/;
+const DEKLARATIONS_KOPF = /^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s*\*?\s*[A-Za-z_$][\w$]*\s*\(/;
 
 function fokusLuecken(datei, lines) {
   const fehlend = [];
@@ -17030,6 +17030,9 @@ test('Fokus-Guard: close-Parameter, Einzeiler, Signaturen, Dialog nach dem Neuau
   ];
   assert.deepEqual(stellen('deklaration.js', deklaration), [],
     'die Signatur von confirmModal ist kein Anker');
+  const standard = deklaration.map((l, k) => (k === 0 ? 'export default function confirmModal(frage) {' : l));
+  assert.deepEqual(stellen('standard.js', standard), [],
+    'auch nicht als Default-Export (Codex-Review zu #1131)');
   const gleichzeile = [
     'async function speichern() { closeModal({ force: true });',
     '  await api.put(url);',


### PR DESCRIPTION
The focus-restore guard from #1083 reports a false positive once `main` is merged into #1055.

## What happens

`fokusLuecken()` treats every line that matches a close name as an anchor. `confirmModal` is one of the result dialogs, so the declaration `export function confirmModal(` in `modal.js` was an anchor too. It sits in column 0, so `rumpfAb()` finds no enclosing function and reads on into the rest of the file.

#1055 adds `finishSuspendedConfirmation(confirmed, closeOnConfirm, suspended, { resume, close = closeModal } = {})` further down. `abgewarteteParameter()` collects its `close` as an awaited callback, which counts as a re-render, so the guard reports `if (confirmed && closeOnConfirm) await close(...)` and asks for `refocusAfterRender()`. Adding that call makes the sister guard ("kein refocusAfterRender ohne ein Schliessen") fail instead, because the function opens no dialog. Nothing renders after that close, so the report is wrong, not the code.

## Change

- The declaration head (`function name(`) is cut off before the close check, so a signature no longer anchors. A close call behind the head on the same line still does (Codex review).
- Two probes in the existing probe test ("Fokus-Guard: close-Parameter, …"): the `confirmModal` shape, and a declaration with `closeModal()` on the same line.

## Verification

- `test:frontend-audit` on this branch: 383 pass, 0 fail.
- Counterproofs: without any skip, exactly the first probe fails (`deklaration.js:1`); with the whole declaration line skipped, exactly the second one fails (`gleichzeile.js:1` missing). The guard on the repo itself stays green in both, since `main` does not contain the shape yet.
- On a local merge of `main` into #1055 (`80c6a958`, with the other merge resolutions described in the #1055 review), the guard failed before this change and `test:frontend-audit` is green with it (383/0).

Refs #1083, #1055.
