### PR TITLE
UI polish: consistent dashboard widget headers, shared section-title adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Dashboard widgets share one header grammar, and more section headings adopt the shared title
+  style.** Three widget header treatments coexisted on the dashboard: most widgets carried a
+  module seal, a title and an optional "view all" link, but Weather and Clock opened straight into
+  their content with no header at all. Both now open with the same seal+title header as their 15
+  neighbours - the large temperature and the clock face stay exactly as prominent as before, they
+  just get a name above them like everywhere else. The metrics tile row is deliberately left alone:
+  each tile already names a different module with its own seal and label, and forcing one title
+  over several modules would misrepresent it, not fix it.
+
+  Separately, Rewards' four section headings and a genuinely unstyled Inventory category heading
+  now use the shared `u-section-title` role instead of a private declaration that had drifted a
+  few pixels off it (Inventory's had no declared size at all - it inherited the browser default,
+  not any design token). Notes' and Budget's section headings, already the right size through their
+  own container rule, now say so directly in markup as well, growing `u-section-title`'s adoption
+  beyond the two files it was previously confined to.
+
+  `.input` and `.form-input` stay aliased to the same rule - renaming roughly 300 existing uses
+  is not worth the review cost - but the alias site and DESIGN.md's Inputs/Fields section now say
+  which one is canonical for new code: `.form-input`, the name `.form-group`/`.form-field`/
+  `.form-label` already use.
+
 - **A scaled ingredient quantity is now written in the household's own digits.** Scaling a recipe
   wrote the number in Latin digits even where the rest of the line used Persian or Arabic ones, so a
   doubled "۲ x ۵۰۰ g" came back as "4 x ۵۰۰ g" - one line in two scripts. That was deliberate at the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1537,6 +1537,10 @@ nur das gerenderte Dokument sieht, ob eine Liste ueberhaupt verdrahtet ist.
   app-weiter Kanon, kein Modul-Detail.
 - **Focus:** Akzentkante plus 3px Glow in `--color-accent-light`; interaktive Nicht-Felder
   tragen den app-weiten 2px-Ring.
+- **Klassenname:** `.input` und `.form-input` sind ein Alias auf dieselbe Regel (layout.css).
+  Kanonisch fuer neuen Code ist `.form-input` - der Name, den `.form-group`/`.form-field`/
+  `.form-label` schon fuehren. Bestand bleibt unangetastet, Umbenennen aller Fundstellen ist
+  keine Migration wert.
 
 ### Navigation
 - **Mobil:** schwebende Glas-Kapsel (`--glass-bg-elevated` + `--blur-md` + saturate,

--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -812,7 +812,7 @@ function renderBody() {
     <!-- Kategorie-Balken -->
     ${s.byCategory.length ? `
     <div class="budget-chart-section">
-      <div class="budget-chart-section__title">${t('budget.byCategory')}</div>
+      <div class="budget-chart-section__title u-section-title">${t('budget.byCategory')}</div>
       <p class="sr-only">${esc(chartSummary(s.byCategory))}</p>
       <div class="budget-chart">
         ${renderCategoryBars(s.byCategory)}
@@ -823,7 +823,7 @@ function renderBody() {
     <div class="budget-list-section">
       <div class="budget-list-header">
         <div>
-          <span class="budget-list-header__title">${t('budget.transactions')}</span>
+          <span class="budget-list-header__title u-section-title">${t('budget.transactions')}</span>
           ${state.accountFilterId ? `
           <button class="budget-account-chip" id="budget-clear-account-filter" type="button"
                   aria-label="${t('budget.clearAccountFilter')}">

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -3296,7 +3296,7 @@ function renderWeatherWidget(weather) {
 
   return `
     <div class="widget widget--weather weather-widget" id="weather-widget"${weatherToneAttr(current.icon)}${weatherMotionAttr(current.icon)}>
-      <h3 class="sr-only">${esc(t('dashboard.weather'))}</h3>
+      ${widgetHeader('weather', t('dashboard.weather'), null, null, null, 'dashboard')}
       <button class="weather-widget__refresh" id="weather-refresh-btn" aria-label="${t('dashboard.weatherRefresh')}" title="${t('dashboard.weatherRefreshTitle')}">
         <i data-lucide="refresh-cw" class="icon-md" aria-hidden="true"></i>
       </button>
@@ -3353,10 +3353,21 @@ function clockWidgetParts(now = new Date()) {
 function renderClockWidget({ wall = false } = {}) {
   const { time, date, machineTime } = clockWidgetParts();
   const cls = wall ? 'clock-widget clock-widget--wall' : 'widget widget--clock clock-widget';
+  const body = `
+    <time class="clock-widget__time" id="clock-widget-time" datetime="${esc(machineTime)}">${esc(time)}</time>
+    <p class="clock-widget__date" id="clock-widget-date">${esc(date)}</p>`;
+  // Kachel-Form bekommt seit dem Polish-Batch (PLAN.md #7) denselben
+  // Siegel+Titel-Kopf wie ihre 15 Geschwister-Widgets - vorher eines von zwei
+  // Widgets ganz ohne Kopf (das andere war das Wetter). Die Wand-Form bleibt
+  // unveraendert kopflos: dort ist die Uhr der Anker der Flaeche, keine
+  // Kachel unter anderen, und ihre Kinder bleiben deshalb ungewrappt.
+  if (wall) {
+    return `<div class="${cls}" id="clock-widget">${body}</div>`;
+  }
   return `
     <div class="${cls}" id="clock-widget">
-      <time class="clock-widget__time" id="clock-widget-time" datetime="${esc(machineTime)}">${esc(time)}</time>
-      <p class="clock-widget__date" id="clock-widget-date">${esc(date)}</p>
+      ${widgetHeader('clock', t('dashboard.clock'), null, null, null, 'dashboard')}
+      <div class="widget__body clock-widget__body">${body}</div>
     </div>`;
 }
 

--- a/public/pages/inventory.js
+++ b/public/pages/inventory.js
@@ -612,7 +612,7 @@ function renderCategoryDetail(list) {
       <i data-lucide="arrow-left" class="inventory-back-link__icon" aria-hidden="true"></i>
       ${esc(t('inventory.backToInventory'))}
     </button>
-    <h2 class="inventory-category-title">${esc(category ? categoryLabel(category) : state.activeCategory)}</h2>`);
+    <h2 class="inventory-category-title u-section-title">${esc(category ? categoryLabel(category) : state.activeCategory)}</h2>`);
   list.querySelector('#inventory-back-link').addEventListener('click', backToBrowse);
 
   const filtered = categoryItems.filter((item) => matchesQuery(item) && matchesAttentionFilter(item));

--- a/public/pages/notes.js
+++ b/public/pages/notes.js
@@ -321,7 +321,7 @@ function renderGrid() {
   // nur, wenn es tatsächlich beide Gruppen gibt.
   const pinned = visible.filter((n) => n.pinned);
   const rest   = visible.filter((n) => !n.pinned);
-  const heading = (label) => `<h2 class="notes-group__title">${label}</h2>`;
+  const heading = (label) => `<h2 class="notes-group__title u-section-title">${label}</h2>`;
 
   const html = (pinned.length && rest.length)
     ? heading(t('notes.groupPinned')) + pinned.map(renderNoteCard).join('')

--- a/public/pages/rewards.js
+++ b/public/pages/rewards.js
@@ -348,7 +348,7 @@ function renderSetupHints() {
     </li>`).join('');
   return `
     <section class="rw-section rw-setup" aria-labelledby="rw-setup-title">
-      <h2 class="rw-section__title" id="rw-setup-title"><i data-lucide="sparkles" aria-hidden="true"></i>${esc(t('rewards.setupTitle'))}</h2>
+      <h2 class="rw-section__title u-section-title" id="rw-setup-title"><i data-lucide="sparkles" aria-hidden="true"></i>${esc(t('rewards.setupTitle'))}</h2>
       <ol class="rw-setup-list">${items}</ol>
     </section>`;
 }
@@ -380,7 +380,7 @@ function renderPendingPanel() {
    * dasselbe Vokabular, das die Zeilengruppen schon fuehren. */
   return `
     <section class="rw-section">
-      <h2 class="rw-section__title"><i data-lucide="hourglass" aria-hidden="true"></i>${esc(heading)}<span class="list-group__count">${state.redemptions.length}</span></h2>
+      <h2 class="rw-section__title u-section-title"><i data-lucide="hourglass" aria-hidden="true"></i>${esc(heading)}<span class="list-group__count">${state.redemptions.length}</span></h2>
       <ul class="rw-pending-list rw-pending-panel">${rows}</ul>
     </section>`;
 }
@@ -406,7 +406,7 @@ function renderOverview(el) {
       ${renderPendingPanel()}
       <section class="rw-section">
         <div class="rw-section__head">
-          <h2 class="rw-section__title">${esc(t('rewards.standings'))}</h2>
+          <h2 class="rw-section__title u-section-title">${esc(t('rewards.standings'))}</h2>
           ${adminBar}
         </div>
         <ul class="row-carrier rw-standings">${list.map(renderStandingRow).join('')}</ul>
@@ -482,7 +482,7 @@ function renderCatalog(el) {
   const items = state.catalog || [];
   const header = isAdmin() ? `
     <div class="rw-section__head">
-      <h2 class="rw-section__title"><i data-lucide="gift" aria-hidden="true"></i>${esc(t('rewards.tabCatalog'))}</h2>
+      <h2 class="rw-section__title u-section-title"><i data-lucide="gift" aria-hidden="true"></i>${esc(t('rewards.tabCatalog'))}</h2>
     </div>` : '';
   if (!items.length) {
     const action = isAdmin()

--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -1484,6 +1484,35 @@ svg.weather-forecast__icon {
   text-align: center;
 }
 
+/* Die Kachel-Form (.widget--clock, NIE die Wand-Form - die traegt keine
+ * .widget-Klasse) bekam mit dem Polish-Batch einen Kopf (PLAN.md #7) und
+ * braucht deshalb zwei Abweichungen von der Basisregel oben: der Kopf pinnt
+ * an die Oberkante statt mit der Uhr als Gruppe zu zentrieren, und das
+ * Aussenpolster wandert vom Wrapper zu Kopf/Body, damit keiner die
+ * Standard-Kopfmasse (.widget__header) duppelt. Die Wand-Form bleibt exakt
+ * die Basisregel, ungewrappt. */
+.widget--clock.clock-widget {
+  padding: 0;
+  justify-content: flex-start;
+}
+
+.widget--clock.clock-widget > .widget__header {
+  align-self: stretch;
+  text-align: left;
+}
+
+.clock-widget__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  text-align: center;
+  min-height: 0;
+  padding: var(--space-2) var(--space-4) var(--space-4);
+}
+
 .widget-size--1x2 > .clock-widget,
 .widget-size--2x2 > .clock-widget,
 .widget-size--1x3 > .clock-widget,

--- a/public/styles/inventory.css
+++ b/public/styles/inventory.css
@@ -114,9 +114,11 @@
   flex: 0 0 auto;
 }
 
-/* Groesse/Rolle kommt vom semantischen <h2> selbst (feste Rollenwerte,
- * DESIGN.md Typografie) - hier nur Abstand/Farbe, gleiches Muster wie
- * .settings-leaf-header__title. */
+/* Der Kommentar hier behauptete "Groesse/Rolle kommt vom semantischen <h2>
+ * selbst" - falsch: reset.css setzt fuer h1-h6 nur font-weight/line-height
+ * zurueck, nie font-size, also rendierte dieser Kopf am UA-Default (~24px),
+ * keiner Design-Stufe (Polish-Audit, PLAN.md #7). Traegt jetzt u-section-title
+ * im Markup, hier bleibt nur Abstand/Farbe. */
 .inventory-category-title {
   margin: 0 0 var(--space-3);
   color: var(--color-text-primary);

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -5072,6 +5072,14 @@ p.field-hint--warn[hidden] {
 
 /* --------------------------------------------------------
  * Form-Elemente
+ *
+ * `.input` und `.form-input` sind derselbe Alias auf dieselbe Regel (~308 vs.
+ * ~155 Fundstellen, Polish-Audit PLAN.md #7) - ohne dass bisher irgendwo
+ * stand, welcher Name fuer NEUEN Code gilt. Kanonisch ist `.form-input`: es
+ * ist der Name, den DESIGN.md ("Inputs / Fields") und `.form-group`/
+ * `.form-field`/`.form-label` schon fuehren. Bestehende `.input`-Stellen
+ * bleiben unangetastet (Umbenennen aller ~308 Fundstellen kostet mehr Review
+ * als es traegt) - neuer Code schreibt `.form-input`.
  * -------------------------------------------------------- */
 .input,
 .form-input {

--- a/public/styles/notes.css
+++ b/public/styles/notes.css
@@ -108,12 +108,12 @@
 }
 
 /* Abschnittsköpfe („Angepinnt" / „Weitere Notizen") spannen über alle Spalten,
- * wie der Leerzustand. */
+ * wie der Leerzustand. Groesse/Gewicht kamen hier als eigene Kopie derselben
+ * Section-Title-Rolle, die u-section-title zentral fuehrt (Polish-Batch,
+ * PLAN.md #7) - jetzt im Markup, hier bleibt nur Layout/Farbe. */
 .notes-group__title {
   grid-column: 1 / -1;
   margin: 0;
-  font-size: var(--type-section-title);
-  font-weight: var(--font-weight-semibold);
   color: var(--color-text-secondary);
 }
 

--- a/public/styles/rewards.css
+++ b/public/styles/rewards.css
@@ -49,13 +49,16 @@
   flex-wrap: wrap;
 }
 
+/* Groesse/Gewicht kommen seit dem Polish-Batch (PLAN.md #7) aus der
+ * geteilten .u-section-title-Rolle (typography.css) statt aus einer eigenen
+ * 18px-Deklaration hier - vier Sektionskoepfe (Setup, Anfragen, Punktestand,
+ * Katalog), die schon vorher eine Bereichs-Ueberschrift waren, nur 2px unter
+ * der kanonischen Section-Title-Stufe. */
 .rw-section__title {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
   margin: 0;
-  font-size: var(--text-lg);
-  font-weight: 600;
   color: var(--color-text-primary);
 }
 .rw-section__title i { width: 18px; height: 18px; color: var(--module-accent); }


### PR DESCRIPTION
From an app-wide UI/UX review; against current `main`, no migrations, no new strings (existing `dashboard.weather`/`dashboard.clock` keys reused).

### What changed

- **Weather and Clock widgets get the standard header.** 15 of the dashboard's widgets open with the shared seal+title `widgetHeader()`; Weather had only an `sr-only` h3 and Clock no title element at all. Both now use the same header as their neighbours, with the large temperature/time reading unchanged. The wall-mounted clock surface stays headerless by design (there the clock is the surface's anchor, not a tile). The metrics tile row was deliberately left alone — each tile names a different module with its own seal, and `.metric-card__label` is a sanctioned micro-label, so one overarching widget title would misrepresent a multi-module row.
- **`u-section-title` adoption** grows from 2 files to include `rewards.js` (4 headings, were 18px against the 20px role), `inventory.js` (the category-drilldown heading had *no* declared size at all — it rendered at the UA default, and the CSS comment claiming otherwise was wrong), plus `notes.js` and `budget.js` (already correctly sized via container-scoped selectors; the markup now says so). Pure class swaps, no restructuring.
- **`.form-input` documented as canonical** for new form fields, with a short comment at the `.input`/`.form-input` alias site in `layout.css` and a line in `DESIGN.md`'s form conventions. No mass rename — 308 `.input` uses are left untouched deliberately; the churn wouldn't survive review cost.

### Verification

`test:typography` 17/17, `test:frontend-audit` 383/383, `test-dashboard.js` 102/102, `test:dashboard-permissions`, `test:budget-ui`, `test:changelog` — all green. Browser-verified on the dashboard and Rewards page at 1440, light theme.

Note: touches `budget.js` in a different region than the sibling UX PR from the same review; only `CHANGELOG.md` overlaps between them.