### PR TITLE
fix(calendar): let a later target choice withdraw a queued move (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attempt. An edit made while the event is being moved goes to its new calendar in the same run
   instead of waiting for the next sync.
 
+- **Choosing the calendar an event already sits in withdraws a move that has not gone out yet**
+  (#593). A move to another calendar is queued and carried out by the sync, and that attempt can
+  fail - the server may be unreachable right then. Choosing the original calendar again in that
+  window looked like no change at all, so the queued move stayed: the next sync moved the event into
+  a calendar nobody had chosen any more, while the dialog showed the one that was. A target pointing
+  back at the calendar the event sits in now withdraws the queued move, and a target pointing at a
+  third calendar replaces it. Only the choice made in that edit counts: an edit that leaves the
+  target alone keeps a queued move, and a target stored on an older event that differs from its
+  actual calendar is still never read as a wish to move. Google and CalDAV alike.
+
 - **A review run that stopped at its gate is named as such, even when it first denied having
   reviewed** (#1101). The check behind the automated review reads the run's closing text to say
   why a silent run went red. It only looked at the first mention of "already reviewed", so a text

--- a/server/services/calendar-outbound.js
+++ b/server/services/calendar-outbound.js
@@ -184,19 +184,27 @@ export function handleDeletionError(err, row, provider) {
 
 /**
  * Markiert ein Event für den Push und/oder den Umzug.
+ *
+ * Ein Umzug überlebt bewusst jede Vormerkung, die keinen kennt: COALESCE lässt die
+ * bestehende Absicht stehen, damit eine Feldänderung einen wartenden Umzug nicht
+ * verschluckt. Zurücknehmen lässt er sich deshalb nur ausdrücklich über
+ * `cancelMove` - ein `moveTo: null` kommt gegen das COALESCE nicht an.
+ *
  * @param {number} eventId
- * @param {{dirty?: boolean, moveTo?: string|null}} what
+ * @param {{dirty?: boolean, moveTo?: string|null, cancelMove?: boolean}} what
+ * @returns {boolean} true, wenn dieser Aufruf Arbeit vorgemerkt hat; ein reines
+ *   Zurücknehmen gibt false zurück - danach ist nichts auszuführen.
  */
-export function markOutbound(eventId, { dirty = false, moveTo = null } = {}) {
-  if (!dirty && !moveTo) return false;
+export function markOutbound(eventId, { dirty = false, moveTo = null, cancelMove = false } = {}) {
+  if (!dirty && !moveTo && !cancelMove) return false;
   db.get().prepare(`
     UPDATE calendar_events
     SET outbound_dirty    = CASE WHEN ? THEN 1 ELSE outbound_dirty END,
-        outbound_move_to  = COALESCE(?, outbound_move_to),
+        outbound_move_to  = CASE WHEN ? THEN NULL ELSE COALESCE(?, outbound_move_to) END,
         outbound_attempts = 0
     WHERE id = ?
-  `).run(dirty ? 1 : 0, moveTo, eventId);
-  return true;
+  `).run(dirty ? 1 : 0, cancelMove ? 1 : 0, moveTo, eventId);
+  return !!(dirty || moveTo);
 }
 
 export function pendingUpdates(source) {
@@ -408,7 +416,8 @@ export function queueEventDeletion(event, database = null) {
  * Der Umzug hängt bewusst an der *Änderung im Request*, nicht am Zustand:
  * Bestandsdaten können ein Ziel tragen, das vom tatsächlichen Kalender abweicht
  * (die target_*-Felder waren für gespiegelte Termine folgenlos setzbar), und das
- * darf nicht nachträglich als Umzugswunsch gelesen werden.
+ * darf nicht nachträglich als Umzugswunsch gelesen werden. Aus demselben Grund
+ * nimmt nur eine Zielwahl im Request einen vorgemerkten Umzug zurück.
  * @returns {boolean} true, wenn etwas aussteht
  */
 export function markEventOutbound(before, after) {
@@ -420,17 +429,24 @@ export function markEventOutbound(before, after) {
 
   const targetField = targetFieldFor(after.external_source);
 
-  let moveTo = null;
+  let moveTo     = null;
+  let cancelMove = false;
   if (targetField) {
-    const target  = after[targetField] || null;
-    const current = currentCalendarId(after);
-    if (target && target !== before?.[targetField] && current && target !== current) {
-      moveTo = target;
+    const target   = after[targetField] || null;
+    const previous = before?.[targetField] || null;
+    const current  = currentCalendarId(after);
+    if (target && target !== previous && current) {
+      // Zurück auf den Kalender, in dem der Termin liegt: ein noch nicht
+      // ausgeführter Umzug ist damit widerrufen und muss fallen. Ohne das bliebe
+      // er stehen (COALESCE) und der nächste Sync schöbe den Termin in einen
+      // Kalender, den niemand mehr gewählt hat.
+      if (target === current) cancelMove = true;
+      else moveTo = target;
     }
   }
 
-  if (!dirty && !moveTo) return false;
-  return markOutbound(after.id, { dirty, moveTo });
+  if (!dirty && !moveTo && !cancelMove) return false;
+  return markOutbound(after.id, { dirty, moveTo, cancelMove });
 }
 
 /**

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1179,6 +1179,59 @@ test('wird der Termin während des Umzugs gelöscht, wird auch die Kopie im Ziel
     'der nächste Lauf räumt die Kopie im Ziel ab');
 });
 
+// ── Ein widerrufener Umzug ──────────────────────────────────────────────────────
+//
+// Zwischen Vormerkung und Ausführung liegt mindestens ein Sync-Lauf, und der kann
+// scheitern (Server offline, Ziel gerade weg). In diesem Fenster darf der Nutzer
+// seine Wahl zurücknehmen: markOutbound schreibt das Ziel über COALESCE, damit eine
+// Feldänderung einen wartenden Umzug nicht verschluckt - ohne ausdrückliches
+// Zurücknehmen kam deshalb keine spätere Wahl mehr gegen die alte Vormerkung an.
+
+test('nach einem gescheiterten Umzug nimmt die Rückkehr zum aktuellen Kalender ihn zurück', async () => {
+  reset();
+  const event = seedMoved('mv18@t');
+  const calendars = new Map([[CAL2_URL, { url: CAL2_URL, displayName: 'Arbeit' }]]);
+  await processPendingUpdates(
+    fakeClient({ onCreate: () => { throw httpError(507); } }), 'caldav', indexFor('mv18@t'), calendars,
+  );
+  assert.equal(reload(event.id).outbound_move_to, CAL2_URL, 'Vorbedingung: der Umzug steht weiter an');
+
+  const before = reload(event.id);
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL_URL, event.id);
+  assert.equal(outbound.markEventOutbound(before, reload(event.id)), false, 'es bleibt nichts auszuführen');
+  assert.equal(reload(event.id).outbound_move_to, null);
+
+  const client = fakeClient();
+  assert.equal(await processPendingUpdates(client, 'caldav', indexFor('mv18@t'), calendars), 0);
+  assert.equal(client.creates.length, 0, 'der Termin bleibt in dem Kalender, der gewählt ist');
+});
+
+test('ein drittes Ziel ersetzt den wartenden Umzug', () => {
+  reset();
+  const CAL3_URL = 'https://dav.example/cal/school/';
+  const event  = seedMoved('mv19@t');
+  const before = reload(event.id);
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL3_URL, event.id);
+
+  assert.equal(outbound.markEventOutbound(before, reload(event.id)), true);
+  assert.equal(reload(event.id).outbound_move_to, CAL3_URL, 'der letzte Wunsch gilt');
+});
+
+test('eine Feldänderung ohne Zielwahl lässt den wartenden Umzug stehen', () => {
+  // Die Gegenprobe zum Zurücknehmen: nur eine Zielwahl IM REQUEST darf einen Umzug
+  // beenden. Der Zustand allein sagt nichts - sonst verlöre jede andere Bearbeitung
+  // den wartenden Umzug.
+  reset();
+  const event  = seedMoved('mv20@t');
+  const before = reload(event.id);
+  db.prepare("UPDATE calendar_events SET title = 'Anders' WHERE id = ?").run(event.id);
+
+  assert.equal(outbound.markEventOutbound(before, reload(event.id)), true);
+  const row = reload(event.id);
+  assert.equal(row.outbound_move_to, CAL2_URL);
+  assert.equal(row.outbound_dirty, 1);
+});
+
 // ── Was während des Provider-Aufrufs eintrifft ──────────────────────────────────
 //
 // Der Patch wird vor den awaits aus der Zeile gebaut. Eine Bearbeitung, die in

--- a/test/test-google-outbound.js
+++ b/test/test-google-outbound.js
@@ -676,6 +676,58 @@ test('ein Zielwechsel auf den Kalender, in dem der Termin liegt, ist kein Umzug'
   assert.equal(reload(before.id).outbound_move_to, null);
 });
 
+// ── Ein widerrufener Umzug ──────────────────────────────────────────────────────
+//
+// Zwischen Vormerkung und Ausführung liegt mindestens ein Sync-Lauf, und der kann
+// scheitern (Google nicht erreichbar, Ziel gerade entzogen). In diesem Fenster darf
+// der Nutzer seine Wahl zurücknehmen: markOutbound schreibt das Ziel über COALESCE,
+// damit eine Feldänderung einen wartenden Umzug nicht verschluckt - ohne
+// ausdrückliches Zurücknehmen kam deshalb keine spätere Wahl mehr dagegen an.
+
+test('nach einem gescheiterten Umzug nimmt die Rückkehr zum aktuellen Kalender ihn zurück', async () => {
+  reset();
+  const { before } = seedMove();
+  const calendars = writableCalendars(['primary', 'fam@g']);
+  await __test.processPendingUpdates(
+    fakeCalendar({ calendars, onMove: () => { throw apiError(503); } }), {},
+  );
+  assert.equal(reload(before.id).outbound_move_to, 'fam@g', 'Vorbedingung: der Umzug steht weiter an');
+
+  const current = reload(before.id);
+  db.prepare("UPDATE calendar_events SET target_google_calendar_id = 'primary' WHERE id = ?").run(before.id);
+  assert.equal(__test.markEventOutbound(current, reload(before.id)), false, 'es bleibt nichts auszuführen');
+  assert.equal(reload(before.id).outbound_move_to, null);
+
+  const calendar = fakeCalendar({ calendars });
+  assert.equal(await __test.processPendingUpdates(calendar, {}), 0);
+  assert.equal(calendar.moves.length, 0, 'der Termin bleibt in dem Kalender, der gewählt ist');
+});
+
+test('ein drittes Ziel ersetzt den wartenden Umzug', () => {
+  reset();
+  const { before } = seedMove();
+  const current = reload(before.id);
+  db.prepare("UPDATE calendar_events SET target_google_calendar_id = 'work@g' WHERE id = ?").run(before.id);
+
+  assert.equal(__test.markEventOutbound(current, reload(before.id)), true);
+  assert.equal(reload(before.id).outbound_move_to, 'work@g', 'der letzte Wunsch gilt');
+});
+
+test('eine Feldänderung ohne Zielwechsel lässt den wartenden Umzug stehen', () => {
+  // Die Gegenprobe zum Zurücknehmen: nur ein Zielwechsel IM REQUEST darf einen
+  // Umzug beenden. Der Zustand allein sagt nichts - sonst verlöre jede andere
+  // Bearbeitung den wartenden Umzug.
+  reset();
+  const { before } = seedMove();
+  const current = reload(before.id);
+  db.prepare("UPDATE calendar_events SET title = 'Anders' WHERE id = ?").run(before.id);
+
+  assert.equal(__test.markEventOutbound(current, reload(before.id)), true);
+  const row = reload(before.id);
+  assert.equal(row.outbound_move_to, 'fam@g');
+  assert.equal(row.outbound_dirty, 1);
+});
+
 // ── Inbound-Schutz ──────────────────────────────────────────────────────────────
 
 function inboundItem(id, summary = 'Termin aus Google') {
@@ -1084,6 +1136,25 @@ test('PUT /:id merkt einen gewechselten Zielkalender als Umzug vor', async () =>
   const row = reload(event.id);
   assert.equal(row.outbound_move_to, 'fam@g');
   assert.equal(row.target_google_calendar_id, 'fam@g');
+});
+
+test('PUT /:id nimmt einen wartenden Umzug zurück, wenn wieder der eigene Kalender kommt', async () => {
+  // Der ganze Weg über die Route: nur wenn sie das gewählte Ziel mitschreibt und
+  // den Stand davor übergibt, kann die Rücknahme überhaupt erkannt werden.
+  reset();
+  const calRefId = __test.upsertExternalCalendar('google', 'primary', 'Primär', '#4285F4');
+  const event = insertGoogleEvent({ calRefId, googleId: 'gev-put-undo', target: 'primary' });
+
+  await callRoute('PUT', `/${event.id}`, { target_google_calendar_id: 'fam@g' });
+  assert.equal(reload(event.id).outbound_move_to, 'fam@g', 'Vorbedingung: der Umzug ist vorgemerkt');
+
+  const res = await callRoute('PUT', `/${event.id}`, { target_google_calendar_id: 'primary' });
+  assert.equal(res.status, 200);
+
+  const row = reload(event.id);
+  assert.equal(row.outbound_move_to, null);
+  assert.equal(row.target_google_calendar_id, 'primary');
+  assert.equal(__test.pendingUpdateCount(), 0, 'der Sync findet keine Arbeit mehr');
 });
 
 test('PUT /:id markiert einen rein lokalen Termin nicht', async () => {


### PR DESCRIPTION
## Was

Eine vorgemerkte Verschiebung in einen anderen Kalender liess sich nicht mehr zurücknehmen.

`markOutbound()` schreibt das Umzugsziel über `COALESCE(?, outbound_move_to)`, damit eine
Feldänderung eine wartende Verschiebung nicht verschluckt. `markEventOutbound()` leitete eine
Verschiebung aber nur ab, wenn das gewählte Ziel vom aktuellen Kalender abweicht - die Wahl des
Kalenders, in dem der Termin liegt, schrieb deshalb gar nichts (`if (!dirty && !moveTo) return false`).

Folge: ist ein Umzug A → B vorgemerkt und der Flush gescheitert (Server offline), und der Nutzer
wählt danach wieder A, bleibt `outbound_move_to = B` stehen. Der nächste Sync führt ihn aus - der
Termin landet in B, während im Dialog A steht. Betraf Google (`target_google_calendar_id`) und
CalDAV (`target_caldav_calendar_url`).

## Wie

- `markOutbound()` kennt `cancelMove`: `outbound_move_to = CASE WHEN ? THEN NULL ELSE COALESCE(?, outbound_move_to) END`.
  Ein `moveTo: null` allein kommt gegen das COALESCE nicht an, und das soll es auch nicht.
- `markEventOutbound()` nimmt den vorgemerkten Umzug zurück, wenn die Zielwahl **im Request** auf den
  Kalender zeigt, in dem der Termin liegt; zeigt sie auf einen dritten Kalender, ersetzt sie ihn.
- Unverändert bleibt, dass **nur die Zielwahl im Request** etwas bedeutet: eine Bearbeitung, die das
  Ziel nicht anfasst, lässt den wartenden Umzug stehen, und ein Ziel, das in Bestandsdaten vom
  tatsächlichen Kalender abweicht, wird weiter nicht als Umzugswunsch gelesen (Migration 105).

Der In-Flight-Fall (Zielwechsel *während* eines laufenden Provider-Aufrufs) liegt weiter in
`settleOutbound()` und ist unberührt: dessen Neuberechnung greift auch dann, wenn die Route den
Umzug in diesem Fenster schon zurückgenommen hat.

## Tests

Netz-frei, je Regel mit Gegenprobe (Rückdrehen über `cp`-Backup, gemessen, nicht behauptet):

- `test:caldav-outbound` (88 → 91 Top-Level-Tests, 91 Laeufe gruen) und `test:google-outbound`
  (74 → 78, 85 Laeufe gruen): Rücknahme nach
  gescheitertem Umzug inkl. Nachweis, dass der folgende Lauf nichts mehr verschiebt; drittes Ziel
  ersetzt den wartenden Umzug; Feldänderung ohne Zielwahl lässt ihn stehen. Dazu ein Routen-Test
  (`PUT /:id`), damit der Weg vom Request bis zur Rücknahme belegt ist und nicht nur die Funktion.
- Gegenproben: ganze Ursache zurückgedreht → die Rücknahme-Tests beider Provider rot; nur der Zweig
  in `markEventOutbound` zurück → rot; `COALESCE` entfernt → der "Umzug bleibt stehen"-Test rot;
  Vormerk-Zweig tot gestellt → 21 (CalDAV) bzw. 19 (Google) Tests rot.
- Suiten aller Aufrufer der geteilten Funktion grün (`caldav-todo-outbound`, `calendar-routes`,
  `calendar-outbound-migration`, `countdown`, `housekeeping`, `calendar-mirrored-cleanup`,
  `recipe-provider-migration`), dazu `npm test` vollständig grün.

Refs #593

