### PR TITLE
docs(release): run the interface train on Wednesdays and Sundays

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -405,12 +405,12 @@ So the limit is on the interface, not on the release count:
 
 | Track | What it carries | When it ships |
 |---|---|---|
-| **Weekly train** | Anything under `public/pages/`, `public/styles/`, `public/utils/`, `public/components/`, `public/settings/` | **Tuesdays only** |
+| **Interface train** | Anything under `public/pages/`, `public/styles/`, `public/utils/`, `public/components/`, `public/settings/` | **Wednesdays and Sundays only** |
 | **Everything else** | Server, database, docs, tests, deploy descriptors, translations | Any day, **at most one release per calendar day** |
 
-Tuesday, because a household planner gets used most at the weekend: an interface change then has four days to settle before the family is standing in front of it on Saturday.
+Two fixed days, since 12 September 2026 (until then the train ran on Tuesdays only). A finished interface change waits at most four days for its train instead of a week, and the interface still moves on two known days rather than whenever something happens to be done.
 
-**Security fixes and data-loss bugs are not held back.** They ship the moment they are ready, on any day. Since v2.64.1 (4 September 2026) a security fix ships as a **patch release cut from the last tag**, carrying the fix, its tests and its documentation and nothing else: the guard judges the whole diff since the last tag, and a branch off that tag is on the second track by construction, so the interface work waiting on `main` for its Tuesday is not pulled forward with it. The steps are in [docs/RELEASING.md](docs/RELEASING.md); the `--hotfix` escape hatch below remains for a fix that cannot be separated from what is already on `main`.
+**Security fixes and data-loss bugs are not held back.** They ship the moment they are ready, on any day. Since v2.64.1 (4 September 2026) a security fix ships as a **patch release cut from the last tag**, carrying the fix, its tests and its documentation and nothing else: the guard judges the whole diff since the last tag, and a branch off that tag is on the second track by construction, so the interface work waiting on `main` for its train is not pulled forward with it. The steps are in [docs/RELEASING.md](docs/RELEASING.md); the `--hotfix` escape hatch below remains for a fix that cannot be separated from what is already on `main`.
 
 `npm run check:release-cadence` decides this, and it runs before the tag rather than after. A release that carries interface changes on a Thursday fails it; so does a second same-day release on the other track. The escape hatch is `--hotfix "<reason>"`, and the reason is mandatory and printed - an exception nobody has to write down is just a rule that quietly stopped applying.
 
@@ -420,7 +420,7 @@ This is a promise the project can keep because it is not a promise: it is a cond
 
 `npm run test:document-guards` is the one suite that is deliberately not in `npm test` and not in CI. It drives a real browser against a seeded server and costs around 80 minutes (82 measured on 2 September 2026), which is not a price worth paying on every push for invariants that only change in bursts. It is a handrail run once before a release instead.
 
-**It is required for any release that carries the weekly train**, that is, any release whose diff touches `public/pages`, `public/styles`, `public/utils`, `public/components` or `public/settings`. A release on the other track does not need it: those probes measure the rendered document, and a change that never reaches the document cannot move them.
+**It is required for any release that carries the interface train**, that is, any release whose diff touches `public/pages`, `public/styles`, `public/utils`, `public/components` or `public/settings`. A release on the other track does not need it: those probes measure the rendered document, and a change that never reaches the document cannot move them.
 
 Treat the path list as a heuristic rather than a boundary. What the probes see also depends on how full the test instance is, and that comes from `scripts/seed-demo.js` and from the shape of server responses: a fuller instance makes header filters wider. If you change the seed or a response shape substantially, run the handrail even when no interface path is in your diff.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,8 +22,8 @@ visible to every household on the next start.
 
 Releases run on two tracks, described in [CONTRIBUTING.md](../CONTRIBUTING.md#release-cadence):
 anything under `public/pages`, `public/styles`, `public/utils`, `public/components` or
-`public/settings` ships on Tuesdays only; everything else ships any day, at most once per calendar
-day. `npm run check:release-cadence` decides, and it runs **before the tag**, because it compares
+`public/settings` ships on Wednesdays and Sundays only; everything else ships any day, at most once
+per calendar day. `npm run check:release-cadence` decides, and it runs **before the tag**, because it compares
 `git describe --tags` with `HEAD` and an already-set tag makes that diff empty. It judges the whole
 release, not the last commit: a server-only fix on a `main` that also carries interface work since
 the last tag is an interface release.
@@ -64,8 +64,8 @@ the last tag is an interface release.
    `<!-- version: X.Y.Z -->` marker. The publish workflow takes the text verbatim and aborts if the
    marker does not match the release, which is deliberate: a stale note describes an update a
    household is not getting. The rules for the text are in the head of the file.
-7. **Cadence.** `npm run check:release-cadence`. Red is an answer, not an obstacle: wait for
-   Tuesday, take the interface change out, or - for a security or data-loss fix that cannot be
+7. **Cadence.** `npm run check:release-cadence`. Red is an answer, not an obstacle: wait for the
+   next Wednesday or Sunday, take the interface change out, or - for a security or data-loss fix that cannot be
    separated from `main` - pass `--hotfix "<reason>"`; the reason is mandatory and printed.
 8. **Handrail, interface releases only.** If the diff since the last tag touches the interface
    paths above, run the browser suite once, and read its exit code from a file rather than a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@ This page is direction, not a queue. It names the few themes that keep coming ba
 open discussions, says for each what has been decided and what is still open, and lists the
 things the maintainer has called worth doing without giving them a ticket yet. It carries no
 dates and no versions: with several releases a week, a date written here would be wrong the
-next morning, and a version number the next afternoon. It is touched on the Tuesday train, when
+next morning, and a version number the next afternoon. It is touched on the interface train, when
 the interface release goes out, and it is edited rather than appended to, so that what is done
 disappears from it.
 

--- a/scripts/check-release-cadence.mjs
+++ b/scripts/check-release-cadence.mjs
@@ -11,13 +11,15 @@
  * nicht auf die Release-Zahl:
  *
  *   Spur 1 (Oberflaeche): alles unter public/pages, public/styles, public/utils,
- *     public/components, public/settings faehrt nur im Wochen-Release, dienstags.
+ *     public/components, public/settings faehrt nur im Oberflaechen-Zug,
+ *     mittwochs und sonntags.
  *   Spur 2 (alles andere): Server, Doku, Tests, Deploy - jederzeit, aber
  *     hoechstens ein Release pro Kalendertag.
  *
- * Dienstag, weil ein Haushaltsplaner am Wochenende am meisten benutzt wird: eine
- * Aenderung an der Oberflaeche hat dann vier Tage Zeit, sich zu setzen, bevor die
- * Familie am Samstag davorsteht.
+ * Bis zum 12.09.2026 fuhr der Zug nur dienstags. Seitdem zwei feste Tage statt
+ * einem: eine fertige Oberflaechen-Aenderung wartet hoechstens vier Tage statt
+ * einer Woche, und die Oberflaeche bewegt sich trotzdem nur an zwei bekannten
+ * Tagen statt immer dann, wenn gerade etwas fertig ist.
  *
  * Ausstieg: `--hotfix "<Grund>"` laesst ein Release jederzeit durch. Ein Guard
  * ohne Ausstieg wird beim ersten echten Notfall umgangen oder geloescht, und
@@ -34,7 +36,7 @@
 
 import { execFileSync } from 'node:child_process';
 
-const TRAIN_DAY = 2; // ISO-8601: 1 = Montag, 2 = Dienstag
+const TRAIN_DAYS = [3, 7]; // ISO-8601: 3 = Mittwoch, 7 = Sonntag
 
 const UI_PREFIXES = [
   'public/pages/',
@@ -126,10 +128,11 @@ if (args.hotfix !== null) {
   process.exit(0);
 }
 
-if (uiFiles.length > 0 && weekday !== TRAIN_DAY) {
+if (uiFiles.length > 0 && !TRAIN_DAYS.includes(weekday)) {
   const sample = uiFiles.slice(0, 8).map((f) => `  ${f}`).join('\n');
   const more = uiFiles.length > 8 ? `\n  ... und ${uiFiles.length - 8} weitere` : '';
-  fail(`Dieses Release fasst die Oberflaeche an und faehrt deshalb nur ${DAY_NAMES[TRAIN_DAY]}s.\n`
+  const trainDays = TRAIN_DAYS.map((d) => `${DAY_NAMES[d].toLowerCase()}s`).join(' und ');
+  fail(`Dieses Release fasst die Oberflaeche an und faehrt deshalb nur ${trainDays}.\n`
     + `Heute ist ${DAY_NAMES[weekday]}.\n\n${sample}${more}\n\n`
     + 'Wege von hier: bis zum naechsten Zug warten, die Oberflaechen-Aenderung aus\n'
     + 'diesem Release herausnehmen, oder - wenn es Sicherheit oder Datenverlust\n'
@@ -143,5 +146,5 @@ if (uiFiles.length === 0 && tagsToday.length > 0) {
 }
 
 console.log(uiFiles.length > 0
-  ? `Release-Kadenz: in Ordnung - Wochen-Release, ${uiFiles.length} Oberflaechen-Datei(en).`
+  ? `Release-Kadenz: in Ordnung - Oberflaechen-Zug, ${uiFiles.length} Oberflaechen-Datei(en).`
   : 'Release-Kadenz: in Ordnung - Spur 2 ohne Oberflaeche, erstes Release heute.');


### PR DESCRIPTION
The interface track moves from Tuesdays only to **Wednesdays and Sundays**.

## What changed

- `scripts/check-release-cadence.mjs`: `TRAIN_DAYS = [3, 7]` (ISO weekdays) instead of a single `TRAIN_DAY = 2`; the refusal names both days, the pass line says "Oberflaechen-Zug".
- `CONTRIBUTING.md` (Release cadence): the table row is now "Interface train - Wednesdays and Sundays only", with the reason: a finished interface change waits at most four days for its train instead of a week, and the interface still moves on two known days. The "weekly train" wording elsewhere in the section follows.
- `docs/RELEASING.md` and `docs/ROADMAP.md`: the two places that named Tuesday.

The second track (server, docs, tests, translations: any day, at most one release per calendar day) and the security patch path are unchanged.

## Proof

The guard's own seams, against `v2.65.2` (50 interface files since that tag):

| `--day` | result |
|---|---|
| 2 (Tuesday) | refused |
| 3 (Wednesday) | passes |
| 4 (Thursday) | refused |
| 6 (Saturday) | refused |
| 7 (Sunday) | passes |
