### PR TITLE
fix(seed): write birthday reminder lead times in minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,8 +195,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The demo data's birthday reminders now come days ahead, not minutes before noon on the day.**
   The demo seed wrote reminder lead times as `1d`, `3d` and `1w`, while Yuvomi stores them as
-  minutes, so they became one minute, three minutes and none: every demo birthday reminded shortly
-  before noon on the birthday itself, and the birthday form showed a lead time it does not offer.
+  minutes and reads only the leading digits, so they became one minute, three minutes and one
+  minute again: every demo birthday reminded shortly before noon on the birthday itself, and the
+  birthday form showed a lead time it does not offer.
   The seed now uses the form's own values (a day, two days, a week - the former three days became
   two), and a guard keeps it to those. Only a database filled by `scripts/seed-demo.js` is
   affected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The demo data's birthday reminders now come days ahead, not minutes before noon on the day.**
+  The demo seed wrote reminder lead times as `1d`, `3d` and `1w`, while Yuvomi stores them as
+  minutes, so they became one minute, three minutes and none: every demo birthday reminded shortly
+  before noon on the birthday itself, and the birthday form showed a lead time it does not offer.
+  The seed now uses the form's own values (a day, two days, a week - the former three days became
+  two), and a guard keeps it to those. Only a database filled by `scripts/seed-demo.js` is
+  affected.
+
 - **A housekeeper can check out again, and work a second session on the same day** (#1133, #1138).
   The one button that carries both directions was disabled while someone was checked in, and it is
   the only thing that triggers the check-out path - so that path was unreachable: a household could

--- a/scripts/seed-demo.js
+++ b/scripts/seed-demo.js
@@ -817,7 +817,7 @@ const insertBirthday = db.prepare(`
 // reminder_offset ist ein Minutenwert als Text, wie ihn das Formular schreibt
 // (REMINDER_OFFSETS in public/pages/birthdays.js - nur deren Werte, sonst zeigt das Formular
 // eine Auswahl, die es nicht kennt; der Server liest ihn per
-// parseInt). Hier stand '1d'/'3d'/'1w' - daraus wurden 1, 3 und 0 Minuten, und
+// parseInt). Hier stand '1d'/'3d'/'1w' - daraus wurden 1, 3 und wieder 1 Minute (parseInt liest nur die Ziffer), und
 // jeder Demo-Geburtstag erinnerte kurz vor Mittag AM Tag selbst statt Tage vorher.
 const DAY_BEFORE  = '1440';
 const TWO_DAYS    = '2880';

--- a/scripts/seed-demo.js
+++ b/scripts/seed-demo.js
@@ -814,15 +814,23 @@ const insertBirthday = db.prepare(`
   INSERT INTO birthdays (name, birth_date, notes, family_user_id, reminder_offset, created_by)
   VALUES (?, ?, ?, ?, ?, ?)
 `);
+// reminder_offset ist ein Minutenwert als Text, wie ihn das Formular schreibt
+// (REMINDER_OFFSETS in public/pages/birthdays.js - nur deren Werte, sonst zeigt das Formular
+// eine Auswahl, die es nicht kennt; der Server liest ihn per
+// parseInt). Hier stand '1d'/'3d'/'1w' - daraus wurden 1, 3 und 0 Minuten, und
+// jeder Demo-Geburtstag erinnerte kurz vor Mittag AM Tag selbst statt Tage vorher.
+const DAY_BEFORE  = '1440';
+const TWO_DAYS    = '2880';
+const WEEK_BEFORE = '10080';
 [
-  ['Emma Johnson',                                    '2018-06-14', L('Turning 8 — chocolate cake & bouncy castle', 'Wird 8 — Schokotorte und Hüpfburg'), emmaId, '1w', lindaId],
-  ['Leo Johnson',                                     '2016-03-22', L('Loves football & LEGO',                      'Liebt Fußball und LEGO'),            leoId,  '1w', lindaId],
-  ['Margaret Johnson',                                '1958-06-19', L("Alex's mum — 'Grandma'",                     'Alex’ Mutter — „Oma"'),              null,   '3d', alexId],
-  [L('Uncle Mike Johnson', 'Onkel Mike Johnson'),     '1985-11-02', L("Alex's brother in Hamburg",                  'Alex’ Bruder in Hamburg'),           null,   '1d', alexId],
-  [L('Aunt Claire Becker', 'Tante Claire Becker'),    '1989-08-30', L("Linda's sister",                             'Lindas Schwester'),                  null,   '1d', lindaId],
-  ['Lena Braun',                                      '2018-09-12', L("Emma's best friend",                         'Emmas beste Freundin'),              null,   '1d', lindaId],
-  ['Alex Johnson',                                    '1986-02-08', '',                                                                                   alexId, '3d', lindaId],
-  ['Linda Johnson',                                   '1988-04-25', '',                                                                                   lindaId,'3d', alexId],
+  ['Emma Johnson',                                    '2018-06-14', L('Turning 8 — chocolate cake & bouncy castle', 'Wird 8 — Schokotorte und Hüpfburg'), emmaId, WEEK_BEFORE, lindaId],
+  ['Leo Johnson',                                     '2016-03-22', L('Loves football & LEGO',                      'Liebt Fußball und LEGO'),            leoId,  WEEK_BEFORE, lindaId],
+  ['Margaret Johnson',                                '1958-06-19', L("Alex's mum — 'Grandma'",                     'Alex’ Mutter — „Oma"'),              null,   TWO_DAYS,    alexId],
+  [L('Uncle Mike Johnson', 'Onkel Mike Johnson'),     '1985-11-02', L("Alex's brother in Hamburg",                  'Alex’ Bruder in Hamburg'),           null,   DAY_BEFORE,  alexId],
+  [L('Aunt Claire Becker', 'Tante Claire Becker'),    '1989-08-30', L("Linda's sister",                             'Lindas Schwester'),                  null,   DAY_BEFORE,  lindaId],
+  ['Lena Braun',                                      '2018-09-12', L("Emma's best friend",                         'Emmas beste Freundin'),              null,   DAY_BEFORE,  lindaId],
+  ['Alex Johnson',                                    '1986-02-08', '',                                                                                   alexId, TWO_DAYS,    lindaId],
+  ['Linda Johnson',                                   '1988-04-25', '',                                                                                   lindaId,TWO_DAYS,    alexId],
 ].forEach(row => insertBirthday.run(...row));
 
 // ── Documents ────────────────────────────────────────────────────────────────

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -9489,6 +9489,36 @@ test('split activity feed translates every type the backend writes', () => {
   assert.deepEqual(unwritten, [], 'verwaiste activityType-Keys — kein Codepfad schreibt diesen Typ');
 });
 
+// Der Demo-Seed schrieb reminder_offset als '1d'/'3d'/'1w'. Gespeichert wird aber
+// ein Minutenwert als Text, und der Server liest ihn per parseInt: aus '1d' wurde
+// eine Minute, aus '1w' null - jeder Demo-Geburtstag erinnerte kurz vor Mittag am
+// Tag selbst. Aufgefallen ist es erst, als der Toast einer so faelligen Erinnerung
+// im Handlauf drei Sonden rot machte (#1160). Der Seed darf deshalb nur Werte
+// schreiben, die das Geburtstagsformular selbst anbietet; alles andere zeigt das
+// Formular als Auswahl, die es nicht kennt.
+test('demo seed writes only reminder offsets the birthday form offers', () => {
+  const page = read('../public/pages/birthdays.js');
+  const optionsBlock = page.match(/const REMINDER_OFFSETS = \(\) => \[([\s\S]*?)\];/);
+  assert.ok(optionsBlock, 'REMINDER_OFFSETS in public/pages/birthdays.js nicht gefunden');
+  const offered = [...optionsBlock[1].matchAll(/value:\s*'([^']*)'/g)].map((m) => m[1]);
+  assert.ok(offered.includes('1440'), `unerwartete Formularwerte: ${offered.join(', ')}`);
+
+  const seed = read('../scripts/seed-demo.js');
+  const start = seed.indexOf("console.log('Inserting birthdays");
+  const end = seed.indexOf("console.log('Inserting documents");
+  assert.ok(start > 0 && end > start, 'Geburtstagsblock im Seed nicht gefunden');
+  const block = seed.slice(start, end);
+  const constants = Object.fromEntries([...block.matchAll(/const (\w+)\s*=\s*'([^']*)';/g)].map((m) => [m[1], m[2]]));
+  // Jede Zeile endet auf `…, <reminder_offset>, <created_by>],`.
+  const tokens = [...block.matchAll(/,\s*('[^']*'|[A-Z_]+),\s*\w+Id\],/g)].map((m) => m[1]);
+  assert.ok(tokens.length >= 8, `erwartet mindestens 8 Geburtstagszeilen, gefunden: ${tokens.length}`);
+  const invalid = tokens
+    .map((token) => [token, token.startsWith("'") ? token.slice(1, -1) : constants[token]])
+    .filter(([, value]) => value === undefined || value === 'custom' || !offered.includes(value))
+    .map(([token, value]) => `${token} = ${value}`);
+  assert.deepEqual(invalid, [], `Seed-Vorlauf ausserhalb der Formularwerte (${offered.join(', ')})`);
+});
+
 // ============================================================
 // Konsistenz-Audit (UX/UI): Invarianten, die der Audit hergestellt hat.
 // Jeder Guard hier hält genau einen Befund geschlossen — die Befunde

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -9491,7 +9491,7 @@ test('split activity feed translates every type the backend writes', () => {
 
 // Der Demo-Seed schrieb reminder_offset als '1d'/'3d'/'1w'. Gespeichert wird aber
 // ein Minutenwert als Text, und der Server liest ihn per parseInt: aus '1d' wurde
-// eine Minute, aus '1w' null - jeder Demo-Geburtstag erinnerte kurz vor Mittag am
+// eine Minute, aus '3d' drei, aus '1w' wieder eine - jeder Demo-Geburtstag erinnerte kurz vor Mittag am
 // Tag selbst. Aufgefallen ist es erst, als der Toast einer so faelligen Erinnerung
 // im Handlauf drei Sonden rot machte (#1160). Der Seed darf deshalb nur Werte
 // schreiben, die das Geburtstagsformular selbst anbietet; alles andere zeigt das


### PR DESCRIPTION
Found while diagnosing the red document-guards run behind #1160 / #1161.

## What was wrong

`reminder_offset` on a birthday is stored as minutes in a text column: the birthday form offers `''`, `'1440'`, `'2880'`, `'10080'` and `'custom'` (`REMINDER_OFFSETS` in `public/pages/birthdays.js`), and the server reads it with `parseInt` (`getOffsetMinutes` in `server/services/birthdays.js`). The demo seed wrote `'1d'`, `'3d'` and `'1w'`. Those parse to 1, 3 and 1 minute (`parseInt` reads the leading digit and stops at the letter), so every demo birthday reminded shortly before noon on the birthday itself instead of days ahead - Lena Braun's reminder was due at `2026-09-12T09:59Z`, one minute before local noon on her birthday. Opening such a birthday in the form also showed a lead time the select does not contain.

## What changed

- `scripts/seed-demo.js`: the eight birthdays use named constants with the form's values - a day (`1440`), two days (`2880`) and a week (`10080`). The former three days became two, the closest option the form offers.
- `test/test-frontend-audit.js`: a guard reads the option values from `REMINDER_OFFSETS` and fails on any seed lead time outside them, so the format cannot drift again without the form.
- CHANGELOG entry under Fixed. Only a database filled by `scripts/seed-demo.js` is affected.

## Proof

- `test:frontend-audit` 386/386, `test:changelog` 28/28.
- Counter-probe: with `'1d'` put back into two seed rows (via backup) exactly the new guard fails, naming `'1d' = 1d`; restored afterwards.

The screenshot pipeline uses the same seed; nothing visual depends on the lead time except the birthday form's reminder select.

