### PR TITLE
fix(tasks): show the markdown toolbar's icons in the edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The formatting toolbar over a task's note shows its icons again** (#1141). Switching a task's
+  detail view into edit mode builds that form only then, but the icon-replacing pass over the whole
+  overlay had already run before the form existed, so the 13 buttons of the markdown toolbar (bold,
+  list, link, and so on) stayed blank. The edit form now gets its own icon pass right after it is
+  built.
+
 - **An event moved to another CalDAV calendar can be deleted or edited right away** (#593). A move
   creates the event in the new calendar and removes it from the old one, but until the next sync
   Yuvomi kept pointing at the old copy. Deleting the event in that window went to an address that

--- a/public/components/detail-view.js
+++ b/public/components/detail-view.js
@@ -351,6 +351,12 @@ async function switchToForm(panel, opts, state) {
       body.appendChild(pane);
       state.formPane = pane;
       opts.edit.mount(panel, pane);
+      // mount() fuegt sein Markup erst jetzt ein - lange nach dem createIcons-
+      // Lauf, der beim ersten Oeffnen der Leseansicht (renderIcons(panel) oben)
+      // durchlief. Ohne diesen zweiten Lauf bleiben `data-lucide`-Platzhalter im
+      // Formular leer, z. B. die 13 Knoepfe der Markdown-Formatierungsleiste
+      // (#1141).
+      renderIcons(pane);
       // Die Formular-Fußzeile entstand gerade erst im Body und muss ans Panel,
       // sonst scrollt die Primäraktion weg und ein „Speichern" mit
       // type="submit" löst außerhalb seines Formulars kein submit aus (#543).

--- a/test/test-detail-view.js
+++ b/test/test-detail-view.js
@@ -94,6 +94,21 @@ test('der Wechsel ins Formular löst die drei Fallen in fester Reihenfolge', asy
   assert.match(form, /focusFirstField\(/, 'Falle 3: der Fokus muss bewusst gesetzt werden');
 });
 
+test('das nachgeladene Formular bekommt seine Lucide-Icons (#1141)', async () => {
+  const src = await detailJs();
+  const form = src.slice(src.indexOf('function switchToForm'), src.indexOf('function switchToDetail'));
+  // edit.mount() fuegt sein Markup erst beim Wechsel ein - der createIcons-Lauf
+  // beim urspruenglichen Oeffnen der Leseansicht (renderIcons(panel) in
+  // onSave()) kommt dafuer zu frueh und erreicht dieses Formular nie. Ohne
+  // einen zweiten Lauf bleiben `data-lucide`-Platzhalter im Formular leer -
+  // z. B. alle 13 Knoepfe der Markdown-Formatierungsleiste ueber der
+  // Aufgaben-Notiz.
+  const mountIdx = form.indexOf('opts.edit.mount(');
+  const iconsIdx = form.indexOf('renderIcons(pane)');
+  assert.ok(mountIdx > -1 && iconsIdx > -1, 'renderIcons(pane) muss nach dem Mount stehen');
+  assert.ok(iconsIdx > mountIdx, 'die Icons muessen NACH dem Einfuegen des Formular-Markups erzeugt werden');
+});
+
 test('„Abbrechen" wirkt auch in einem nachträglich gebauten Formular (#738)', async () => {
   const src = await modalJs();
   const open = src.slice(src.indexOf('export function openModal'), src.indexOf('export async function closeModal'));


### PR DESCRIPTION
## Summary

Fixes #1141 — the markdown formatting toolbar over a task's note field showed no icons when editing a task from its detail view.

**Root cause:** the task detail view mounts its edit form lazily, only when "Edit" is clicked (`switchToForm()` in `public/components/detail-view.js`). The pass that converts `<i data-lucide="...">` placeholders into real icons runs once, when the read view first opens - before the edit form (and its markdown toolbar, from `public/utils/markdown-toolbar.js`) exists. The 13 toolbar buttons were left as empty tags with nothing rendered.

Other places that build a form don't hit this: a brand-new task opens through `openModal()` with its content already in the initial HTML, so the existing icon pass covers it. Only the lazily-mounted edit pane inside the shared detail view was missing a second pass.

**Fix:** call the existing local `renderIcons()` helper on the form pane right after `opts.edit.mount()` inserts its markup.

## Testing

- `npm run test:detail-view` (53/53) - added a test asserting `renderIcons(pane)` runs after `opts.edit.mount()` in `switchToForm()`.
- `npm run test:markdown-toolbar` (17/17) and `npm run test:frontend-audit` (383/383) as regression checks - unaffected.
- Live-verified against a real running instance: reproduced the empty toolbar with the fix reverted, then confirmed all 12 icons render with the fix applied, editing the same task both times.

## Test plan

- [x] `npm run test:detail-view`
- [x] `npm run test:markdown-toolbar`
- [x] `npm run test:frontend-audit`
- [x] Manual browser verification (task detail → Edit → note toolbar icons render)