### PR TITLE
fix(housekeeping): reach check-out, allow a second session (#1133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A housekeeper can check out again, and work a second session on the same day** (#1133, #1138).
+  The one button that carries both directions was disabled while someone was checked in, and it is
+  the only thing that triggers the check-out path - so that path was unreachable: a household could
+  check a housekeeper in and never close the session from the app. The button now offers "Check
+  out" in that state. Behind it, two answers had collapsed into one: a worker's "currently working"
+  and "was here today" both reported the last session of the day, so someone stayed "checked in"
+  after checking out. They are separate again. The check-in route matched the same mistake and
+  refused a second check-in for the rest of the day, which made split shifts, a break with resumed
+  work, and two separate visits impossible; it now only refuses while a session is actually open.
+  Overlapping sessions stay blocked, and each session keeps its own rate, calendar event and
+  payment task. The line under the name still shows today's visit once it is closed.
+
 - **The formatting toolbar over a task's note shows its icons again** (#1141). Switching a task's
   detail view into edit mode builds that form only then, but the icon-replacing pass over the whole
   overlay had already run before the form existed, so the 13 buttons of the markdown toolbar (bold,

--- a/public/pages/housekeeping.js
+++ b/public/pages/housekeeping.js
@@ -208,7 +208,9 @@ function renderCurrentTab(container) {
 
 async function toggleSession(container, workerId) {
   const worker = state.workers.find((item) => String(item.id) === String(workerId));
-  const current = worker?.today_session;
+  // `current_session` ist die noch offene Sitzung. `today_session` traegt auch
+  // eine abgeschlossene und haette hier ein zweites Auschecken ausgeloest.
+  const current = worker?.current_session;
   if (!state.workers.length) {
     window.yuvomi?.showToast(t('housekeeping.checkInDisabled'), 'warning');
     return;
@@ -250,8 +252,16 @@ function renderWorkerSummary() {
     });
   }
   const rows = state.workers.map((worker) => {
-    const checkedIn = !!worker.today_session;
-    const session = worker.today_session;
+    // Derselbe Knopf fuehrt beide Richtungen: toggleSession() liest die offene
+    // Sitzung und checkt aus, sonst ein. Er trug im eingecheckten Zustand ein
+    // disabled-Attribut - und weil er der EINZIGE Ausloeser ist, war der
+    // Auscheck-Zweig damit unerreichbar (#1133).
+    const checkedIn = !!worker.current_session;
+    // Zwei verschiedene Fragen: `checkedIn` traegt den Knopf ("arbeitet
+    // gerade"), `session` die Zeile darunter ("war heute da"). Haengt die
+    // Zeile am Knopf, verliert sie nach dem Auschecken den Besuch von heute
+    // und faellt auf den Tarif zurueck.
+    const session = worker.current_session ?? worker.today_session;
     return `
     <section class="housekeeping-worker-strip">
       <div class="housekeeping-avatar" style="background:${esc(worker.avatar_color) || 'var(--module-housekeeping)'}">
@@ -259,12 +269,12 @@ function renderWorkerSummary() {
       </div>
       <div class="housekeeping-worker-strip__identity">
         <strong>${esc(worker.display_name)}</strong>
-        <span>${esc(checkedIn ? `${t('housekeeping.visitRecordedAt')} ${formatTime(session.check_in)}` : (worker.rate_type === 'hourly' ? `${money(worker.hourly_rate)}/${t('housekeeping.rateHourly')}` : `${money(worker.daily_rate)} · ${scheduleLabel(worker.payment_schedule)}`))}</span>
+        <span>${esc(session ? `${t('housekeeping.visitRecordedAt')} ${formatTime(session.check_in)}` : (worker.rate_type === 'hourly' ? `${money(worker.hourly_rate)}/${t('housekeeping.rateHourly')}` : `${money(worker.daily_rate)} · ${scheduleLabel(worker.payment_schedule)}`))}</span>
       </div>
       <button class="btn ${checkedIn ? 'btn--secondary' : 'btn--primary'} housekeeping-check-small" type="button"
-              data-worker-check="${worker.id}" ${checkedIn ? 'disabled' : ''}>
-        <i data-lucide="${checkedIn ? 'check' : 'log-in'}" aria-hidden="true"></i>
-        <span>${esc(checkedIn ? t('housekeeping.checkedInToday') : t('housekeeping.checkIn'))}</span>
+              data-worker-check="${worker.id}">
+        <i data-lucide="${checkedIn ? 'log-out' : 'log-in'}" aria-hidden="true"></i>
+        <span>${esc(checkedIn ? t('housekeeping.checkOut') : t('housekeeping.checkIn'))}</span>
       </button>
     </section>
   `;

--- a/server/routes/housekeeping.js
+++ b/server/routes/housekeeping.js
@@ -131,7 +131,12 @@ function publicWorker(row, context = localDayContext()) {
     hourly_rate: Number(row.hourly_rate || 0),
     payment_schedule: row.payment_schedule,
     calendar_color: row.calendar_color || DEFAULT_CALENDAR_COLOR,
-    current_session: publicSession(todaySession),
+    // Zwei verschiedene Fragen, die vorher dieselbe Zeile beantworteten:
+    // `current_session` heisst "arbeitet gerade" und traegt den Auscheck-Knopf,
+    // `today_session` heisst "war heute da" und traegt die Zeitangabe darunter.
+    // Solange beide die letzte Sitzung des Tages lieferten, blieb ein Arbeiter
+    // nach dem Auschecken "eingecheckt" (#1133).
+    current_session: publicSession(loadOpenSession(row.id)),
     today_session: publicSession(todaySession),
     notes: row.notes ?? null,
     created_at: row.created_at,
@@ -778,7 +783,11 @@ router.post('/work-sessions/check-in', (req, res) => {
     const workerRateType = worker.rate_type || 'daily';
     const workerHourlyRate = worker.hourly_rate ?? 0;
     const context = localDayContext(req.body);
-    if (loadTodaySession(worker.id, context)) return res.status(409).json({ error: 'A visit is already recorded today for this housekeeper.', code: 409 });
+    // Nur eine OFFENE Sitzung sperrt. Vorher sperrte jede Sitzung des Tages,
+    // auch eine laengst abgeschlossene - geteilte Schichten, eine Pause mit
+    // Wiederaufnahme und zwei getrennte Besuche am selben Tag waren damit
+    // unmoeglich (#1138).
+    if (loadOpenSession(worker.id)) return res.status(409).json({ error: 'This housekeeper is already checked in.', code: 409 });
 
     const vDailyRate = num(req.body.daily_rate, 'daily_rate', { required: true });
     const vExtras = num(req.body.extras, 'extras');

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -8192,6 +8192,34 @@ test('German housekeeping visit copy contains no English fallback strings', () =
   );
 });
 
+test('der Housekeeping-Check-Knopf bleibt in beide Richtungen bedienbar (#1133)', () => {
+  const page = read('../public/pages/housekeeping.js');
+
+  // `toggleSession()` kann ein- UND auschecken, und `[data-worker-check]` ist
+  // sein EINZIGER Ausloeser (eine zweite Fundstelle waere hier ein Signal,
+  // dass diese Zusicherung nicht mehr die ganze Wahrheit ist).
+  const ausloeser = page.match(/data-worker-check/g) ?? [];
+  assert.equal(ausloeser.length, 2,
+    'Knopf-Markup und Handler-Selektor - mehr Stellen heben diesen Guard aus');
+
+  // Der Knopf trug im eingecheckten Zustand `disabled`. Damit war der
+  // Auscheck-Zweig von toggleSession() unerreichbar: toter Code hinter einem
+  // toten Knopf, und die Suiten blieben gruen.
+  const knopf = page.slice(page.indexOf('<button class="btn ${checkedIn'), page.indexOf('</button>', page.indexOf('<button class="btn ${checkedIn')));
+  assert.ok(knopf, 'der Check-Knopf muss auffindbar bleiben');
+  assert.doesNotMatch(knopf, /disabled/,
+    'ein disabled Check-Knopf macht das Auschecken unerreichbar (#1133)');
+  assert.match(knopf, /checkedIn \? t\('housekeeping\.checkOut'\)/,
+    'im eingecheckten Zustand muss der Knopf das Auschecken anbieten');
+
+  // Und er haengt an der OFFENEN Session, nicht an "war heute da" - sonst
+  // bliebe er nach dem Auschecken auf "Auschecken" stehen.
+  assert.match(page, /const checkedIn = !!worker\.current_session;/,
+    'der Zustand kommt aus current_session, nicht aus today_session');
+  assert.match(page, /const current = worker\?\.current_session;/,
+    'toggleSession entscheidet an der offenen Session');
+});
+
 test('holiday chips derive readable ink from each configured color', () => {
   const calendarPage = read('../public/pages/calendar.js');
   const calendarCss = read('../public/styles/calendar.css');

--- a/test/test-housekeeping-routes.js
+++ b/test/test-housekeeping-routes.js
@@ -97,7 +97,10 @@ test('check-in: öffnet Session -> 201', async () => {
   assert.ok(SESSION_ID);
 });
 
-test('check-in: zweiter Check-in am selben Tag -> 409', async () => {
+test('check-in: zweiter Check-in bei OFFENER Session -> 409', async () => {
+  // Der Name hiess bis #1138 "am selben Tag" und beschrieb damit die alte,
+  // zu weite Sperre. Gemessen hat er immer diesen Fall hier: die Session aus
+  // dem Test davor ist noch offen. Ueberlappende Sessions bleiben gesperrt.
   const r = await call('POST', '/work-sessions/check-in', { as: ADM, body: { worker_id: WORKER_ID, daily_rate: 50 } });
   assert.equal(r.status, 409);
 });
@@ -120,6 +123,46 @@ test('check-out: schließt offene Session, Besuch erscheint mit total_amount = r
 test('check-out: keine offene Session mehr -> 404', async () => {
   const r = await call('POST', '/work-sessions/check-out', { as: ADM, body: { worker_id: WORKER_ID } });
   assert.equal(r.status, 404);
+});
+
+test('check-in: nach dem Auschecken ist am selben Tag eine zweite Session erlaubt (#1138)', async () => {
+  // Geteilte Schicht, Pause mit Wiederaufnahme, zwei getrennte Besuche: die
+  // Sperre las vorher JEDE Session des Tages (`loadTodaySession`) und lehnte
+  // deshalb auch nach einem sauberen Auschecken mit 409 ab.
+  const r = await call('POST', '/work-sessions/check-in', { as: ADM, body: { worker_id: WORKER_ID, daily_rate: 40, extras: 0 } });
+  assert.equal(r.status, 201, 'die zweite Session des Tages wird angelegt');
+  const second = r.body.data.id;
+  assert.notEqual(second, SESSION_ID, 'es ist eine eigene Session, nicht die alte');
+
+  // Beide Sessions liegen am selben lokalen Tag und tragen ihre eigenen Daten.
+  const rows = db.prepare(
+    'SELECT id, check_in, check_out, daily_rate FROM housekeeping_work_sessions WHERE worker_id = ? ORDER BY id',
+  ).all(WORKER_ID);
+  assert.equal(rows.length, 2, 'zwei Sessions am selben Tag');
+  assert.equal(rows[0].check_in.slice(0, 10), rows[1].check_in.slice(0, 10), 'derselbe Tag');
+  assert.ok(rows[0].check_out, 'die erste ist abgeschlossen');
+  assert.equal(rows[1].check_out, null, 'die zweite ist offen');
+  assert.equal(rows[0].daily_rate, 50, 'die erste behaelt ihren eigenen Satz');
+  assert.equal(rows[1].daily_rate, 40, 'die zweite ihren');
+});
+
+test('current_session traegt nur die OFFENE Session, today_session auch die geschlossene (#1133)', async () => {
+  // Solange beide Felder dieselbe Zeile lieferten, blieb ein Arbeiter nach dem
+  // Auschecken "eingecheckt" - und der Auscheck-Knopf im Frontend, der an
+  // current_session haengt, war dauerhaft tot.
+  const open = await call('GET', '/workers', { as: ADM });
+  const w = open.body.data.find((item) => item.id === WORKER_ID);
+  assert.ok(w.current_session, 'die zweite Session ist offen');
+  assert.equal(w.current_session.check_out, null);
+
+  const out = await call('POST', '/work-sessions/check-out', { as: ADM, body: { worker_id: WORKER_ID } });
+  assert.equal(out.status, 200);
+
+  const after = await call('GET', '/workers', { as: ADM });
+  const w2 = after.body.data.find((item) => item.id === WORKER_ID);
+  assert.equal(w2.current_session, null, 'ausgecheckt heisst: keine laufende Session');
+  assert.ok(w2.today_session, 'der Besuch von heute steht weiterhin');
+  assert.ok(w2.today_session.check_out, 'und zwar als abgeschlossener');
 });
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1133, closes #1138. Two reports from @nriel with one root cause.

## What was wrong

The button in the worker strip carries both directions - `toggleSession()` checks out when a session is running, otherwise in. But it was rendered `disabled` while checked in, and `[data-worker-check]` is its **only** trigger. The check-out branch was therefore unreachable: a household could check a housekeeper in and never close that session from the app again (#1133).

Behind it sat the actual cause. `publicWorker()` answered two different questions with the same row:

```js
current_session: publicSession(todaySession),
today_session:   publicSession(todaySession),
```

`current_session` means *"is working right now"* and carries the button; `today_session` means *"was here today"* and carries the line underneath. While both reported the last session of the day, anyone who had checked out still counted as checked in.

The check-in route shared the mistake. It guarded with `loadTodaySession()`, which finds **any** session that started today, and returned 409 even after a clean check-out - so split shifts, a break with resumed work, and two separate visits on one day were all impossible (#1138).

## What changed

- `current_session` now comes from `loadOpenSession(row.id)`; `today_session` is unchanged.
- Check-in guards against `loadOpenSession` instead of `loadTodaySession`. Overlapping sessions stay blocked, each session keeps its own rate, calendar event and payment task.
- The button drops `disabled` and offers `housekeeping.checkOut` with a `log-out` icon when checked in. No new locale key - `checkOut` already exists in all 24 locales.
- The status line now hangs on `session`, not on `checkedIn`. Otherwise this fix would have introduced a regression of its own: after checking out, the line would have lost today's visit and fallen back to the rate.

## Proof

Three counter-probes, each undoing exactly one cause, each red on exactly the right test:

| undone | result |
|---|---|
| check-in guard back to `loadTodaySession` | `#1138` test fails |
| `current_session` back to `todaySession` | `#1133` route test fails |
| `disabled` back on the button | `#1133` frontend guard fails |

Suites green: `housekeeping` 13/13, `housekeeping-routes` 53/53 (was 51), `frontend-audit` 384/384 (was 383), `api` 14/14, `dashboard` 102/0, `dashboard-permissions` 15/15, `permissions` 26/26, `module-registry-parity` 12/12, `i18n` 53/53, `i18n-plural` 16/16.

## Two notes

- I renamed the existing test `check-in: zweiter Check-in am selben Tag -> 409`. It always measured the *open* session (the one from the test before it), and after #1138 its name would simply have been untrue.
- `housekeeping.checkedInToday` ("Heute erfasst") is now unused in product code - only `test-frontend-audit.js:8176` still pins it as German. Left in place rather than deleted from 24 locale files inside an unrelated fix; say the word and it goes.

No migration. `current_session` and `today_session` are not described in `docs/SPEC.md` or the OpenAPI paths, so no doc change was needed - and the one-session-per-day rule was never written down anywhere, it only lived in that guard.
