### PR TITLE
Split-expenses: one primary action, section heading when embedded, destructive delete styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Split Expenses no longer shows three ways to add an expense at once, or a second page title
+  under Budget's own heading.** Viewed as Budget's Split Expenses tab, the tab used to offer its own
+  header button and its own floating button for adding an expense, on top of Budget's own generic
+  toolbar button and FAB - both of the latter only ever repeated the tab's own button under the
+  hood. Budget's generic add action is now switched off for this tab, the same way it already is for
+  Reports; the tab's own floating button is the one primary action, and its header button steps back
+  to a secondary one. The tab's own `<h1>` - a second page title stacked under Budget's - is now a
+  section heading instead, matching how it already looked in a lighter type size. Deleting a group
+  now gets the same restrained red treatment used for a destructive action elsewhere in the app,
+  instead of looking identical to editing or archiving it.
+
 - **A housekeeper can check out again, and work a second session on the same day** (#1133, #1138).
   The one button that carries both directions was disabled while someone was checked in, and it is
   the only thing that triggers the check-out path - so that path was unreachable: a household could

--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -249,7 +249,16 @@ const TAB_CAPS = {
   'subscriptions':  { month: false, note: 'budget.periodNoteSubscriptions', add: 'subscriptions.add' },
   'loans':          { month: false, note: 'budget.periodNoteLoans',         add: 'budget.newLoan' },
   'reports':        { month: true,  range: true, add: null },
-  'split-expenses': { month: false, note: 'budget.periodNoteSplit',         add: 'splitExpenses.addExpense' },
+  // `add: null` wie Berichte: Split-Ausgaben bringt seine eigene Primaeraktion
+  // mit (Kopfknopf + FAB in split-expenses.js). Vorher stand hier derselbe
+  // Aktionsname wie im eingebetteten Kopf, und der generische Kopfknopf UND
+  // der generische FAB dieser Seite delegierten beide per Klick an
+  // #split-add-expense - macht mit dem eigenen Kopfknopf und dem eigenen FAB
+  // der Unterseite VIER Ausloeser fuer dieselbe Handlung (Cross-Modul-Review:
+  // "drei violette Add-Knoepfe zugleich"). Split-Ausgaben ist das einzige
+  // Sub-Tab mit eigenem Primaerknopf/-FAB; die anderen sechs teilen sich
+  // Budgets generische Knoepfe, weil sie keinen eigenen mitbringen.
+  'split-expenses': { month: false, note: 'budget.periodNoteSplit',         add: null },
 };
 
 // Sentinel für „keine eigene Farbe" im Kontofarb-Wähler: der echte Wert ist der
@@ -567,11 +576,11 @@ function wireNav() {
       renderBody();
     },
   });
-  // Neu-Aktion je Tab — spiegelt TAB_CAPS.add. Tabs ohne Neu-Aktion (Berichte)
+  // Neu-Aktion je Tab — spiegelt TAB_CAPS.add. Tabs ohne Neu-Aktion (Berichte,
+  // Split-Ausgaben - die Unterseite bringt ihren eigenen Kopfknopf/FAB mit)
   // blenden beide Auslöser aus, der Handler bleibt dort folgenlos.
   const addHandler = () => {
     switch (state.activeTab) {
-      case 'split-expenses': _container.querySelector('#split-add-expense')?.click(); return;
       case 'subscriptions':  openSubscriptionModal(); return;
       case 'plan':           _container.querySelector('#budget-plan-add')?.click(); return;
       case 'accounts':       openAccountModal(); return;

--- a/public/pages/split-expenses.js
+++ b/public/pages/split-expenses.js
@@ -81,7 +81,7 @@ function groupIcon(type) {
   }[type] || 'users';
 }
 
-export async function render(container, { user } = {}) {
+export async function render(container, { user, embedded = false } = {}) {
   _container = container;
   state.user = user || null;
   // `split`, nicht `reading`: Kopf und Kennzahlenband stehen ueber einem
@@ -89,14 +89,28 @@ export async function render(container, { user } = {}) {
   // Bauart des Modus. Das Raster selbst traegt die Seite noch in eigenem CSS
   // (Container-Queries statt Viewport-Breite, siehe split-expenses.css);
   // das Shell-Raster wirkt nur auf .app-page__body, den es hier nicht gibt.
+  //
+  // EINGEBETTET (budget.js ruft immer mit embedded:true - es gibt heute keine
+  // eigenstaendige Route) TRAEGT DIE UEBERSCHRIFT KEIN ZWEITES <h1>: der
+  // Modulkopf sagt bereits "Budget" (Cross-Modul-Review). Die Budget-Seiten-
+  // CSS behandelte den Split-Titel dort eingebettet schon laenger als
+  // Bereichs-Ueberschrift (typography.css) - das Element selbst blieb bis
+  // hierher ein <h1> und widersprach damit seiner eigenen Rolle. Aus demselben
+  // Grund traegt der Knopf hier --secondary statt --primary: die Primaeraktion ist der FAB
+  // (#split-fab, siehe unten), nicht zwei violette Knoepfe fuer dieselbe
+  // Handlung. Unveraendert bleibt die (heute nicht erreichte) eigenstaendige
+  // Zukunft: <h1> plus Primaerknopf, falls Split-Ausgaben je eine eigene
+  // Navigationsebene bekommt (DESIGN.md, Q-3).
+  const TitleTag = embedded ? 'h2' : 'h1';
+  const addExpenseBtnVariant = embedded ? 'btn--secondary' : 'btn--primary';
   setHtml(container, `
     <div class="split-page app-page app-page--split" data-composition="split">
       <header class="panel-head split-topbar">
         <div>
-          <h1 class="split-title">${t('splitExpenses.title')}</h1>
+          <${TitleTag} class="split-title">${t('splitExpenses.title')}</${TitleTag}>
           <p class="split-subtitle">${t('splitExpenses.subtitle')}</p>
         </div>
-        <button class="btn btn--primary" id="split-add-expense">
+        <button class="btn ${addExpenseBtnVariant}" id="split-add-expense">
           <i data-lucide="plus" class="icon-md" aria-hidden="true"></i>
           ${t('splitExpenses.addExpense')}
         </button>
@@ -369,7 +383,12 @@ function renderMain() {
         <button class="btn btn--secondary btn--icon" id="split-archive-group" aria-label="${t('splitExpenses.archiveGroup')}">
           <i data-lucide="archive" aria-hidden="true"></i>
         </button>
-        <button class="btn btn--secondary btn--icon" id="split-delete-group" aria-label="${t('splitExpenses.deleteGroup')}">
+        <!-- Loeschen ist unumkehrbar (die Gruppe faellt mitsamt ihrer Ausgaben),
+             Bearbeiten/Archivieren nicht - dieselbe Kapsel fuer alle drei
+             verwischte den Unterschied. --danger-outline hebt sich ab, ohne die
+             Zeile zu dominieren; confirmModal({danger:true}) haengt schon
+             darunter (deleteGroup()). -->
+        <button class="btn btn--icon btn--danger-outline" id="split-delete-group" aria-label="${t('splitExpenses.deleteGroup')}">
           <i data-lucide="trash-2" aria-hidden="true"></i>
         </button>`}
         <button class="btn btn--secondary" id="split-settle">

--- a/test/test-budget-ui.js
+++ b/test/test-budget-ui.js
@@ -1439,3 +1439,62 @@ test('Serien-Speichern reicht ein leeres Konto einer kontolosen Instanz nicht we
   assert.match(zweig, /api\.put\(`\/budget\/\$\{entry\.id\}\/series`, seriesBody\)/,
     'gesendet wird der bereinigte Body, nicht der ursprüngliche');
 });
+
+// --------------------------------------------------------
+// Split-Ausgaben: eine Primäraktion statt vier (Cross-Modul-Review)
+// --------------------------------------------------------
+
+/**
+ * Split-Ausgaben bringt seinen eigenen Kopfknopf UND seinen eigenen FAB mit
+ * (split-expenses.js). Solange TAB_CAPS['split-expenses'].add einen Aktionsnamen
+ * trug, zeigte Budgets EIGENER Toolbar-Knopf (#budget-add) und Budgets EIGENER
+ * FAB (#fab-new-budget) auf diesem Tab ZUSAETZLICH auf, beide per Klick an
+ * #split-add-expense delegiert - macht mit dem Unterseiten-eigenen Kopfknopf
+ * und dessen eigenem FAB vier Ausloeser fuer dieselbe Handlung, gemessen als
+ * "drei violette Add-Knoepfe zugleich" im UX-Review. `add: null` (wie Berichte)
+ * haelt Budgets generische Knoepfe auf diesem Tab unsichtbar.
+ */
+test('Split-Ausgaben bietet keine zweite, generische Neu-Aktion aus dem Budget-Kopf', () => {
+  const table = budget.match(/const TAB_CAPS = \{[\s\S]*?\n\};/);
+  assert.ok(table, 'TAB_CAPS-Tabelle fehlt');
+  assert.match(table[0], /'split-expenses':\s*\{[^}]*add:\s*null/,
+    'Split-Ausgaben bringt seinen eigenen Kopfknopf/FAB mit - Budgets generischer ' +
+    '#budget-add/#fab-new-budget-Knopf darf hier keine zweite Aktion anbieten');
+  // Der Kontext-Schalter darf die Unterseite nicht mehr direkt anklicken -
+  // sonst bliebe der alte Vierfach-Ausloeser ueber einen zweiten Codepfad stehen.
+  assert.doesNotMatch(withoutComments(budget), /case 'split-expenses':/,
+    'addHandler darf für Split-Ausgaben keinen eigenen Zweig mehr brauchen - ' +
+    'der Tab hat keine generische Neu-Aktion mehr');
+});
+
+/**
+ * Eingebettet (der einzige heute erreichte Fall - budget.js ruft immer mit
+ * embedded:true) darf Split-Ausgaben keine zweite Seiten-Ueberschrift unter
+ * Budgets eigenem <h1> führen, und sein Kopfknopf darf nicht als zweiter
+ * Primärknopf neben dem FAB (#split-fab) auftreten.
+ */
+test('eingebettete Split-Ausgaben tragen keine zweite <h1> und keinen zweiten Primärknopf', () => {
+  assert.match(splitExpenses, /const TitleTag = embedded \? 'h2' : 'h1'/,
+    'die Überschrift muss im eingebetteten Fall eine Bereichs-Überschrift sein, kein zweites <h1>');
+  assert.match(splitExpenses, /const addExpenseBtnVariant = embedded \? 'btn--secondary' : 'btn--primary'/,
+    'der Kopfknopf muss im eingebetteten Fall zurücktreten - die Primäraktion ist der FAB');
+  assert.match(splitExpenses, /<\$\{TitleTag\} class="split-title">/,
+    'die Überschrift muss über TitleTag gerendert werden, nicht fest als <h1>');
+  assert.match(splitExpenses, /<button class="btn \$\{addExpenseBtnVariant\}" id="split-add-expense">/,
+    'der Kopfknopf muss über addExpenseBtnVariant gerendert werden, nicht fest als --primary');
+});
+
+/**
+ * Löschen einer Gruppe ist unumkehrbar (die Gruppe fällt mitsamt ihrer
+ * Ausgaben), Bearbeiten/Archivieren nicht - dieselbe Kapsel für alle drei
+ * verwischte den Unterschied (UX-Review).
+ */
+test('Gruppe löschen trägt eine andere Gewichtung als bearbeiten/archivieren', () => {
+  assert.match(splitExpenses, /id="split-edit-group"[^>]*>/);
+  assert.match(splitExpenses, /class="btn btn--secondary btn--icon" id="split-edit-group"/,
+    'Bearbeiten bleibt eine gewöhnliche Sekundäraktion');
+  assert.match(splitExpenses, /class="btn btn--secondary btn--icon" id="split-archive-group"/,
+    'Archivieren bleibt eine gewöhnliche Sekundäraktion');
+  assert.match(splitExpenses, /class="btn btn--icon btn--danger-outline" id="split-delete-group"/,
+    'Löschen muss sich sichtbar von Bearbeiten/Archivieren abheben, ohne die Zeile zu dominieren');
+});


### PR DESCRIPTION
From an app-wide UI/UX review; against current `main`, no migrations, no new strings.

The "Today"/"Current" period-navigation half of the original PR has been removed as requested in review, with the original placement — and the comment recording that decision — restored verbatim. The position question now lives in #1164, with the honest answer to the review's question (it is chiefly about the inconsistency between the three modules, not a bad-reading arrangement).

### What changed

- **Split-expenses: four triggers for one action, reduced to one primary.** `TAB_CAPS['split-expenses'].add` carried an action, so Budget's generic toolbar button *and* Budget's FAB both stayed enabled for the tab and delegated (`.click()`) into Split-expenses' own header button — on top of that page's own FAB. Budget's generic add is now off for this tab (same as Reports), the embedded header button is demoted to secondary, and the tab's FAB is the single primary.
- **No second page title.** Split-expenses re-rendered its own `<h1>` under Budget's page title; embedded rendering now emits it as an `<h2>` section heading (the `embedded` parameter was already passed, just never consumed).
- **Deleting a group looks destructive.** `#split-delete-group` was styled identically to edit/archive; now `btn--danger-outline`, matching the existing app-wide precedent.

### Findings re-verified as already fixed on main (no change)

Four items from the same review batch did not reproduce against current `main` and were left alone: the Meals week-board clipping (a `wireScrollFade` scroller already exists), the dashboard FAB overlapping the Rewards widget (`--fab-safe-zone`/`--shell-tail` already reserves clearance — re-confirmed in a live browser at true scroll-bottom), the Documents filter-chip clipping (both scrollers already wired), and Budget's `+ Entry` placement (already in the toolbar actions slot).

### Verification

Rebased onto current `main` (v2.65.3). `test:budget-ui` 71/71 (3 new regression tests), `test:split-expenses`, `test:budget-structure` 5/5, `test:meals` 48/48, `test:calendar` 25/25, `test:frontend-audit` 385/385, `test:changelog` 28/28 — all green. `public/pages/meals.js` and the period-nav section of `public/pages/budget.js` are byte-identical to `main`.
