### PR TITLE
fix(birthdays): keep a dismissed birthday reminder dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A dismissed birthday reminder stays dismissed.** Dismissing a due birthday reminder only lasted
+  until the next check: the sync that keeps a birthday's reminder in step looked for an active row,
+  found none, removed the dismissed one and created the same reminder again - so it was back within
+  a minute, and could be pushed a second time. The reminder now stays dismissed until its time
+  actually changes: a different lead time, a changed date, or next year's birthday.
+
 - **A housekeeper can check out again, and work a second session on the same day** (#1133, #1138).
   The one button that carries both directions was disabled while someone was checked in, and it is
   the only thing that triggers the check-out path - so that path was unreachable: a household could

--- a/server/services/birthdays.js
+++ b/server/services/birthdays.js
@@ -334,8 +334,16 @@ function syncBirthdayReminder(database, birthday, from = new Date(), kind = 'bir
     ORDER BY created_at DESC
   `).all(eventId, birthday.created_by);
 
-  const active = existing.find((row) => row.dismissed === 0);
-  if (active && active.remind_at === desired) return active.id;
+  // EINE ZEILE JE TERMIN, verworfen oder nicht. Hier stand
+  // `existing.find((row) => row.dismissed === 0)`: nach dem Verwerfen fand die
+  // Suche nichts, loeschte alles und legte dieselbe Erinnerung unverworfen neu
+  // an. `GET /reminders/pending` gleicht bei jedem Poll ab, also stand sie eine
+  // Minute spaeter wieder da, mit leerem `pushed_at` auch fuer den Push-Scheduler.
+  // Ersetzt wird nur, wenn sich der Termin selbst aendert: anderer Vorlauf,
+  // anderes Datum, oder der Geburtstag ist vorbei und das naechste Jahr dran.
+  const current = existing.find((row) => row.remind_at === desired && row.dismissed === 0)
+    ?? existing.find((row) => row.remind_at === desired);
+  if (current) return current.id;
 
   database.prepare(`
     DELETE FROM reminders

--- a/test/test-birthdays-routes.js
+++ b/test/test-birthdays-routes.js
@@ -512,3 +512,46 @@ test('Stichtag und Erinnerung folgen der Haushaltszone, nicht der des Servers', 
     db.prepare('DELETE FROM birthdays WHERE id = ?').run(rowId);
   }
 });
+
+// Eine verworfene Geburtstagserinnerung kam zurueck: `syncBirthdayReminder`
+// suchte nur UNverworfene Zeilen, fand nach dem Verwerfen keine, loeschte alles
+// und legte dieselbe Erinnerung unverworfen neu an. `GET /reminders/pending`
+// gleicht bei jedem Poll ab, also stand sie nach einer Minute wieder da, und der
+// Push-Scheduler sah ein leeres `pushed_at`. Gefunden am 13.09.2026 beim
+// Handlauf-Fix zu #1160. Verglichen wird relativ zur ersten Zeile, damit die
+// Maschinenzone der Suite hier keine Rolle spielt.
+test('eine verworfene Geburtstagserinnerung bleibt verworfen, bis sich ihr Termin aendert', () => {
+  const rowId = db.prepare(`
+    INSERT INTO birthdays (name, birth_date, reminder_offset, created_by) VALUES (?, ?, '1440', ?)
+  `).run('Verwerfprobe', '1990-03-10', USER).lastInsertRowid;
+  const ON_BIRTHDAY = new Date('2026-03-10T12:00:00Z');
+  const sync = () => syncBirthdayArtifacts(db, db.prepare('SELECT * FROM birthdays WHERE id = ?').get(rowId), ON_BIRTHDAY);
+  const rows = (eventId) => db.prepare(`
+    SELECT id, remind_at, dismissed, pushed_at FROM reminders
+    WHERE entity_type = 'event' AND entity_id = ? AND created_by = ? ORDER BY id
+  `).all(eventId, USER);
+
+  try {
+    const { calendar_event_id: eventId } = sync();
+    assert.ok(eventId, 'Fixture: der Geburtstag hat einen Kalendertermin');
+    const [first, ...rest] = rows(eventId);
+    assert.equal(rest.length, 0, 'Fixture: genau eine Erinnerung');
+
+    const PUSHED = '2026-03-09T12:00:00.000Z';
+    db.prepare('UPDATE reminders SET dismissed = 1, pushed_at = ? WHERE id = ?').run(PUSHED, first.id);
+    sync();
+    assert.deepEqual(rows(eventId), [{ ...first, dismissed: 1, pushed_at: PUSHED }],
+      'derselbe Termin: die verworfene Zeile bleibt, und keine unverworfene kommt daneben');
+
+    // Aendert sich der Termin der Erinnerung, ist es eine neue Erinnerung.
+    db.prepare("UPDATE birthdays SET reminder_offset = '2880' WHERE id = ?").run(rowId);
+    sync();
+    const [moved, ...others] = rows(eventId);
+    assert.equal(others.length, 0, 'der alte Termin wird ersetzt, nicht ergaenzt');
+    assert.notEqual(moved.remind_at, first.remind_at);
+    assert.equal(moved.dismissed, 0, 'ein anderer Vorlauf erinnert neu');
+  } finally {
+    deleteBirthdayArtifacts(db, db.prepare('SELECT * FROM birthdays WHERE id = ?').get(rowId));
+    db.prepare('DELETE FROM birthdays WHERE id = ?').run(rowId);
+  }
+});


### PR DESCRIPTION
Found while reworking #1161 after its review.

## What was wrong

A due birthday reminder cannot be dismissed for longer than a minute. `syncBirthdayReminder` (`server/services/birthdays.js`) searched only for an **undismissed** row matching the current occurrence. After a dismissal it found none, deleted every reminder of that birthday event and inserted the same reminder again - undismissed, and with an empty `pushed_at`. `GET /reminders/pending` runs `syncAllBirthdayReminders` on every poll (every 60 seconds in the client), and the push scheduler runs it too.

Measured with the real `birthdays` and `reminders` routers on an in-memory database: `PATCH /reminders/1/dismiss` returns 200 and row 1 is `dismissed: 1`; the next `GET /reminders/pending` returns row **2**, same `remind_at`, `dismissed: 0`, `pushed_at: null`.

## What changed

- A row whose `remind_at` equals the current occurrence is kept, dismissed or not (an undismissed one wins if both exist). The rows are replaced only when the occurrence itself changes: a different lead time, a changed date, or the birthday has passed and next year's is due - each of those is a new reminder and should notify again.
- CHANGELOG entry under Fixed.

## Proof

- New test in `test/test-birthdays-routes.js`: sync, dismiss with a `pushed_at`, sync again - the single row stays, with `dismissed` and `pushed_at` intact; then a changed lead time replaces it with one undismissed row at a different time. Compared relative to the first row, so the suite's machine zone plays no part.
- Counter-probe: with the old lookup put back (via backup) exactly this test fails; restored afterwards.
- `test:birthdays-routes` 29/29, `test:reminders-routes` 28/28, `test:birthday-localization` 42/42, `test:notifications` 46/46, `test:changelog` 28/28.

#1161 depends on this: its reworked harness dismisses the seed's reminders, which only holds once a dismissal holds.
