### PR TITLE
fix(calendar): withdraw a move even while outbound writes are off (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   back at the calendar the event sits in now withdraws the queued move, and a target pointing at a
   third calendar replaces it. Only the choice made in that edit counts: an edit that leaves the
   target alone keeps a queued move, and a target stored on an older event that differs from its
-  actual calendar is still never read as a wish to move. Google and CalDAV alike.
+  actual calendar is still never read as a wish to move. Withdrawing also works while the sync is
+  set to read-only or its account is gone - it changes nothing at the provider, and a move the user
+  took back must not come back to life once writing is allowed again. Google and CalDAV alike.
 
 - **A review run that stopped at its gate is named as such, even when it first denied having
   reviewed** (#1101). The check behind the automated review reads the run's closing text to say

--- a/server/services/calendar-outbound.js
+++ b/server/services/calendar-outbound.js
@@ -192,19 +192,22 @@ export function handleDeletionError(err, row, provider) {
  *
  * @param {number} eventId
  * @param {{dirty?: boolean, moveTo?: string|null, cancelMove?: boolean}} what
- * @returns {boolean} true, wenn dieser Aufruf Arbeit vorgemerkt hat; ein reines
- *   Zurücknehmen gibt false zurück - danach ist nichts auszuführen.
+ * @returns {boolean} true, wenn danach ausgehende Arbeit ansteht - nicht nur die
+ *   dieses Aufrufs: nimmt er einen Umzug zurück, kann aus einem früheren,
+ *   gescheiterten Versuch noch ein Push offen sein, und der Aufrufer entscheidet
+ *   daran über seinen Sofortversuch.
  */
 export function markOutbound(eventId, { dirty = false, moveTo = null, cancelMove = false } = {}) {
   if (!dirty && !moveTo && !cancelMove) return false;
-  db.get().prepare(`
+  const row = db.get().prepare(`
     UPDATE calendar_events
     SET outbound_dirty    = CASE WHEN ? THEN 1 ELSE outbound_dirty END,
         outbound_move_to  = CASE WHEN ? THEN NULL ELSE COALESCE(?, outbound_move_to) END,
         outbound_attempts = 0
     WHERE id = ?
-  `).run(dirty ? 1 : 0, cancelMove ? 1 : 0, moveTo, eventId);
-  return !!(dirty || moveTo);
+    RETURNING outbound_dirty, outbound_move_to
+  `).get(dirty ? 1 : 0, cancelMove ? 1 : 0, moveTo, eventId);
+  return !!(row && (row.outbound_dirty || row.outbound_move_to));
 }
 
 export function pendingUpdates(source) {
@@ -423,7 +426,6 @@ export function queueEventDeletion(event, database = null) {
 export function markEventOutbound(before, after) {
   if (!after || !OUTBOUND_SOURCES.includes(after.external_source)) return false;
   if (!after.external_calendar_id) return false;
-  if (!acceptsOutbound(after.external_source)) return false;
 
   const dirty = mirroredFieldsChanged(before, after);
 
@@ -443,6 +445,16 @@ export function markEventOutbound(before, after) {
       if (target === current) cancelMove = true;
       else moveTo = target;
     }
+  }
+
+  // Vormerken kann nur, wer überhaupt hinausschreiben darf. Das Zurücknehmen
+  // nicht: es ist eine rein lokale Buchung, und genau in einer Nur-Lesen-Phase
+  // muss sie durchkommen - sonst steht nach dem Abschalten des Nur-Lesen-Modus
+  // noch ein Umzug an, den der Nutzer längst widerrufen hat. Ein Sofortversuch
+  // lohnt dann trotzdem nicht, deshalb false.
+  if (!acceptsOutbound(after.external_source)) {
+    if (cancelMove) markOutbound(after.id, { cancelMove });
+    return false;
   }
 
   if (!dirty && !moveTo && !cancelMove) return false;

--- a/test/test-caldav-outbound.js
+++ b/test/test-caldav-outbound.js
@@ -1232,6 +1232,53 @@ test('eine Feldänderung ohne Zielwahl lässt den wartenden Umzug stehen', () =>
   assert.equal(row.outbound_dirty, 1);
 });
 
+test('ein noch offener Push macht die Rücknahme zum Sofortversuch wert', () => {
+  // Der Rückgabewert steuert den Sofortversuch der Route. Er muss den Zustand NACH
+  // dem Aufruf melden, nicht nur die Arbeit dieses Aufrufs: bleibt aus einem
+  // gescheiterten Versuch ein Push offen, wartete er sonst auf den nächsten Sync.
+  reset();
+  const event   = seedMoved('mv21@t');
+  const renamed = reload(event.id);
+  db.prepare("UPDATE calendar_events SET title = 'Anders' WHERE id = ?").run(event.id);
+  outbound.markEventOutbound(renamed, reload(event.id));
+  assert.equal(reload(event.id).outbound_dirty, 1, 'Vorbedingung: ein Push steht an');
+
+  const before = reload(event.id);
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL_URL, event.id);
+
+  assert.equal(outbound.markEventOutbound(before, reload(event.id)), true);
+  const row = reload(event.id);
+  assert.equal(row.outbound_move_to, null);
+  assert.equal(row.outbound_dirty, 1, 'der Push bleibt, nur der Umzug fällt');
+});
+
+test('auch ohne CalDAV-Konto wird ein wartender Umzug zurückgenommen', () => {
+  // Zurücknehmen ist eine lokale Buchung und braucht kein schreibbares Konto. Bliebe
+  // der Umzug stehen, liefe er los, sobald wieder ein Konto eingerichtet ist.
+  reset();
+  const event  = seedMoved('mv22@t');
+  const before = reload(event.id);
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL_URL, event.id);
+
+  db.prepare('DELETE FROM caldav_accounts').run();
+  assert.equal(outbound.markEventOutbound(before, reload(event.id)), false, 'kein Sofortversuch, es geht nichts hinaus');
+
+  assert.equal(reload(event.id).outbound_move_to, null);
+});
+
+test('ohne CalDAV-Konto entsteht dagegen kein neuer Umzug', () => {
+  // Die Gegenprobe: der Guard fällt nur für das Zurücknehmen, nicht fürs Vormerken.
+  reset();
+  const calRefId = upsertCalendar(CAL_URL);
+  const before = insertSyncedEvent({ uid: 'mv23@t', calRefId, target: CAL_URL });
+  db.prepare('UPDATE calendar_events SET target_caldav_calendar_url = ? WHERE id = ?').run(CAL2_URL, before.id);
+
+  db.prepare('DELETE FROM caldav_accounts').run();
+  assert.equal(outbound.markEventOutbound(before, reload(before.id)), false);
+
+  assert.equal(reload(before.id).outbound_move_to, null);
+});
+
 // ── Was während des Provider-Aufrufs eintrifft ──────────────────────────────────
 //
 // Der Patch wird vor den awaits aus der Zeile gebaut. Eine Bearbeitung, die in

--- a/test/test-google-outbound.js
+++ b/test/test-google-outbound.js
@@ -728,6 +728,55 @@ test('eine Feldänderung ohne Zielwechsel lässt den wartenden Umzug stehen', ()
   assert.equal(row.outbound_dirty, 1);
 });
 
+test('ein noch offener Push macht die Rücknahme zum Sofortversuch wert', () => {
+  // Der Rückgabewert steuert den Sofortversuch der Route. Er muss den Zustand
+  // NACH dem Aufruf melden, nicht nur die Arbeit dieses Aufrufs: bleibt aus einem
+  // gescheiterten Versuch ein Push offen, wartete er sonst auf den nächsten Sync.
+  reset();
+  const { before } = seedMove();
+  const renamed = reload(before.id);
+  db.prepare("UPDATE calendar_events SET title = 'Anders' WHERE id = ?").run(before.id);
+  __test.markEventOutbound(renamed, reload(before.id));
+  assert.equal(reload(before.id).outbound_dirty, 1, 'Vorbedingung: ein Push steht an');
+
+  const current = reload(before.id);
+  db.prepare("UPDATE calendar_events SET target_google_calendar_id = 'primary' WHERE id = ?").run(before.id);
+
+  assert.equal(__test.markEventOutbound(current, reload(before.id)), true);
+  const row = reload(before.id);
+  assert.equal(row.outbound_move_to, null);
+  assert.equal(row.outbound_dirty, 1, 'der Push bleibt, nur der Umzug fällt');
+});
+
+test('auch im Nur-Lesen-Modus wird ein wartender Umzug zurückgenommen', () => {
+  // Zurücknehmen ist eine lokale Buchung und braucht keinen Schreibzugriff. Bliebe
+  // der Umzug hier stehen, liefe er nach dem Abschalten des Nur-Lesen-Modus los.
+  reset();
+  const { before } = seedMove();
+  const current = reload(before.id);
+  db.prepare("UPDATE calendar_events SET target_google_calendar_id = 'primary' WHERE id = ?").run(before.id);
+
+  __test.setReadonly(true);
+  assert.equal(__test.markEventOutbound(current, reload(before.id)), false, 'kein Sofortversuch, es geht nichts hinaus');
+  __test.setReadonly(false);
+
+  assert.equal(reload(before.id).outbound_move_to, null);
+});
+
+test('im Nur-Lesen-Modus entsteht dagegen kein neuer Umzug', () => {
+  // Die Gegenprobe: der Guard fällt nur für das Zurücknehmen, nicht fürs Vormerken.
+  reset();
+  const fromRef = __test.upsertExternalCalendar('google', 'primary', 'Primär', '#4285F4');
+  const before  = insertGoogleEvent({ calRefId: fromRef, googleId: 'gev-ro-move', target: 'primary' });
+  db.prepare("UPDATE calendar_events SET target_google_calendar_id = 'fam@g' WHERE id = ?").run(before.id);
+
+  __test.setReadonly(true);
+  assert.equal(__test.markEventOutbound(before, reload(before.id)), false);
+  __test.setReadonly(false);
+
+  assert.equal(reload(before.id).outbound_move_to, null);
+});
+
 // ── Inbound-Schutz ──────────────────────────────────────────────────────────────
 
 function inboundItem(id, summary = 'Termin aus Google') {


### PR DESCRIPTION
Nachtrag zu PR #1150 (gemergt als `a7a9e9b2`): zwei Codex-Befunde aus dem Review dort, beide
berechtigt. Liegt über #1151, Suiten der Serialisierung mitgeprüft.

## 1. Zurücknehmen war hinter dem Schreib-Guard unerreichbar (P2)

`markEventOutbound()` prüft `acceptsOutbound()` vor allem anderen, also kam die Rücknahme nicht
durch, solange der Anbieter gerade nichts annimmt: Umzug vorgemerkt → Admin schaltet Nur-Lesen ein →
Nutzer wählt wieder den aktuellen Kalender → das Zielfeld wandert, `outbound_move_to` bleibt. Nach
dem Abschalten des Nur-Lesen-Modus führte der nächste Sync den längst widerrufenen Umzug aus.

Das Zurücknehmen ist eine rein lokale Buchung und braucht keinen Schreibzugriff. Der Guard steht
jetzt nach der Entscheidung und sperrt weiter das **Vormerken**; ein Sofortversuch wird in dieser
Lage nicht ausgelöst (Rückgabe `false`), weil ohnehin nichts hinausgeht.

## 2. Der Rückgabewert verschwieg einen noch offenen Push (P2)

`markOutbound()` meldete nur die Arbeit des eigenen Aufrufs. Eine Rücknahme gab deshalb `false`
zurück, auch wenn aus einem früheren, gescheiterten Versuch noch `outbound_dirty = 1` stand - die
Route überspringt dann ihren Sofortversuch, und der Push lag bis zum nächsten Sync-Intervall. Die
Funktion liest ihren Schreibvorgang nun per `RETURNING` zurück und meldet den Zustand **danach**.

`UPDATE ... RETURNING` mit `.get()` ist gegen den Produktionstreiber gemessen
(`better-sqlite3-multiple-ciphers`, SQLite 3.53.4): liefert die Zeile, bei fehlendem Treffer
`undefined` - das fängt der Ausdruck ab.

## Tests

`test:caldav-outbound` 98 grün, `test:google-outbound` 85 grün (je 3 neu), dazu
`test:caldav-todo-outbound`, `test:sync-lock` und `test:calendar-routes` grün.

Gegenproben je Regel, über `cp`-Backup zurückgedreht und gemessen:

- Rückgabewert zurück auf "nur dieser Aufruf" → der Sofortversuch-Test fällt, beide Anbieter.
- Guard wieder vor die Entscheidung → die Rücknahme-Tests für Nur-Lesen bzw. fehlendes CalDAV-Konto
  fallen.
- Guard ganz entfernt → die Gegenprobe fällt, dass in dieser Lage **kein** Umzug vorgemerkt wird
  (bei Google zusätzlich der bestehende Nur-Lesen-Test).

Refs #593
