### PR TITLE
fix(contacts): use the misc category key for auto-created member/guest contacts

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -464,7 +464,7 @@ function syncFamilyMemberArtifacts(database, userId, {
     database.prepare(`
       UPDATE contacts
       SET name = ?,
-          category = COALESCE(category, 'Sonstiges'),
+          category = COALESCE(category, 'misc'),
           phone = ?,
           email = ?
       WHERE id = ?
@@ -490,7 +490,7 @@ function syncFamilyMemberArtifacts(database, userId, {
   } else {
     database.prepare(`
       INSERT INTO contacts (name, category, phone, email, family_user_id)
-      VALUES (?, 'Sonstiges', ?, ?, ?)
+      VALUES (?, 'misc', ?, ?, ?)
     `).run(name, phone ?? null, email ?? null, userId);
   }
 

--- a/server/db.js
+++ b/server/db.js
@@ -7601,6 +7601,19 @@ const MIGRATIONS = [
       CREATE INDEX idx_shopping_items_store ON shopping_items(store_id);
     `,
   },
+  {
+    version: 194,
+    description: 'heal contacts auto-created for family/guest members with the legacy Sonstiges category (#1140)',
+    up: `
+      -- Migration 91 heilte das schon fuer CardDAV-Import-Kontakte, aber die
+      -- Kontakte, die beim Anlegen eines Haushaltsmitglieds oder Gasts
+      -- gespiegelt werden (server/auth.js, server/routes/split-expenses.js),
+      -- schrieben weiterhin die alte, deutsche Kategorie 'Sonstiges' statt des
+      -- stabilen Keys 'misc'. Da 'Sonstiges' kein Key in contact_categories
+      -- ist, gab die UI ihn ungeuebersetzt aus (#1140).
+      UPDATE contacts SET category = 'misc' WHERE category = 'Sonstiges';
+    `,
+  },
 ];
 
 /**

--- a/server/routes/split-expenses.js
+++ b/server/routes/split-expenses.js
@@ -166,7 +166,7 @@ function syncGuestArtifacts(database, userId, { displayName, phone, email, birth
   const contact = database.prepare('SELECT id, name FROM contacts WHERE family_user_id = ?').get(userId);
   if (contact) {
     database.prepare(`
-      UPDATE contacts SET name = ?, category = COALESCE(category, 'Sonstiges'), phone = ?, email = ?
+      UPDATE contacts SET name = ?, category = COALESCE(category, 'misc'), phone = ?, email = ?
       WHERE id = ?
     `).run(displayName, phone || null, email || null, contact.id);
 
@@ -183,7 +183,7 @@ function syncGuestArtifacts(database, userId, { displayName, phone, email, birth
   } else {
     database.prepare(`
       INSERT INTO contacts (name, category, phone, email, family_user_id)
-      VALUES (?, 'Sonstiges', ?, ?, ?)
+      VALUES (?, 'misc', ?, ?, ?)
     `).run(displayName, phone || null, email || null, userId);
   }
 


### PR DESCRIPTION
## Summary
- Household member and guest accounts get an auto-created/mirrored contact
  (`syncFamilyMemberArtifacts` in `server/auth.js`, `syncGuestArtifacts` in
  `server/routes/split-expenses.js`). Both fell back to the legacy German
  literal `'Sonstiges'` for the contact's category instead of the canonical
  `misc` key.
- Since `'Sonstiges'` isn't a key in `contact_categories`, the contacts page
  couldn't resolve a translated label for it and rendered the raw key
  verbatim — showing "Sonstiges" regardless of the user's locale.
- Added migration 194 to backfill existing contacts still carrying the
  literal `'Sonstiges'` category over to `misc` (mirrors the CardDAV-only
  backfill added in migration 91, extended to cover this path too).
- `misc`'s label (`contacts.categoryOther`) is defined in all 24 locale
  files, so the fix applies to every supported language, not just en/de.

Fixes #1140

## Test plan
- [x] `node --experimental-sqlite --test test/test-family-contacts.js test/test-carddav.js`
- [x] `node --experimental-sqlite --test test/test-split-expenses-routes.js test/test-family-routes.js test/test-contact-categories.js`
- [x] `npm run test:migrations-append-only`
- [x] `npm run test:schema-reconcile`